### PR TITLE
Hotfix/20170222 fix zent tabs style lcj

### DIFF
--- a/packages/zent-tabs/assets/index.scss
+++ b/packages/zent-tabs/assets/index.scss
@@ -32,7 +32,7 @@ $slidercolor: #0099fc;
                 position: relative;
                 top: 50%;
                 margin-top: -10px;
-                line-height: 22px;
+                line-height: 18px;
                 height: 20px;
             }
         }
@@ -128,7 +128,7 @@ $slidercolor: #0099fc;
         color: $disablecolor;
 
         &.zent-tabs-tab {
-            cursor: default;
+            cursor: not-allowed;
         }
 
         &.zent-tabs-tab:hover {


### PR DESCRIPTION
修复zent-tabs样式：
1. disabled情况下tab增加cursor: not-allowed样式
2. canadd情况下修复样式问题