### PR TITLE
修改form导出方式

### DIFF
--- a/packages/zent-form/examples/async_validation.js
+++ b/packages/zent-form/examples/async_validation.js
@@ -1,9 +1,11 @@
 /* eslint-disable no-console */
 
 import React, { Component } from 'react';
-import { Form, Field, createForm, InputField } from '../src';
+import Form from '../src';
 import '../assets/index.scss';
 import 'zent-input/assets/index.scss';
+
+const { Field, createForm, InputField } = Form;
 
 class FieldsForm extends Component {
 

--- a/packages/zent-form/examples/fieldset.js
+++ b/packages/zent-form/examples/fieldset.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 
 import React, { Component } from 'react';
-import { Form, Field, Fieldset, createForm, InputField, RadioGroupField, SelectField } from '../src';
+import Form from '../src';
 import Radio from 'zent-radio';
 import Option from 'zent-select';
 import '../assets/index.scss';
@@ -9,6 +9,8 @@ import 'zent-checkbox/assets/index.scss';
 import 'zent-select/assets/index.scss';
 import 'zent-radio/assets/index.scss';
 import 'zent-input/assets/index.scss';
+
+const { Field, Fieldset, createForm, InputField, RadioGroupField, SelectField } = Form;
 
 class FieldsetForm extends Component {
 

--- a/packages/zent-form/examples/form_fields.js
+++ b/packages/zent-form/examples/form_fields.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 
 import React, { Component } from 'react';
-import { Form, Field, createForm, InputField, CheckboxField, CheckboxGroupField, RadioGroupField, SelectField } from '../src';
+import Form from '../src';
 import Checkbox from 'zent-checkbox';
 import Radio from 'zent-radio';
 import Option from 'zent-select';
@@ -10,6 +10,8 @@ import 'zent-checkbox/assets/index.scss';
 import 'zent-select/assets/index.scss';
 import 'zent-radio/assets/index.scss';
 import 'zent-input/assets/index.scss';
+
+const { Field, createForm, InputField, CheckboxField, CheckboxGroupField, RadioGroupField, SelectField } = Form;
 
 class FieldsForm extends Component {
 

--- a/packages/zent-form/examples/form_level_validation_rules.js
+++ b/packages/zent-form/examples/form_level_validation_rules.js
@@ -1,8 +1,10 @@
 /* eslint-disable no-console */
 
 import React, { Component } from 'react';
-import { Form, Field, createForm } from '../src';
+import Form from '../src';
 import '../assets/index.scss';
+
+const { Field, createForm } = Form;
 
 const renderField = props => (
   <div className="zent-form__control-group">

--- a/packages/zent-form/examples/format_and_normalize.js
+++ b/packages/zent-form/examples/format_and_normalize.js
@@ -5,10 +5,12 @@
 
 import React, { Component } from 'react';
 import _ from 'lodash'; // eslint-disable-line
-import { Form, Field, InputField, CheckboxField, createForm } from '../src';
+import Form from '../src';
 import '../assets/index.scss';
 import 'zent-input/assets/index.scss';
 import 'zent-checkbox/assets/index.scss';
+
+const { Field, InputField, CheckboxField, createForm } = Form;
 
 const renderTimeRange = props => (
   <select name={props.name} value={props.value} onChange={props.onChange}>

--- a/packages/zent-form/examples/input_file.js
+++ b/packages/zent-form/examples/input_file.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
-import { Form, Field, createForm } from '../src';
+import Form from '../src';
 import '../assets/index.scss';
+
+const { Field, createForm } = Form;
 
 const renderField = props => (
   <div className="control-group">

--- a/packages/zent-form/examples/overview.js
+++ b/packages/zent-form/examples/overview.js
@@ -1,13 +1,15 @@
 /* eslint-disable no-console */
 
 import React, { Component } from 'react';
-import { Form, Field, InputField, createForm } from '../src';
+import Form from '../src';
 import Checkbox from 'zent-checkbox';
 import Select, { SelectTrigger } from 'zent-select';
 import 'zent-input/assets/index.scss';
 import 'zent-select/assets/index.scss';
 import 'zent-checkbox/assets/index.scss';
 import '../assets/index.scss';
+
+const { Field, InputField, createForm } = Form;
 
 const renderEmail = (props) => {
   return (

--- a/packages/zent-form/examples/submit_validation.js
+++ b/packages/zent-form/examples/submit_validation.js
@@ -1,10 +1,11 @@
 /* eslint-disable no-console */
 
 import React, { Component } from 'react';
-import { Form, Field, createForm } from '../src';
+import Form from '../src';
 import cx from 'zent-utils/classnames';
 import '../assets/index.scss';
 
+const { Field, createForm } = Form;
 const renderField = props => {
   const showError = props.isTouched && props.error;
   const controlGroupClass = cx({

--- a/packages/zent-form/src/index.js
+++ b/packages/zent-form/src/index.js
@@ -10,8 +10,9 @@ import CheckboxField from './form_components/CheckboxField';
 import CheckboxGroupField from './form_components/CheckboxGroupField';
 import RadioGroupField from './form_components/RadioGroupField';
 import SelectField from './form_components/SelectField';
+import assign from 'zent-utils/lodash/assign';
 
-export default {
+export default assign(Form, {
   Form,
   createForm,
   Field,
@@ -24,4 +25,4 @@ export default {
   RadioGroupField,
   SelectField,
   SubmissionError
-};
+});


### PR DESCRIPTION
以后可以写成
import { Form } from 'zent';
const { Field, createForm } = Form;
然后直接在render中使用Form组件即可

不需要再写成
import { Form } from 'zent';
const { Form as ZentForm, Field, createForm } = Form;