### PR TITLE
add onFocus callback & add field active state & update control group

### DIFF
--- a/packages/zent-form/CHANGELOG.md
+++ b/packages/zent-form/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.6 (2017-04-07)
+
+* Field 中增加 onFocus 回调，并添加 focus 时的 active state
+* getControlGroup 改为返回一个 class 类型的 React Component, 增加 field active 时对应的类 `zent-form__control-group--active`，增加 `getControlInstance` 方法。
+
 ## 2.0.4 (2017-03-17)
 
 * getControlGroup支持在Field中传className，作为添加到control-group上的额外类名，可以用来覆盖子元素的样式

--- a/packages/zent-form/__tests__/GetControlGroup-Component_Fields.js
+++ b/packages/zent-form/__tests__/GetControlGroup-Component_Fields.js
@@ -14,8 +14,13 @@ describe('GetControlGroup and Component_Fields', () => {
   ).find(Field).getNode().context;
 
   it('will render default structure with example usage(as component prop of Field)', () => {
-    const addtionInput = getControlGroup(props => (<input type="text" {...props} />));
-    const wrapper = mount(<Field name="foo" component={addtionInput} />, { context });
+    class Input extends React.Component {
+      render() {
+        return <input type="text" {...this.props} />;
+      }
+    }
+    const addtionInput = getControlGroup(Input);
+    const wrapper = mount(<Field name="foo" ref="field" component={addtionInput} />, { context });
     /**
      * .zent-form__control-group
      *   label.zent-form__control-label
@@ -26,6 +31,7 @@ describe('GetControlGroup and Component_Fields', () => {
     expect(wrapper.find('.zent-form__control-label').length).toBe(1);
     expect(wrapper.find('.zent-form__controls').length).toBe(1);
     expect(wrapper.find('input').length).toBe(1);
+    expect(wrapper.get(0).getWrappedComponent().getControlInstance() instanceof Input).toBe(true);
   });
 
   it('ControlGroup have three render switch: required, helpDesc and showError', () => {

--- a/packages/zent-form/assets/index.scss
+++ b/packages/zent-form/assets/index.scss
@@ -27,20 +27,10 @@
     margin-bottom: 20px;
 
     &.has-error {
-        input,
-        select,
-        textarea,
-        .zent-form__checkbox,
-        .zent-form__radio,
         .zent-form__control-label,
         .zent-form__error-desc,
         .zent-form__help-block {
             color: #f44;
-        }
-        input,
-        select,
-        textarea {
-            border-color: #f44;
         }
     }
 }

--- a/packages/zent-form/src/Field.js
+++ b/packages/zent-form/src/Field.js
@@ -86,6 +86,10 @@ class Field extends Component {
     return this.state._isValidating;
   }
 
+  isActive = () => {
+    return this.state._active;
+  }
+
   getPristineValue = () => {
     return this.state._pristineValue;
   }
@@ -164,6 +168,18 @@ class Field extends Component {
     }
   }
 
+  handleFocus = (event) => {
+    const { onFocus } = this.props;
+
+    if (onFocus) {
+      onFocus(event);
+    }
+
+    this.setState({
+      _active: true
+    });
+  }
+
   handleBlur = (event) => {
     const { onBlur, asyncValidation } = this.props;
     const previousValue = this.getValue();
@@ -173,6 +189,10 @@ class Field extends Component {
     if (onBlur) {
       onBlur(event, newValue, previousValue, () => (preventSetValue = true));
     }
+
+    this.setState({
+      _active: false
+    });
 
     if (!preventSetValue) {
       this.setValue(newValue);
@@ -211,11 +231,13 @@ class Field extends Component {
       isTouched: !this.isPristine(),
       isPristine: this.isPristine(),
       isValid: this.isValid(),
+      isActive: this.isActive(),
       value: this.format(this.getValue()),
       error: this.getErrorMessage(),
       errors: this.getErrorMessages(),
       onChange: this.handleChange,
-      onBlur: this.handleBlur
+      onBlur: this.handleBlur,
+      onFocus: this.handleFocus
     });
 
     // 原生的标签不能传非标准属性进去

--- a/packages/zent-form/src/getControlGroup.js
+++ b/packages/zent-form/src/getControlGroup.js
@@ -1,25 +1,39 @@
 import React from 'react';
 import cx from 'zent-utils/classnames';
 
-export default Control => ({ required = false, helpDesc = '', label = '', className = '', ...props }) => {
-  const showError = props.isTouched && props.error;
-  const groupClassName = cx({
-    'zent-form__control-group': true,
-    'has-error': showError,
-    [className]: true
-  });
+export default Control => {
+  return class ControlGroup extends React.Component {
+    getControlInstance = () => {
+      return this.control;
+    }
 
-  return (
-    <div className={groupClassName}>
-      <label className="zent-form__control-label">
-        {required ? <em className="zent-form__required">*</em> : null}
-        {label}
-      </label>
-      <div className="zent-form__controls">
-        <Control {...props} />
-        {showError && <p className="zent-form__error-desc">{props.error}</p>}
-        {helpDesc && <p className="zent-form__help-desc">{helpDesc}</p>}
-      </div>
-    </div>
-  );
+    render() {
+      const { required = false, helpDesc = '', label = '', className = '', ...props } = this.props;
+
+      const showError = props.isTouched && props.error;
+      const groupClassName = cx({
+        'zent-form__control-group': true,
+        'zent-form__control-group--active': props.isActive,
+        'has-error': showError,
+        [className]: true
+      });
+
+      return (
+        <div className={groupClassName}>
+          <label className="zent-form__control-label">
+            {required ? <em className="zent-form__required">*</em> : null}
+            {label}
+          </label>
+          <div className="zent-form__controls">
+            <Control
+              {...props}
+              ref={ref => this.control = ref}
+            />
+            {showError && <p className="zent-form__error-desc">{props.error}</p>}
+            {helpDesc && <p className="zent-form__help-desc">{helpDesc}</p>}
+          </div>
+        </div>
+      );
+    }
+  };
 };


### PR DESCRIPTION
* Field 中增加 onFocus 回调，并添加 focus 时的 active state
* getControlGroup 改为返回一个 class 类型的 React Component, 增加 field active 时对应的类 `zent-form__control-group--active`，增加 `getControlInstance` 方法。