### PR TITLE
修复 Dialog 宽度大于屏幕宽度时移位的问题。

### DIFF
--- a/packages/zent-dialog/assets/zent-dialog.scss
+++ b/packages/zent-dialog/assets/zent-dialog.scss
@@ -31,6 +31,7 @@ $rgbamaskbgcolor: rgba(0, 0, 0, .6);
   outline: 0;
   text-align: center;
   font-size: 0;
+  white-space: nowrap;
 
   &::before {
       content: '';

--- a/packages/zent-dialog/assets/zent-dialog.scss
+++ b/packages/zent-dialog/assets/zent-dialog.scss
@@ -52,6 +52,7 @@ $rgbamaskbgcolor: rgba(0, 0, 0, .6);
     box-sizing: border-box;
     font-size: 14px;
     z-index: 1041;
+    white-space: normal;
 }
 
 .zent-dialog-r-title {


### PR DESCRIPTION
现在居中是用 `vertical-align` 做的，在 `Dialog` 宽度大于屏幕宽度时行内元素会换行，导致下移。