### PR TITLE
修复 steps 组件状态为成功时，前面的子项以数字显示

### DIFF
--- a/packages/zent-steps/examples/number.js
+++ b/packages/zent-steps/examples/number.js
@@ -10,7 +10,7 @@ class Example extends Component {
     super(props);
 
     this.state = {
-      current: 2
+      current: 3
     };
 
     this.nextStep = this.nextStep.bind(this);

--- a/packages/zent-steps/src/components/Step.js
+++ b/packages/zent-steps/src/components/Step.js
@@ -35,7 +35,7 @@ export default class Step extends Component {
 
     let iconNode;
 
-    if ((status === 'finish' || status === 'error') && (!isCurrentStep || !isLastFinishStep)) {
+    if ((status === 'finish' || status === 'error') && (isCurrentStep || isLastFinishStep)) {
       if (status === 'finish') {
         iconNode = <Icon type="check-circle" />;
       } else {


### PR DESCRIPTION
- 修复步骤条展示问题 ，现在的问题是所有的项都是成功的图标，修改后前几项以数字标识

