### PR TITLE
Popover: ensure window.onblur's target is window in Popover hover trigger

### DIFF
--- a/packages/zent-popover/__tests__/index.js
+++ b/packages/zent-popover/__tests__/index.js
@@ -385,7 +385,26 @@ describe('Popover', () => {
 
     simulateWithTimers(wrapper.find('button'), 'mouseenter');
     expect(wrapper.find('Portal').length).toBe(1);
-    const fakeEvent = new FocusEvent('blur');
+
+    // wont' close if target is not window
+    let fakeEvent = new FocusEvent('blur');
+    dispatchWithTimers(window, fakeEvent);
+    expect(wrapper.find('Portal').length).toBe(1);
+
+    // it's tricky to set target manually
+    fakeEvent = new FocusEvent('blur');
+    const evt = fakeEvent.__proto__.__proto__.__proto__;
+    const descriptor = Object.assign(
+      {},
+      Object.getOwnPropertyDescriptor(evt, 'target'),
+      {
+        get() {
+          return window;
+        }
+      }
+    );
+    Object.defineProperty(evt, 'target', descriptor);
+
     dispatchWithTimers(window, fakeEvent);
     expect(wrapper.find('Portal').length).toBe(0);
     wrapper.unmount();

--- a/packages/zent-popover/src/trigger/HoverTrigger.js
+++ b/packages/zent-popover/src/trigger/HoverTrigger.js
@@ -24,7 +24,7 @@ function isMouseEventSuffix(suffix) {
 const HoverState = {
   Init: 1,
 
-  // Leave识别开始必须先有内出去
+  // Leave识别开始必须先由内出去
   Started: 2,
 
   // 延迟等待中
@@ -182,7 +182,15 @@ function makeHoverLeaveRecognizer({ leaveDelay, onLeave, isOutSide }) {
       }, 16),
 
       // 页面失去焦点的时候强制关闭，否则会出现必须先移动进来再出去才能关闭的问题
-      blur: () => {
+      blur: (evt) => {
+        // 确保事件来自 window
+        // React 的事件系统会 bubble blur事件，但是原生的是不会 bubble 的。
+        // https://github.com/facebook/react/issues/6410#issuecomment-292895495
+        const target = evt.target || evt.srcElement;
+        if (target !== window) {
+          return;
+        }
+
         if (timerId) {
           clearTimeout(timerId);
           timerId = undefined;


### PR DESCRIPTION
React's `onBlur` bubbles while native event doesn't. This causes popover to close unexpectedly in some circumstances.

Related React issue: https://github.com/facebook/react/issues/6410