### PR TITLE
add babel plugin to transform zent import

### DIFF
--- a/packages/babel-plugin-zent/package.json
+++ b/packages/babel-plugin-zent/package.json
@@ -12,8 +12,6 @@
     "babel-preset-env": "^1.4.0"
   },
   "dependencies": {
-    "babel-runtime": "^6.23.0",
-    "babel-types": "^6.24.1",
-    "chalk": "^1.1.3"
+    "babel-runtime": "^6.23.0"
   }
 }

--- a/packages/babel-plugin-zent/package.json
+++ b/packages/babel-plugin-zent/package.json
@@ -12,6 +12,8 @@
     "babel-preset-env": "^1.4.0"
   },
   "dependencies": {
-    "babel-runtime": "^6.23.0"
+    "babel-runtime": "^6.23.0",
+    "babel-types": "^6.24.1",
+    "chalk": "^1.1.3"
   }
 }

--- a/packages/babel-plugin-zent/src/index.js
+++ b/packages/babel-plugin-zent/src/index.js
@@ -1,0 +1,166 @@
+const t = require('babel-types');
+
+const chalk = require('chalk');
+
+const moduleName = 'zent';
+
+let moduleMapping = {};
+
+function replaceRules(name) {
+  if (moduleMapping.hasOwnProperty(name)) {
+    return moduleMapping[name].js;
+  }
+  return name;
+}
+
+function isEmpty(obj) {
+  if (Object.keys(obj).length === 0) {
+    return true;
+  }
+  return false;
+}
+
+function capitalizeFirstLetter(string) {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+// import below is not allowed
+// "Error: require('zent') is not allowed, use ES6 import instead." + "\n" +
+// "Error: namespace import is not allowed for zent, specify the components you need." + "\n" +
+// "Error: zent-button is no longer maintained, use `import { Button } from 'zent'` instead." + "\n" +
+// "Error: zent/button is no longer supported, use `import { Button } from 'zent'` instead." + "\n" +
+function log(value) {
+  const reg1 = /^zent$/gi;
+  const reg2 = /zent-/gi;
+  const reg3 = /^zent\/(?!lib\/)/gi;
+  const reg4 = /^requirezent$/gi;
+  const reg5 = /^requirezent\/(?!lib\/)/gi;
+
+  // Error
+  if (reg1.test(value)) {
+    throw new Error(
+      chalk.yellow(
+        `\n
+        ===================================================
+        Error: namespace import is not allowed for zent, specify the components you need.
+        ===================================================`
+      )
+    );
+  } else if (reg2.test(value)) {
+    let idx = value.indexOf('-');
+    let name = value.substr(idx + 1);
+    let newName = capitalizeFirstLetter(name);
+    throw new Error(
+      chalk.yellow(
+        `\n
+        =========================================
+        Error: ${value} is no longer maintained, use " import { ${newName} } from 'zent' " instead.
+        =========================================`
+      )
+    );
+  } else if (reg3.test(value)) {
+    let idx = value.indexOf('/');
+    let name = value.substr(idx + 1);
+    let newName = capitalizeFirstLetter(name);
+    throw new Error(
+      chalk.yellow(
+        `\n
+      "=========================================
+      "Error: ${value} is no longer supported, use " import { ${newName} } from 'zent' " instead.
+      "=========================================`
+      )
+    );
+  } else if (reg4.test(value)) {
+    throw new Error(
+      chalk.yellow(
+        `\n
+      "=========================================
+      "Error: require('zent') is not allowed, use ES6 import instead.
+      "=========================================`
+      )
+    );
+  } else if (reg5.test(value)) {
+    let idx = value.indexOf('require');
+    let name = value.substr(idx + 7);
+    throw new Error(
+      chalk.yellow(
+        `\n
+        "=========================================
+        "Error: require('${name}') is not allowed, use ES6 import instead.
+        "=========================================`
+      )
+    );
+  }
+}
+
+module.exports = function() {
+  return {
+    visitor: {
+      CallExpression(path) {
+        const node = path.node;
+        const callee = node.callee;
+        const arg = node.arguments[0];
+        if (callee.type !== 'Identifier' || callee.name !== 'require' || !arg) {
+          return;
+        }
+
+        const args = node.arguments || [];
+        if (
+          callee.name === 'require' &&
+          args.length === 1 &&
+          t.isStringLiteral(args[0])
+        ) {
+          const reg = /(^zent\/)/gi;
+          if (args[0].value === moduleName) {
+            log(`require${args[0].value}`);
+          } else if (reg.test(args[0].value)) {
+            log(`require${args[0].value}`);
+          }
+        }
+      },
+      ImportDeclaration(path, state) {
+        const opts = state.opts;
+        if (isEmpty(moduleMapping) && opts.moduleMappingFile.length > 0) {
+          // eslint-disable-next-line import/no-dynamic-require
+          moduleMapping = require(state.opts.moduleMappingFile); // eslint-disable-line global-require
+        }
+
+        const source = path.node.source;
+        const fullImports = path.node.specifiers.filter(specifier => {
+          return specifier.type !== 'ImportSpecifier';
+        });
+        const importSpecifiers = path.node.specifiers.filter(specifier => {
+          return specifier.type === 'ImportSpecifier';
+        });
+        if (fullImports.length > 0) {
+          if (importSpecifiers.length === 0) {
+            const reg = /(^zent$|^zent-|^zent\/)/gi;
+            if (reg.test(source.value)) {
+              log(source.value);
+            }
+          }
+        }
+
+        const newImportDeclarations = [];
+        if (importSpecifiers.length > 0 && source.value === moduleName) {
+          importSpecifiers.forEach(importSpecifier => {
+            const importedName = importSpecifier.imported.name;
+
+            if (moduleMapping.hasOwnProperty(importedName)) {
+              const newImportedName = replaceRules(importedName);
+              const newImportDeclaration = t.importDeclaration(
+                [t.importDefaultSpecifier(t.identifier(importedName))],
+                t.stringLiteral(newImportedName)
+              );
+              newImportDeclarations.push(newImportDeclaration);
+            }
+          });
+        }
+
+        if (newImportDeclarations.length > 0) {
+          path.replaceWithMultiple(newImportDeclarations);
+        }
+      }
+    }
+  };
+};

--- a/packages/babel-plugin-zent/yarn.lock
+++ b/packages/babel-plugin-zent/yarn.lock
@@ -573,7 +573,7 @@ babel-types@^6.19.0, babel-types@^6.24.1:
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babylon@^6.11.0, babylon@^6.15.0, babylon@^6.17.0:
+babylon@^6.11.0, babylon@^6.15.0:
   version "6.17.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.0.tgz#37da948878488b9c4e3c4038893fa3314b3fc932"
 
@@ -637,7 +637,7 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
-chalk@^1.1.0:
+chalk@^1.1.0, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -882,7 +882,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@^7.0.0, glob@^7.0.5, glob@^7.1.1:
+glob@^7.0.0, glob@^7.0.5:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:

--- a/packages/babel-plugin-zent/yarn.lock
+++ b/packages/babel-plugin-zent/yarn.lock
@@ -637,7 +637,7 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
-chalk@^1.1.0, chalk@^1.1.3:
+chalk@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:


### PR DESCRIPTION
slove [issue200](https://github.com/youzan/zent/issues/200), add below features

-  Transform import { Button } from 'zent' to import Button from 'zent/lib/button'. 
-  Error on import Button from 'zent-button'
-  Error on import Button from 'zent/button'
-  Error on import * as Zent from 'zent'
-  Error on const Zent = require('zent')
-  Error on const Alert = require('zent/alert')


