### PR TITLE
loading: change static to float

### DIFF
--- a/packages/zent/__tests__/loading.js
+++ b/packages/zent/__tests__/loading.js
@@ -46,9 +46,9 @@ describe('Loading', () => {
     wrapper.unmount();
   });
 
-  it('Loading has dynamic model(static = false).', () => {
+  it('Loading has floating model.', () => {
     const wrapper = mount(
-      <Loading show={false} static={false}>
+      <Loading show={false} float>
         <span className="foo" />
       </Loading>
     );

--- a/packages/zent/src/loading/Loading.js
+++ b/packages/zent/src/loading/Loading.js
@@ -76,7 +76,7 @@ export default class Loading extends Component {
   render() {
     let { prefix, className, containerClass } = this.props;
 
-    if (this.props.static) {
+    if (!this.props.float) {
       return (
         <div
           className={`${prefix}-loading-container ${prefix}-loading-container-static ${containerClass}`}

--- a/packages/zent/src/loading/LoadingInstance.js
+++ b/packages/zent/src/loading/LoadingInstance.js
@@ -10,7 +10,7 @@ export default class Instance extends Component {
   static propTypes = {
     prefix: PropTypes.string,
     className: PropTypes.string,
-    static: PropTypes.bool,
+    float: PropTypes.bool,
     show: PropTypes.bool,
     zIndex: PropTypes.number,
     containerClass: PropTypes.string
@@ -19,7 +19,8 @@ export default class Instance extends Component {
   static defaultProps = {
     prefix: 'zent',
     className: '',
-    static: true,
+    // FIXME: use defaultProps when we drop support for static
+    // float: false,
     show: false,
     height: 160,
     zIndex: 9998,
@@ -54,7 +55,8 @@ export default class Instance extends Component {
         prefix,
         className,
         containerClass,
-        zIndex
+        zIndex,
+        float: true
       });
     }
 
@@ -93,7 +95,7 @@ export default class Instance extends Component {
   // 通过以下函数与组件通信
   renderLoading(target) {
     // static 方式，loading 将存在于文档流中
-    if (this.props.static) {
+    if (!isFloat(this.props)) {
       return;
     }
 
@@ -115,9 +117,11 @@ export default class Instance extends Component {
   }
 
   render() {
-    if (this.props.static) {
+    const float = isFloat(this.props);
+
+    if (!isFloat(this.props)) {
       return (
-        <Loading {...this.props}>
+        <Loading {...this.props} float={float}>
           {this.props.children}
         </Loading>
       );
@@ -125,4 +129,16 @@ export default class Instance extends Component {
 
     return this.props.children;
   }
+}
+
+// FIXME: remove support for props.static
+function isFloat(props) {
+  const hasStatic = props.hasOwnProperty('static');
+  const hasFloat = props.hasOwnProperty('float');
+
+  if (hasFloat) {
+    return props.float;
+  }
+
+  return hasStatic ? !props.static : false;
 }

--- a/packages/zent/src/loading/README.md
+++ b/packages/zent/src/loading/README.md
@@ -81,8 +81,8 @@ ReactDOM.render(<Example />, mountNode);
 | 参数             | 说明                                                     | 类型     | 默认值 |
 | -------------- | ------------------------------------------------------ | ------ | -------- |
 | show           | 显示控制                                                   | bool   | `false`  |
-| static         | 是否以标签形式存在于文档流中                                         | bool   | `true`   |
-| height         | 设置 static 为 true 情况下，设置高度，如果包裹了组件，将会表现为组件高度，否则将会使用默认高度 | number | `160`    |
+| float         | 是否脱离文档流，一般全局加载的时候设置为 `true`        | bool   | `false`   |
+| height       | float 为 false 时设置高度，如果包裹了组件，将会表现为组件高度，否则将会使用默认高度 | number | `160`    |
 | zIndex         | 设置 z-index                                             | number | `9998`   |
 | className      | 自定义额外类名                                                | string | `''`     |
 | containerClass | 自定义额外类名，外部包裹的容器使用                                      | string | `''`     |

--- a/site/src/components/PageHeader/style.pcss
+++ b/site/src/components/PageHeader/style.pcss
@@ -4,7 +4,9 @@
   &-header {
     position: fixed;
     top: 0;
-    z-index: 1;
+
+    /* 10000 should be enough */
+    z-index: 10000;
     width: 100%;
 
     &__top {


### PR DESCRIPTION
1. Deprecate `static` in `Loading`, use `float`.
2. Fix style in doc page header.