### PR TITLE
fix: colorpicker css fix & add props type

### DIFF
--- a/packages/zent/__tests__/colorpicker.js
+++ b/packages/zent/__tests__/colorpicker.js
@@ -89,6 +89,22 @@ describe('ColorPicker', () => {
     expect(ColorPickerDom.node.handleChange(color)).toBe(undefined);
   });
 
+  it('colorPicker type simple', () => {
+    const handleChange = jest.fn();
+    const wrapper = mount(
+      <ColorPicker
+        color="#5197FF"
+        type="simple"
+        presetColors={['#FFFFFF']}
+        onChange={handleChange}
+      />
+    );
+    const props = wrapper.props();
+    const state = wrapper.state();
+    expect(state.popVisible).toBe(false);
+    expect(props.color).toBe('#5197FF');
+  });
+
   it('SketchFields renders correctly', () => {
     const handleChange = jest.fn();
     const data = {

--- a/packages/zent/assets/colorpicker.pcss
+++ b/packages/zent/assets/colorpicker.pcss
@@ -6,13 +6,13 @@ $c-light-blue: #bdf;
   cursor: pointer;
   display: inline-block;
   font-size: 12px;
-  line-height: 1.5;
   margin-right: 10px;
   outline: none;
   position: relative;
   text-align: left;
   user-select: none;
   width: 100px;
+  height: 32px;
   vertical-align: middle;
 
   &.open {

--- a/packages/zent/assets/colorpicker.pcss
+++ b/packages/zent/assets/colorpicker.pcss
@@ -76,4 +76,5 @@ $c-light-blue: #bdf;
   margin-left: 10px;
   margin-bottom: 10px;
   cursor: pointer;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.15);
 }

--- a/packages/zent/assets/colorpicker.pcss
+++ b/packages/zent/assets/colorpicker.pcss
@@ -59,3 +59,21 @@ $c-light-blue: #bdf;
     height: 20px;
   }
 }
+
+.zent-colorpicker-colors-select {
+  background: #fff;
+  width: 190px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+  box-sizing: content-box;
+  line-height: 10px;
+  padding-top: 10px;
+}
+
+.zent-colorpicker-colors-select__preview {
+  width: 20px;
+  height: 20px;
+  display: inline-block;
+  margin-left: 10px;
+  margin-bottom: 10px;
+  cursor: pointer;
+}

--- a/packages/zent/src/colorpicker/ColorBoard.js
+++ b/packages/zent/src/colorpicker/ColorBoard.js
@@ -16,7 +16,8 @@ const Sketch = ({
   presetColors,
   renderers,
   prefix,
-  className
+  className,
+  type
 }) => {
   const styles = reactCSS(
     {
@@ -141,6 +142,7 @@ const Sketch = ({
         colors={presetColors}
         onClick={onChange}
         prefix={prefix}
+        type={type}
       />
     </div>
   );

--- a/packages/zent/src/colorpicker/README.md
+++ b/packages/zent/src/colorpicker/README.md
@@ -15,7 +15,7 @@ class Simple extends React.Component {
 
 	handleChange = (color) => {
 		this.setState({
-			color,
+			color
 		});
 	}
 
@@ -73,6 +73,55 @@ ReactDOM.render(
 
 ```
 :::
+
+:::demo 简化版用法
+```jsx
+import { ColorPicker } from 'zent';
+
+class Simple extends React.Component {
+	state = {
+		color: '#FF4444',
+		presetColors: [
+	    '#FF4444',
+	    '#FF6500',
+	    '#FF884D',
+	    '#FFCD00',
+	    '#3FBD00',
+	    '#3FBC87',
+	    '#00CD98',
+	    '#5197FF',
+	    '#BADCFF',
+	    '#FFEFB8',
+	    '#999999',
+	    '#444444'
+	  ]
+	}
+
+	handleChange = (color) => {
+		this.setState({
+			color
+		});
+	}
+
+	render() {
+		const { color, presetColors } = this.state;
+		return (
+			<div>
+				<ColorPicker color={color} type="simple" presetColors={presetColors} onChange={this.handleChange} />
+				<div style={{ color }}>当前颜色：{color}</div>
+			</div>
+		)
+	}
+}
+
+ReactDOM.render(
+	<Simple />
+	, mountNode
+);
+
+```
+:::
+
 
 :::demo 颜色面板
 ```jsx
@@ -157,7 +206,8 @@ ReactDOM.render(
 | className     | 可选，自定义类名      | string              | `''`     |         |
 | wrapperClassName | 可选，自定义trigger包裹节点的类名 | string | `''`    |         |
 | prefix        | 可选，自定义前缀      | string              | `'zent'` |         |
-
+| type          | 颜色选择器类型       | string              | `'default'`   |   `'default'`、`'simple'`      |
+| presetColors  | 简化版自定义颜色数组  | array               |          |         |
 
 #### ColorBoard
 

--- a/packages/zent/src/colorpicker/README.md
+++ b/packages/zent/src/colorpicker/README.md
@@ -80,21 +80,7 @@ import { ColorPicker } from 'zent';
 
 class Simple extends React.Component {
 	state = {
-		color: '#FF4444',
-		presetColors: [
-	    '#FF4444',
-	    '#FF6500',
-	    '#FF884D',
-	    '#FFCD00',
-	    '#3FBD00',
-	    '#3FBC87',
-	    '#00CD98',
-	    '#5197FF',
-	    '#BADCFF',
-	    '#FFEFB8',
-	    '#999999',
-	    '#444444'
-	  ]
+		color: '#FF4444'
 	}
 
 	handleChange = (color) => {
@@ -104,10 +90,10 @@ class Simple extends React.Component {
 	}
 
 	render() {
-		const { color, presetColors } = this.state;
+		const { color } = this.state;
 		return (
 			<div>
-				<ColorPicker color={color} type="simple" presetColors={presetColors} onChange={this.handleChange} />
+				<ColorPicker color={color} type="simple" onChange={this.handleChange} />
 				<div style={{ color }}>当前颜色：{color}</div>
 			</div>
 		)
@@ -202,12 +188,12 @@ ReactDOM.render(
 | ------------- | ------------------- | ------------------- | ----------- | --------- |
 | color         | 颜色选择器的颜色      | string              |          |   `'#5197FF'` 或  `'rgba(81, 151, 255, 0.6)'`  |
 | showAlpha     | 是否显示透明度选择    | bool                | `false`  |   `true/false`     |
+| type          | 颜色选择器类型       | string              | `'default'`   |   `'default'`、`'simple'`      |
+| presetColors  | 简化版自定义颜色数组  | array | [`'#FFFFFF'`, `'#F8F8F8'`, `'#F2F2F2'`, `'#999999'`, `'#444444'`, `'#FF4444'`, `'#FF6500'`, `'#FF884D'`, `'#FFCD00'`, `'#3FBD00'`, `'#3FBC87'`, `'#00CD98'`, `'#5197FF'`, `'#BADCFF'`, `'#FFEFB8'`] |         |
 | onChange      | 颜色变化时回调函数    | func(color)         | `noop`   |         |
 | className     | 可选，自定义类名      | string              | `''`     |         |
 | wrapperClassName | 可选，自定义trigger包裹节点的类名 | string | `''`    |         |
 | prefix        | 可选，自定义前缀      | string              | `'zent'` |         |
-| type          | 颜色选择器类型       | string              | `'default'`   |   `'default'`、`'simple'`      |
-| presetColors  | 简化版自定义颜色数组  | array               |          |         |
 
 #### ColorBoard
 

--- a/packages/zent/src/colorpicker/SketchPresetColors.js
+++ b/packages/zent/src/colorpicker/SketchPresetColors.js
@@ -55,6 +55,7 @@ const SketchPresetColors = ({ colors, onClick, prefix, type }) => {
             className={`${prefix}-colorpicker-colors-select__preview`}
             style={{ backgroundColor: color }}
             onClick={() => onClick(color)}
+            title={color}
           />
         ))}
       </div>

--- a/packages/zent/src/colorpicker/SketchPresetColors.js
+++ b/packages/zent/src/colorpicker/SketchPresetColors.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import reactCSS from './helpers/reactcss';
 import { Swatch } from './common';
 
-const SketchPresetColors = ({ colors, onClick, prefix }) => {
+const SketchPresetColors = ({ colors, onClick, prefix, type }) => {
   const styles = reactCSS(
     {
       default: {
@@ -45,6 +45,21 @@ const SketchPresetColors = ({ colors, onClick, prefix }) => {
       e
     );
   };
+
+  if (type === 'simple') {
+    return (
+      <div className={`${prefix}-colorpicker-colors-select`}>
+        {colors.map(color => (
+          <div
+            key={color}
+            className={`${prefix}-colorpicker-colors-select__preview`}
+            style={{ backgroundColor: color }}
+            onClick={() => onClick(color)}
+          />
+        ))}
+      </div>
+    );
+  }
 
   return (
     <div style={styles.colors} className={`${prefix}-colorpicker-colors`}>

--- a/packages/zent/src/colorpicker/index.js
+++ b/packages/zent/src/colorpicker/index.js
@@ -6,7 +6,6 @@
  */
 import React, { Component, PureComponent } from 'react';
 import Popover from 'popover';
-import isArray from 'lodash/isArray';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import ColorBoard from './ColorBoard';
@@ -25,14 +24,7 @@ class ColorPicker extends (PureComponent || Component) {
     wrapperClassName: PropTypes.string,
     prefix: PropTypes.string,
     type: PropTypes.oneOf(['default', 'simple']),
-    presetColors: props => {
-      if (
-        props.type === 'simple' &&
-        (!isArray(props.presetColors) || props.presetColors.length === 0)
-      ) {
-        return new Error('presetColors is required.');
-      }
-    }
+    presetColors: PropTypes.array
   };
 
   static defaultProps = {
@@ -41,7 +33,24 @@ class ColorPicker extends (PureComponent || Component) {
     className: '',
     wrapperClassName: '',
     prefix: 'zent',
-    type: 'default'
+    type: 'default',
+    presetColors: [
+      '#FFFFFF',
+      '#F8F8F8',
+      '#F2F2F2',
+      '#999999',
+      '#444444',
+      '#FF4444',
+      '#FF6500',
+      '#FF884D',
+      '#FFCD00',
+      '#3FBD00',
+      '#3FBC87',
+      '#00CD98',
+      '#5197FF',
+      '#BADCFF',
+      '#FFEFB8'
+    ]
   };
 
   static ColorBoard = ColorBoard;

--- a/packages/zent/src/colorpicker/index.js
+++ b/packages/zent/src/colorpicker/index.js
@@ -6,9 +6,11 @@
  */
 import React, { Component, PureComponent } from 'react';
 import Popover from 'popover';
+import isArray from 'lodash/isArray';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import ColorBoard from './ColorBoard';
+import SketchPresetColors from './SketchPresetColors';
 
 class ColorPicker extends (PureComponent || Component) {
   state = {
@@ -21,7 +23,16 @@ class ColorPicker extends (PureComponent || Component) {
     onChange: PropTypes.func,
     className: PropTypes.string,
     wrapperClassName: PropTypes.string,
-    prefix: PropTypes.string
+    prefix: PropTypes.string,
+    type: PropTypes.oneOf(['default', 'simple']),
+    presetColors: props => {
+      if (
+        props.type === 'simple' &&
+        (!isArray(props.presetColors) || props.presetColors.length === 0)
+      ) {
+        return new Error('presetColors is required.');
+      }
+    }
   };
 
   static defaultProps = {
@@ -29,15 +40,19 @@ class ColorPicker extends (PureComponent || Component) {
     onChange() {},
     className: '',
     wrapperClassName: '',
-    prefix: 'zent'
+    prefix: 'zent',
+    type: 'default'
   };
 
   static ColorBoard = ColorBoard;
 
   handleChange = color => {
     const { onChange, showAlpha } = this.props;
-    const colorOutPut = showAlpha ? color.rgba : color.hex;
-    onChange(colorOutPut);
+    let transColor = color;
+    if (typeof color === 'object') {
+      transColor = showAlpha ? color.rgba : color.hex;
+    }
+    onChange(transColor);
   };
 
   handleVisibleChange = visible => {
@@ -52,7 +67,9 @@ class ColorPicker extends (PureComponent || Component) {
       showAlpha,
       prefix,
       className,
-      wrapperClassName
+      wrapperClassName,
+      type,
+      presetColors
     } = this.props;
     const { popVisible } = this.state;
     const openClassName = popVisible ? 'open' : '';
@@ -85,12 +102,20 @@ class ColorPicker extends (PureComponent || Component) {
           </div>
         </Popover.Trigger.Click>
         <Popover.Content>
-          <ColorBoard
-            color={color}
-            showAlpha={showAlpha}
-            onChange={this.handleChange}
-            prefix={prefix}
-          />
+          {type === 'simple'
+            ? <SketchPresetColors
+                colors={presetColors}
+                onClick={this.handleChange}
+                prefix={prefix}
+                type={type}
+              />
+            : <ColorBoard
+                color={color}
+                showAlpha={showAlpha}
+                onChange={this.handleChange}
+                prefix={prefix}
+                type={type}
+              />}
         </Popover.Content>
       </Popover>
     );


### PR DESCRIPTION
1、修改color-picker样式
2、color-picker增加一个prop：type ，可选值为 'default' 和 'simple'，用于输出简化版颜色选择器。