### PR TITLE
tree: fix dataType=plain data order unstable #323

### DIFF
--- a/packages/zent/src/tree/index.js
+++ b/packages/zent/src/tree/index.js
@@ -119,15 +119,19 @@ export default class Tree extends (PureComponent || Component) {
     let roots = [];
     if (dataType === 'plain') {
       const { isRoot } = this.props;
-      let map = {};
-      data.forEach(node => {
+      const map = {};
+      const orderRecord = [];
+
+      data.forEach((node, index) => {
         if (!node.isLeaf) {
           node.children = [];
         }
         map[node.id] = node;
+        orderRecord[index] = node.id;
       });
-      Object.keys(map).forEach(key => {
-        let node = map[key];
+
+      orderRecord.forEach(key => {
+        const node = map[key];
         const isRootNode =
           (isRoot && isRoot(node)) ||
           node.parentId === 0 ||


### PR DESCRIPTION
Fixes #323 

Changes you made in this pull request:

- tree组件dataType="plain"时，节点顺序与data数据不一致
