### PR TITLE
portal: Add a count to support non sequential dialog closes

### DIFF
--- a/packages/zent/src/portal/withNonScrollable.js
+++ b/packages/zent/src/portal/withNonScrollable.js
@@ -7,6 +7,9 @@ import { getNodeFromSelector } from './util';
   lifecycle.
 **/
 export default function withNonScrollable(Portal) {
+  let portalVisibleCount = 0;
+  let originalOverflow;
+
   return class NonScrollableWrapper extends (PureComponent || Component) {
     static propTypes = {
       selector: PropTypes.string
@@ -17,15 +20,23 @@ export default function withNonScrollable(Portal) {
     };
 
     restoreStyle() {
-      const node = getNodeFromSelector(this.props.selector);
-      node.style.overflow = this.originalOverflow;
+      portalVisibleCount--;
+
+      if (portalVisibleCount <= 0) {
+        const node = getNodeFromSelector(this.props.selector);
+        node.style.overflow = originalOverflow;
+      }
     }
 
     saveStyle() {
-      const node = getNodeFromSelector(this.props.selector);
-      const { style } = node;
-      this.originalOverflow = style.overflow;
-      style.overflow = 'hidden';
+      portalVisibleCount++;
+
+      if (portalVisibleCount === 1) {
+        const node = getNodeFromSelector(this.props.selector);
+        const { style } = node;
+        originalOverflow = style.overflow;
+        style.overflow = 'hidden';
+      }
     }
 
     componentDidMount() {


### PR DESCRIPTION
确保多个对话框非顺序关闭时body的overflow可以被正确设置回原来的值。