### PR TITLE
table: only show boder when children rendered

### DIFF
--- a/packages/zent/assets/table.pcss
+++ b/packages/zent/assets/table.pcss
@@ -104,10 +104,13 @@ $orange: #f60;
 
     &__batchcomponents {
       float: left;
-      border: 1px solid #eee;
       padding: 5px;
       padding-left: 10px;
-      background: #fff;
+
+      &--has-children {
+        border: 1px solid #eee;
+        background: #fff;
+      }
 
       &--fixed {
         position: fixed;

--- a/packages/zent/src/table/modules/Foot.js
+++ b/packages/zent/src/table/modules/Foot.js
@@ -55,6 +55,10 @@ export default class Foot extends (PureComponent || Component) {
       (batchComponents && batchComponents.length > 0) ||
       Object.keys(pageInfo).length !== 0;
 
+    if (batchComponents && batchComponents.length > 0) {
+      batchClassName += ' tfoot__batchcomponents--has-children';
+    }
+
     if (this.props.batchComponentsFixed) {
       batchClassName += ' tfoot__batchcomponents--fixed';
     }


### PR DESCRIPTION
- fix table foot batch component border style