### PR TITLE
loading: Fix bug in floating Loading without children

### DIFF
--- a/packages/zent/__tests__/loading.js
+++ b/packages/zent/__tests__/loading.js
@@ -47,7 +47,7 @@ describe('Loading', () => {
   });
 
   it('Loading has floating model.', () => {
-    const wrapper = mount(
+    let wrapper = mount(
       <Loading show={false} float>
         <span className="foo" />
       </Loading>
@@ -58,6 +58,15 @@ describe('Loading', () => {
     wrapper.setProps({ show: true });
     wrapper.setProps({ show: false });
     wrapper.setProps({ show: true });
+    wrapper.unmount();
+
+    // Can be used without children
+    wrapper = mount(
+      <Loading show float className="loading-test-no-children" />
+    );
+    expect(document.querySelectorAll('.loading-test-no-children').length).toBe(
+      1
+    );
     wrapper.unmount();
   });
 

--- a/packages/zent/src/loading/LoadingInstance.js
+++ b/packages/zent/src/loading/LoadingInstance.js
@@ -127,7 +127,8 @@ export default class Instance extends (PureComponent || Component) {
       );
     }
 
-    return this.props.children;
+    // In case Loading has no children
+    return this.props.children || null;
   }
 }
 


### PR DESCRIPTION
Return `null` if no children