### PR TITLE
fix: form自定义Field里调用this.props.onChange会将整个对象覆盖掉

### DIFF
--- a/packages/zent/src/form/Field.js
+++ b/packages/zent/src/form/Field.js
@@ -172,10 +172,12 @@ class Field extends (PureComponent || Component) {
     return format(value);
   };
 
-  handleChange = event => {
+  handleChange = (event, options = { merge: false }) => {
     const { onChange, validateOnChange } = this.props;
     const previousValue = this.getValue();
-    const currentValue = getCurrentValue(getValue(event), previousValue);
+    const currentValue = options.merge
+      ? getCurrentValue(getValue(event), previousValue)
+      : getValue(event);
     const newValue = this.normalize(currentValue);
     let preventSetValue = false;
 
@@ -210,10 +212,12 @@ class Field extends (PureComponent || Component) {
     this.setState(data);
   };
 
-  handleBlur = event => {
+  handleBlur = (event, options = { merge: false }) => {
     const { onBlur, asyncValidation, validateOnBlur } = this.props;
     const previousValue = this.getValue();
-    const currentValue = getCurrentValue(getValue(event), previousValue);
+    const currentValue = options.merge
+      ? getCurrentValue(getValue(event), previousValue)
+      : getValue(event);
     const newValue = this.normalize(currentValue);
     let preventSetValue = false;
 

--- a/packages/zent/src/form/Field.js
+++ b/packages/zent/src/form/Field.js
@@ -4,6 +4,8 @@ import { Component, PureComponent, createElement } from 'react';
 import isEqual from 'lodash/isEqual';
 import omit from 'lodash/omit';
 import assign from 'lodash/assign';
+import isObject from 'lodash/isObject';
+import cloneDeep from 'lodash/cloneDeep';
 import PropTypes from 'prop-types';
 
 import { getValue } from './utils';
@@ -175,7 +177,10 @@ class Field extends (PureComponent || Component) {
   handleChange = event => {
     const { onChange, validateOnChange } = this.props;
     const previousValue = this.getValue();
-    const newValue = this.normalize(getValue(event));
+    const changedValue = isObject(previousValue)
+      ? assign(cloneDeep(previousValue), getValue(event))
+      : getValue(event);
+    const newValue = this.normalize(changedValue);
     let preventSetValue = false;
 
     // 在传入的onChange中可以按需阻止更新value值
@@ -212,7 +217,10 @@ class Field extends (PureComponent || Component) {
   handleBlur = event => {
     const { onBlur, asyncValidation, validateOnBlur } = this.props;
     const previousValue = this.getValue();
-    const newValue = this.normalize(getValue(event));
+    const changedValue = isObject(previousValue)
+      ? assign(cloneDeep(previousValue), getValue(event))
+      : getValue(event);
+    const newValue = this.normalize(changedValue);
     let preventSetValue = false;
 
     if (onBlur) {

--- a/packages/zent/src/form/Field.js
+++ b/packages/zent/src/form/Field.js
@@ -4,11 +4,9 @@ import { Component, PureComponent, createElement } from 'react';
 import isEqual from 'lodash/isEqual';
 import omit from 'lodash/omit';
 import assign from 'lodash/assign';
-import isObject from 'lodash/isObject';
-import cloneDeep from 'lodash/cloneDeep';
 import PropTypes from 'prop-types';
 
-import { getValue } from './utils';
+import { getValue, getCurrentValue } from './utils';
 import unknownProps from './unknownProps';
 
 class Field extends (PureComponent || Component) {
@@ -177,10 +175,8 @@ class Field extends (PureComponent || Component) {
   handleChange = event => {
     const { onChange, validateOnChange } = this.props;
     const previousValue = this.getValue();
-    const changedValue = isObject(previousValue)
-      ? assign(cloneDeep(previousValue), getValue(event))
-      : getValue(event);
-    const newValue = this.normalize(changedValue);
+    const currentValue = getCurrentValue(getValue(event), previousValue);
+    const newValue = this.normalize(currentValue);
     let preventSetValue = false;
 
     // 在传入的onChange中可以按需阻止更新value值
@@ -217,10 +213,8 @@ class Field extends (PureComponent || Component) {
   handleBlur = event => {
     const { onBlur, asyncValidation, validateOnBlur } = this.props;
     const previousValue = this.getValue();
-    const changedValue = isObject(previousValue)
-      ? assign(cloneDeep(previousValue), getValue(event))
-      : getValue(event);
-    const newValue = this.normalize(changedValue);
+    const currentValue = getCurrentValue(getValue(event), previousValue);
+    const newValue = this.normalize(currentValue);
     let preventSetValue = false;
 
     if (onBlur) {

--- a/packages/zent/src/form/README.md
+++ b/packages/zent/src/form/README.md
@@ -203,15 +203,15 @@ const ContactPhone = (props) => {
     'has-error': showError
   });
   const onSelectChange = (e, selectedItem) => {
-    const newValue = Object.assign({}, value, {
+    const newValue = {
       areacode: selectedItem.index
-    });
+    };
     props.onChange(newValue);
   };
   const onPhoneChange = (e) => {
-    const newValue = Object.assign({}, value, {
+    const newValue = {
       mobile: e.target.value
-    });
+    };
     props.onChange(newValue);
   };
   const filterHandler = (item, keyword) => {

--- a/packages/zent/src/form/README.md
+++ b/packages/zent/src/form/README.md
@@ -206,12 +206,12 @@ const ContactPhone = (props) => {
     const newValue = {
       areacode: selectedItem.index
     };
-    props.onChange(newValue);
+    props.onChange(newValue, { merge: true });
   };
   const onPhoneChange = (e) => {
-    const newValue = {
+    const newValue = Object.assign({}, value,{
       mobile: e.target.value
-    };
+    });
     props.onChange(newValue);
   };
   const filterHandler = (item, keyword) => {

--- a/packages/zent/src/form/utils.js
+++ b/packages/zent/src/form/utils.js
@@ -1,3 +1,6 @@
+import isPlainObject from 'lodash/isPlainObject';
+import assign from 'lodash/assign';
+
 const getSelectedValues = options => {
   const result = [];
   if (options) {
@@ -35,6 +38,17 @@ export function getValue(event) {
 
   // 自定义组件需要直接抛出value或者把value放在一个对象中
   return event && event.value !== undefined ? event.value : event;
+}
+
+// 根据旧值和变化值，得到当前值
+export function getCurrentValue(changedValue, prevValue) {
+  let currentValue;
+  if (prevValue && isPlainObject(prevValue)) {
+    currentValue = assign({}, prevValue, changedValue);
+  } else {
+    currentValue = changedValue;
+  }
+  return currentValue;
 }
 
 export function getDisplayName(Component) {


### PR DESCRIPTION
Fixes #375 .

Changes you made in this pull request:

- form: use assign in onChange function of filed to avoid object being overlapping.
