### PR TITLE
Field in Form: validationErrors与validationError置空时，校验出错误时的显示策略调整

### DIFF
--- a/packages/zent/src/form/createForm.js
+++ b/packages/zent/src/form/createForm.js
@@ -373,7 +373,7 @@ const createForm = (config = {}) => {
               value
             );
             updateResults(validation, validationMethod);
-          } else if (typeof validations[validationMethod] !== 'function') {
+          } else {
             const validation = validationRules[validationMethod](
               currentValues,
               value,

--- a/packages/zent/src/form/getControlGroup.js
+++ b/packages/zent/src/form/getControlGroup.js
@@ -16,7 +16,7 @@ export default Control => {
         ...props
       } = this.props;
 
-      const showError = props.isTouched && props.error;
+      const showError = props.isTouched && props.error !== null;
       const groupClassName = cx({
         'zent-form__control-group': true,
         'zent-form__control-group--active': props.isActive,


### PR DESCRIPTION
当校验失败，同时校验规则没有对应的错误提示以及validationError为`""`时，getControllGroup 中 showError 开关表现为 false. 

通过改变showError的逻辑修复之.

Before this pr

```jsx
validations={{ required: true }}
validationErrors={{ required: '值不能为空' }}
```
![](http://youzan-fancy.oss-cn-shanghai.aliyuncs.com/zent-issues/17_08_19/before.png)

```jsx
validations={{ required: true }}
validationErrors={{}}
```
![](http://youzan-fancy.oss-cn-shanghai.aliyuncs.com/zent-issues/17_08_19/before-error.png)

After

```jsx
validations={{ required: true }}
validationErrors={{}}
```
![](http://youzan-fancy.oss-cn-shanghai.aliyuncs.com/zent-issues/17_08_19/after.png)
