### PR TITLE
[bug fix] DateRangeQuickPicker: 调整最近7天，使end_time包含到当前时间

### DIFF
--- a/packages/zent/src/date-range-quick-picker/constants.js
+++ b/packages/zent/src/date-range-quick-picker/constants.js
@@ -4,5 +4,6 @@ nowDate.setMinutes(0);
 nowDate.setSeconds(0);
 
 export const NOW = Number(nowDate);
+export const NOWDATE = Number(new Date());
 export const ONE_DAY = 1000 * 60 * 60 * 24;
 export const TOMORROW = NOW + ONE_DAY;

--- a/packages/zent/src/date-range-quick-picker/helper.js
+++ b/packages/zent/src/date-range-quick-picker/helper.js
@@ -1,11 +1,24 @@
 import formatDate from 'zan-utils/date/formatDate';
-import { NOW, TOMORROW, ONE_DAY } from './constants';
+import { NOW, TOMORROW, ONE_DAY, NOWDATE } from './constants';
 
 export function calculateTime(format, chooseDays, valueType) {
-  const startTime = NOW - chooseDays * ONE_DAY;
-  const startTimeRes = formatDate(startTime, format);
+  let startTime;
+  if (chooseDays > 1) {
+    startTime = NOW - (chooseDays - 1) * ONE_DAY;
+  } else {
+    startTime = NOW - chooseDays * ONE_DAY;
+  }
 
-  const endTime = (chooseDays === 0 ? TOMORROW : NOW) - 1000;
+  let endTime;
+  if (chooseDays === 0) {
+    endTime = TOMORROW - 1000;
+  } else if (chooseDays === 1) {
+    endTime = NOW - 1000;
+  } else {
+    endTime = NOWDATE;
+  }
+
+  const startTimeRes = formatDate(startTime, format);
   const endTimeRes = formatDate(endTime, format);
 
   if (valueType === 'number') {


### PR DESCRIPTION
DateRangeQuickPicker ： 快速筛选最近7天，end_time 值为当前时间，而不是前一天晚上11:59:59.