### PR TITLE
[bug fix] Design: 在componentWillUnmount时，移除监听的beforeunload事件

### DIFF
--- a/packages/zent/src/design/Design.js
+++ b/packages/zent/src/design/Design.js
@@ -620,7 +620,7 @@ export default class Design extends (PureComponent || Component) {
   }
 
   uninstallBeforeUnloadHook() {
-    window.addEventListener('beforeunload', this.onBeforeWindowUnload);
+    window.removeEventListener('beforeunload', this.onBeforeWindowUnload);
     this._hasBeforeUnloadHook = false;
   }
 


### PR DESCRIPTION
`uninstallBeforeUnloadHook`函数内部，`addEventLisner` 修改成 `removeEventListener`
