### PR TITLE
[bug fix] Swiper: 修复当只有一个子元素时的显示错误问题

### DIFF
--- a/packages/zent/src/swiper/Swiper.js
+++ b/packages/zent/src/swiper/Swiper.js
@@ -64,7 +64,7 @@ export default class Swiper extends (PureComponent || Component) {
       });
     });
 
-    this.translate(currentIndex, true);
+    innerElements.length > 1 && this.translate(currentIndex, true);
   };
 
   getSwiper = swiper => {


### PR DESCRIPTION
Fixes #466 