### PR TITLE
[bug fix]Select：修复select在选项数组置空后选中项不会重置的bug

### DIFF
--- a/packages/zent/src/select/README.md
+++ b/packages/zent/src/select/README.md
@@ -139,6 +139,69 @@ ReactDOM.render(
 ```
 :::
 
+:::demo 支持动态操控选项数组
+```jsx
+import { Select, Button } from 'zent';
+
+const Option = Select.Option;
+
+class Demo extends Component {
+	state = {
+  	selectedValue: '2',
+		selectData: [
+			{ value: '1', text: '选项一' },
+			{ value: '2', text: '选项二' },
+			{ value: '3', text: '选项三' },
+		]
+  };
+
+	reRender = () => {
+		this.forceUpdate();
+	};
+
+	selectChangeHandler = (event, selected) => {
+		this.setState({
+			selectedValue: selected.value
+		});
+	};
+
+	reset = () => {
+		this.setState({
+			selectData: []
+		});
+	};
+
+	refill = () => {
+		this.setState({
+			selectData: [
+				{ value: '1', text: '选项一' },
+				{ value: '2', text: '选项二' },
+				{ value: '3', text: '选项三' },
+			]
+		});
+	};
+
+  render() {
+  	return (
+    	<div>
+        <Select
+					data={this.state.selectData}
+					onChange={this.selectChangeHandler}
+					value={this.state.selectedValue} />
+				<Button onClick={this.reset}>置空选项数组</Button>
+				<Button onClick={this.refill}>重新装填</Button>
+    	</div>
+    );
+  }
+}
+
+ReactDOM.render(
+  <Demo />
+  , mountNode
+);
+```
+:::
+
 :::demo 支持数组类型选项
 ```jsx
 import { Select } from 'zent';

--- a/packages/zent/src/select/Select.js
+++ b/packages/zent/src/select/Select.js
@@ -181,10 +181,18 @@ class Select extends (PureComponent || Component) {
         }
         return item;
       });
-    this.setState({
-      selectedItem: selected.sItem,
-      selectedItems: selected.sItems
-    });
+    if (this.sourceData.length) {
+      this.setState({
+        selectedItem: selected.sItem,
+        selectedItems: selected.sItems
+      });
+    } else {
+      // data置空之后选项也置空
+      this.setState({
+        selectedItem: {},
+        selectedItems: []
+      });
+    }
     return this.sourceData;
   }
 


### PR DESCRIPTION
通过受控逻辑将Select的data置为空数组时，原本的selectedItem内部state不会被充值。
