### PR TITLE
[bug fix] babel-plugin-zent: 增加老版本 zent 的警告

### DIFF
--- a/packages/babel-plugin-zent/README.md
+++ b/packages/babel-plugin-zent/README.md
@@ -33,6 +33,10 @@ In your component Javascript files, use zent like this: `import { Button, Dialog
 
 ### Options
 
+- `moduleMapppingFile`: absolute path of module mapping config for zent.
+- `automaticStyleImport`: `true` to enable styles imports for component.
+- `useRawStyle`: should be used with `automaticStyleImport`, imports postcss source files if set to `true`. **Requires zent >= 3.8.1**
+
 ```js
 // defaults
 {
@@ -41,9 +45,3 @@ In your component Javascript files, use zent like this: `import { Button, Dialog
 	useRawStyle: false
 }
 ```
-
-`moduleMapppingFile`: absolute path of module mapping config for zent.
-
-If `automaticStyleImport` is `true`, import styles for component.
-
-`useRawStyle` should be used with `automaticStyleImport`, imports postcss source files if set to `true`.

--- a/packages/babel-plugin-zent/src/index.js
+++ b/packages/babel-plugin-zent/src/index.js
@@ -64,7 +64,7 @@ module.exports = function(babel) {
             }
 
             if (t.isImportSpecifier(sp)) {
-              return r.concat(buildImportReplacement(sp, t, state));
+              return r.concat(buildImportReplacement(sp, t, state, path));
             }
 
             throw path.buildCodeFrameError('Unexpected import type');
@@ -77,7 +77,7 @@ module.exports = function(babel) {
   };
 };
 
-function buildImportReplacement(specifier, types, state) {
+function buildImportReplacement(specifier, types, state, originalPath) {
   initModuleMapppingAsNecessary(state);
 
   // import {Button as _Button} from 'zent'
@@ -101,6 +101,12 @@ function buildImportReplacement(specifier, types, state) {
     // style
     if (options.automaticStyleImport) {
       if (options.useRawStyle) {
+        if (!rule.postcss) {
+          throw originalPath.buildCodeFrameError(
+            '`useRawStyle` is not compatible with old versions of zent, please upgrade zent to >= zent@3.8.1'
+          );
+        }
+
         rule.postcss.forEach(path => {
           if (data.STYLE_IMPORT_MAPPING[path] === undefined) {
             replacement.push(


### PR DESCRIPTION
老版本的 zent 没有 postcss 配置。