### PR TITLE
[bug fix] Select: 修正select在格式化数据时会对data数组中对象进行操作的bug. 

### DIFF
--- a/packages/zent/src/select/README.md
+++ b/packages/zent/src/select/README.md
@@ -220,7 +220,7 @@ ReactDOM.render(
 import { Select } from 'zent';
 
 const data = [
-  {value: 1, text: '选项一'},
+  {value: 0, text: '选项一'},
   {value: 2, text: '选项二'},
   {value: 3, text: '选项三'}
 ];
@@ -418,17 +418,22 @@ ReactDOM.render(
 ```jsx
 import { Select } from 'zent';
 
+// const data = [
+//      {id: 1, value: '选项一'},
+//      {id: 2, value: '选项二'},
+//      {id: 3, value: '选项三'}
+// ];
+
 const data = [
-     {id: 1, name: '选项一'},
-     {id: 2, name: '选项二'},
-     {id: 3, name: '选项三'}
+	{ code: '+86', zh: 'zhongguo', eng: 'china', value: '中国 +86', index: 0 },
+	{ code: '+853', zh: 'aomen', eng: 'Macau', value: '中国澳门 +853', index: 1 }
 ];
 
 ReactDOM.render(
   <Select
     data={data}
-    optionValue="id"
-    optionText="name"
+    optionValue="index"
+    optionText="value"
     emptyText="No Result"
     filter={(item, keyword) => item.name.indexOf(keyword) > -1}
   />

--- a/packages/zent/src/select/Select.js
+++ b/packages/zent/src/select/Select.js
@@ -7,6 +7,7 @@ import omit from 'lodash/omit';
 import isEqual from 'lodash/isEqual';
 import isArray from 'lodash/isArray';
 import noop from 'lodash/noop';
+import cloneDeep from 'lodash/cloneDeep';
 import PropTypes from 'prop-types';
 
 import Popover from 'popover';
@@ -100,16 +101,16 @@ class Select extends (PureComponent || Component) {
         }
 
         // hacky the quirk when optionText = 'value' and avoid modify props
-        const copy = JSON.parse(JSON.stringify(option));
+        const optCopy = cloneDeep(option);
 
-        copy.cid = `${index}`;
+        optCopy.cid = `${index}`;
         if (optionValue) {
-          copy.value = option[optionValue];
+          optCopy.value = option[optionValue];
         }
         if (optionText) {
-          copy.text = option[optionText];
+          optCopy.text = option[optionText];
         }
-        return copy;
+        return optCopy;
       }));
     }
 

--- a/packages/zent/src/select/Select.js
+++ b/packages/zent/src/select/Select.js
@@ -3,7 +3,6 @@
  */
 
 import React, { Component, PureComponent, Children } from 'react';
-import assign from 'lodash/assign';
 import omit from 'lodash/omit';
 import isEqual from 'lodash/isEqual';
 import isArray from 'lodash/isArray';
@@ -48,7 +47,7 @@ class Select extends (PureComponent || Component) {
       this.trigger = props.trigger;
     }
 
-    this.state = assign(
+    this.state = Object.assign(
       {
         selectedItems: [],
         selectedItem: {
@@ -100,14 +99,17 @@ class Select extends (PureComponent || Component) {
           return { text: option, value: option, cid: `${index}` };
         }
 
-        option.cid = `${index}`;
+        // hacky the quirk when optionText = 'value' and avoid modify props
+        const copy = JSON.parse(JSON.stringify(option));
+
+        copy.cid = `${index}`;
         if (optionValue) {
-          option.value = option[optionValue];
+          copy.value = option[optionValue];
         }
         if (optionText) {
-          option.text = option[optionText];
+          copy.text = option[optionText];
         }
-        return option;
+        return copy;
       }));
     }
 
@@ -116,7 +118,7 @@ class Select extends (PureComponent || Component) {
       uniformedData = Children.map(children, (item, index) => {
         let value = item.props.value;
         value = typeof value === 'undefined' ? item : value;
-        return assign({}, item.props, {
+        return Object.assign({}, item.props, {
           value,
           cid: `${index}`,
           text: item.props.children


### PR DESCRIPTION
原本Select序列化输入数据的过程中，如果`data` prop类型为对象数组  会对其中的对象进行直接改写。

同时`optionValue`与`optionText`同时存在时, `optionText`值不起作用。

使用`lodash/cloneDeep`做数据拷贝修正了上述问题。