### PR TITLE
[bug fix] Design: 修复变量名

### DIFF
--- a/packages/zent/src/design/utils/component-group.js
+++ b/packages/zent/src/design/utils/component-group.js
@@ -79,6 +79,6 @@ export function splitGroup(components) {
 
       return state;
     },
-    { groups: [], buffer: [], g: null }
+    { groups: [], buffer: [], group: null }
   ).groups;
 }


### PR DESCRIPTION
重构的时候漏改了一个变量名字，不影响代码功能。