### PR TITLE
[bug fix] Cascader: 参数 `value`、`options`、`title`不为数组时的兼容处理

### DIFF
--- a/packages/zent/__tests__/cascader.js
+++ b/packages/zent/__tests__/cascader.js
@@ -74,8 +74,11 @@ describe('Cascader', () => {
         ]
       }
     ];
+    const title = ['省份', '城市', '县区'];
 
-    const wrapper = mount(<Cascader value={value} options={options} />);
+    const wrapper = mount(
+      <Cascader value={value} options={options} title={title} />
+    );
     expect(
       wrapper
         .find('.zent-cascader__select-text')

--- a/packages/zent/src/cascader/Cascader.js
+++ b/packages/zent/src/cascader/Cascader.js
@@ -7,6 +7,7 @@ import Icon from 'icon';
 import forEach from 'lodash/forEach';
 import find from 'lodash/find';
 import noop from 'lodash/noop';
+import isArray from 'lodash/isArray';
 
 const PopoverContent = Popover.Content;
 const withPopover = Popover.withPopover;
@@ -32,8 +33,8 @@ class Cascader extends (PureComponent || Component) {
     super(props);
 
     this.state = {
-      value: props.value,
-      options: props.options,
+      value: isArray(props.value) ? props.value : [],
+      options: isArray(props.options) ? props.options : [],
       onChangeValue: [],
       activeId: 1,
       open: false
@@ -48,7 +49,7 @@ class Cascader extends (PureComponent || Component) {
     let { loadMore } = this.props;
 
     if (nextProps.hasOwnProperty('value')) {
-      let nextValue = nextProps.value || [];
+      let nextValue = isArray(nextProps.value) ? nextProps.value : [];
       if (!loadMore) {
         this.setState({
           value: nextValue
@@ -58,7 +59,7 @@ class Cascader extends (PureComponent || Component) {
     }
     if (this.props.options !== nextProps.options) {
       this.setState({
-        options: nextProps.options
+        options: isArray(nextProps.options) ? nextProps.options : []
       });
     }
   }
@@ -180,7 +181,7 @@ class Cascader extends (PureComponent || Component) {
     let { options, value } = this.state;
     let tabTitle = '标题';
 
-    title = title || [];
+    title = isArray(title) ? title : [];
     if (title.length > 0) {
       tabTitle = title[0];
     }

--- a/packages/zent/src/cascader/Cascader.js
+++ b/packages/zent/src/cascader/Cascader.js
@@ -352,7 +352,7 @@ Cascader.defaultProps = {
   options: [],
   placeholder: '请选择',
   changeOnSelect: false,
-  title: ['省份', '城市', '县区']
+  title: []
 };
 
 export default Cascader;

--- a/packages/zent/src/cascader/README_en-US.md
+++ b/packages/zent/src/cascader/README_en-US.md
@@ -14,7 +14,7 @@ Cascader is used for cascade operation, e.g. cascade location selection.
 |------|------|------|--------|--------|
 | value | The selected value | array | [] | '' |
 | options | Optional data source | array | [] | '' |
-| title | title of tab | array | ['省份', '城市', '县区'] | '' |
+| title | Title of tab, tab title default is `标题` | array | [] | '' |
 | onChange | The callback when data changes | func | noop | '' |
 | loadMore | Function to load data dynamicly, must return Promise | func | - | '' |
 | changeOnSelect | Wether trigger change once sth. is seleted | boolean | false | '' |

--- a/packages/zent/src/cascader/README_zh-CN.md
+++ b/packages/zent/src/cascader/README_zh-CN.md
@@ -17,7 +17,7 @@ group: 数据
 |------|------|------|--------|--------|
 | value | 级联的选中值 | array | [] | '' |
 | options | 可选项数据源 | array | [] | '' |
-| title | tab子项的标题 | array | ['省份', '城市', '县区'] | '' |
+| title | tab子项的标题，每一项的默认值是 `标题` | array | [] | '' |
 | onChange | 数据变化时的回调 | func | noop | '' |
 | loadMore | 动态加载级联的数据，返回值需为 Promise | func | - | '' |
 | changeOnSelect | 是否选择即触发改变 | boolean | false | '' |


### PR DESCRIPTION
Fixes #546 

- [bug fix] Cascader: 参数 `value`、`options`、`title`不为数组时的兼容处理
- [breaking change] Cascader: 参数 `title` 默认值改为空数组，此时每一项tab显示 `标题` 两字
