### PR TITLE
[bug fix] Design: Prevent component select when click on delete button

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-es3-member-expression-literals": "^6.22.0",
     "babel-plugin-transform-es3-property-literals": "^6.22.0",
-    "babel-plugin-transform-react-constant-elements": "^6.23.0",
     "babel-plugin-transform-remove-console": "^6.8.1",
     "babel-plugin-transform-remove-debugger": "^6.8.1",
     "babel-plugin-transform-runtime": "^6.23.0",

--- a/packages/zent/.babelrc
+++ b/packages/zent/.babelrc
@@ -13,8 +13,7 @@
     "production": {
       "plugins": [
         "transform-remove-console",
-        "transform-remove-debugger",
-        "transform-react-constant-elements"
+        "transform-remove-debugger"
       ]
     },
 
@@ -22,7 +21,6 @@
       "plugins": [
         "transform-remove-console",
         "transform-remove-debugger",
-        "transform-react-constant-elements",
         "./scripts/babel/babel-plugin-resolve-zent-module"
       ]
     }

--- a/packages/zent/src/design/preview/DesignPreviewController.js
+++ b/packages/zent/src/design/preview/DesignPreviewController.js
@@ -228,7 +228,7 @@ function DeleteButton({ prefix, onDelete }) {
       onConfirm={onDelete}
       wrapperClassName={`${prefix}-design-preview-controller__action-btn-delete`}
     >
-      <IconDelete prefix={prefix} />
+      <IconDelete prefix={prefix} onClick={stopEventPropagation} />
     </Pop>
   );
 }
@@ -311,6 +311,10 @@ class IconDelete extends (PureComponent || Component) {
       </svg>
     );
   }
+}
+
+function stopEventPropagation(evt) {
+  evt && evt.stopPropagation();
 }
 
 export default DesignPreviewController;

--- a/yarn.lock
+++ b/yarn.lock
@@ -846,12 +846,6 @@ babel-plugin-transform-object-rest-spread@^6.22.0:
     babel-plugin-syntax-object-rest-spread "^6.8.0"
     babel-runtime "^6.26.0"
 
-babel-plugin-transform-react-constant-elements@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-constant-elements/-/babel-plugin-transform-react-constant-elements-6.23.0.tgz#2f119bf4d2cdd45eb9baaae574053c604f6147dd"
-  dependencies:
-    babel-runtime "^6.22.0"
-
 babel-plugin-transform-react-display-name@^6.23.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz#67e2bf1f1e9c93ab08db96792e05392bf2cc28d1"


### PR DESCRIPTION
* Remove `babel-plugin-transform-react-constant-elements`, buggy as always.
* Prevent component select when click on delete button