### PR TITLE
[new feature && breaking changes]: Add resetOption prop and resetText to Select.

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "precss": "2.0.0",
     "prettier": "^1.2.2",
     "react": "^15.5.4",
+    "react-beautiful-dnd": "^2.6.4",
     "react-dom": "^15.5.4",
     "react-test-renderer": "^15.5.4",
     "stylefmt": "^5.3.2",

--- a/packages/zent/__tests__/select.js
+++ b/packages/zent/__tests__/select.js
@@ -280,15 +280,44 @@ describe('<Select />', () => {
     expect(wrapper.state('selectedItem').value).toBe(2);
   });
 
-  // it('initial value and index', () => {
-  //   const data = [
-  //     { value: '1', text: '选项一' },
-  //     { value: '2', text: '选项二' },
-  //     { value: '3', text: '选项三' },
-  //   ];
-  //   let wrapper = mount(<Select data={data} initialValue="1" />);
-  //   expect(wrapper.state('selectedItem').value).toBe('1');
-  //   wrapper = mount(<Select data={data} initialIndex={2} />);
-  //   expect(wrapper.state('selectedItem').value).toBe('2');
-  // });
+  it('Reset after data array erased', () => {
+    let data = ['1', '2', '3'];
+    const wrapper = mount(<Select data={data} />);
+    wrapper.find('SelectTrigger').simulate('click');
+    let pop = new ReactWrapper(wrapper.instance().popup, true);
+    expect(pop.find('Option').length).toBe(3);
+    pop
+      .find('Option')
+      .at(1)
+      .simulate('click');
+    expect(wrapper.state('selectedItem').value).toBe('2');
+    wrapper.setProps({ data: [] });
+    expect(wrapper.state('selectedItem').value).toBe(undefined);
+    expect(wrapper.find('.zent-select-text').text()).toBe(
+      wrapper.prop('placeholder')
+    );
+  });
+
+  it('Reset Option', () => {
+    const data = ['1', '2', '3'];
+    const wrapper = mount(<Select data={data} resetOption />);
+    wrapper.find('SelectTrigger').simulate('click');
+    let pop = new ReactWrapper(wrapper.instance().popup, true);
+    expect(pop.find('Option').length).toBe(4);
+    pop
+      .find('Option')
+      .at(1)
+      .simulate('click');
+    expect(wrapper.state('selectedItem').value).toBe('1');
+    wrapper.find('SelectTrigger').simulate('click');
+    pop = new ReactWrapper(wrapper.instance().popup, true);
+    pop
+      .find('Option')
+      .at(0)
+      .simulate('click');
+    expect(wrapper.state('selectedItem').value).toBe(undefined);
+    expect(wrapper.find('.zent-select-text').text()).toBe(
+      wrapper.prop('placeholder')
+    );
+  });
 });

--- a/packages/zent/src/select/Select.js
+++ b/packages/zent/src/select/Select.js
@@ -65,7 +65,7 @@ class Select extends (PureComponent || Component) {
      * data支持字符串数组和对象数组两种模式
      *
      * 字符串数组默认value为下标
-     * 对象数组需提供value和text, 或者通过 optionValue-prop optionText-prop 自定义
+     * 对象数组需提供value和text, 或者通过 optionValue(prop) optionText(prop) 自定义
      *
      */
     this.uniformedData = this.uniformData(this.props);
@@ -89,50 +89,68 @@ class Select extends (PureComponent || Component) {
    * @memberof Select
    */
   uniformData(props) {
-    const { data, children, optionValue, optionText } = props;
-    let uniformedData = [];
+    const {
+      data,
+      children,
+      optionValue,
+      optionText,
+      resetOption,
+      resetText
+    } = props;
+
+    let uniformedData =
+      resetOption && data.length
+        ? [{ cid: '-1', value: null, text: resetText }] // insert reset option
+        : [];
 
     // data-prop 高优先级, 格式化 optionValue、optionText
     if (data) {
-      return (uniformedData = data.map((option, index) => {
-        // 处理字符串数组
-        if (typeof option !== 'object') {
-          return { text: option, value: option, cid: `${index}` };
-        }
+      uniformedData = uniformedData.concat(
+        data.map((option, index) => {
+          // 处理字符串数组
+          if (typeof option !== 'object') {
+            return { text: option, value: option, cid: `${index}` };
+          }
 
-        // hacky the quirk when optionText = 'value' and avoid modify props
-        const optCopy = cloneDeep(option);
+          // hacky the quirk when optionText = 'value' and avoid modify props
+          const optCopy = cloneDeep(option);
 
-        optCopy.cid = `${index}`;
-        if (optionValue) {
-          optCopy.value = option[optionValue];
-        }
-        if (optionText) {
-          optCopy.text = option[optionText];
-        }
-        return optCopy;
-      }));
+          optCopy.cid = `${index}`;
+          if (optionValue) {
+            optCopy.value = option[optionValue];
+          }
+          if (optionText) {
+            optCopy.text = option[optionText];
+          }
+          return optCopy;
+        })
+      );
+
+      return uniformedData;
     }
 
     // 格式化 child-element
     if (children) {
-      uniformedData = Children.map(children, (item, index) => {
-        let value = item.props.value;
-        value = typeof value === 'undefined' ? item : value;
-        return Object.assign({}, item.props, {
-          value,
-          cid: `${index}`,
-          text: item.props.children
-        });
-      });
+      uniformedData = uniformedData.concat(
+        Children.map(children, (item, index) => {
+          let value = item.props.value;
+          value = typeof value === 'undefined' ? item : value;
+          return Object.assign({}, item.props, {
+            value,
+            cid: `${index}`,
+            text: item.props.children
+          });
+        })
+      );
     }
+
     return uniformedData;
   }
 
   /**
    * accept uniformed data to traverse then inject selected option or options to next state
    *
-   * @param {object[]} data - uniformedData
+   * @param {object[]} data - uniformed data
    * @param {object} props - props of Select
    * @memberof Select
    */
@@ -152,7 +170,7 @@ class Select extends (PureComponent || Component) {
     const selected = { sItem: selectedItem, sItems: [] };
 
     data.forEach((item, i) => {
-      // 处理 quirk 默认选项(initialIndex, initialValue)
+      // 处理 quirk 默认选项(initialIndex, initialValue), 主要用于在非受控组件模式下指定默认值
       if (
         selectedItems.length === 0 &&
         !selectedItem.cid &&
@@ -162,8 +180,8 @@ class Select extends (PureComponent || Component) {
         this.locateSelected(selected, coord, item, i);
       }
 
-      // 处理受控逻辑(index, value)
-      if (value !== null || index !== null) {
+      // 处理受控逻辑(index, value)，受控模式与怪癖模式不兼容
+      if (initialIndex === null && initialValue === null) {
         this.locateSelected(selected, { value, index }, item, i);
       }
     });
@@ -182,7 +200,8 @@ class Select extends (PureComponent || Component) {
    * @param {object} item - option object after uniformed
    * @param {number} i - index of option in options list
    * @memberof Select
-  * */
+   * 多选不支持使用index控制选项，同时仅当value为null时，会重置单选结果。
+   * */
   locateSelected(state, coord, item, i) {
     const { value, index } = coord;
 
@@ -198,13 +217,11 @@ class Select extends (PureComponent || Component) {
     } else if (typeof value === 'object' && isEqual(value, item.value)) {
       state.sItem = item;
     } else if (
-      (typeof value !== 'undefined' &&
-        typeof value !== 'object' &&
-        `${item.value}` === `${value}`) ||
-      (index !== 'undefined' && `${i}` === `${index}`)
+      (value !== null && item.value === value) ||
+      (index !== null && i === index)
     ) {
       state.sItem = item;
-    } else if (!value && !index && value !== 0) {
+    } else if (value === null && index === null) {
       // github#406 修复option-value为假值数字0时的异常重置。
       // 单选重置
       state.sItem = {};
@@ -257,6 +274,9 @@ class Select extends (PureComponent || Component) {
       if (!selectedItems.some(item => item.cid === selectedItem.cid)) {
         selectedItems.push(selectedItem);
       }
+    } else if (selectedItem.value === null) {
+      // customize reset option
+      selectedItem = {};
     }
     this.setState(
       {
@@ -396,7 +416,13 @@ Select.propTypes = {
   width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 
   // 自动根据ref计算弹层宽度
-  autoWidth: PropTypes.bool
+  autoWidth: PropTypes.bool,
+
+  // 自动添加重置选项
+  resetOption: PropTypes.bool,
+
+  // 重置选项展示文本
+  resetText: PropTypes.string
 };
 
 Select.defaultProps = {
@@ -422,7 +448,10 @@ Select.defaultProps = {
   onOpen: noop,
   autoWidth: false,
 
-  // HACK
+  resetOption: false,
+  resetText: '...',
+
+  // null作为Select系统内唯一假值
   value: null,
   index: null,
   initialValue: null,

--- a/packages/zent/src/select/demos/array.md
+++ b/packages/zent/src/select/demos/array.md
@@ -14,7 +14,7 @@ import { Select } from 'zent';
 const data = ['Option 1', 'Option 2', 'Option 3'];
 
 ReactDOM.render(
-	<Select placeholder="{i18n.pla}" data={data} />,
+	<Select resetOption placeholder="{i18n.pla}" data={data} />,
 	mountNode
 );
 ```

--- a/packages/zent/src/select/demos/controlled.md
+++ b/packages/zent/src/select/demos/controlled.md
@@ -42,7 +42,7 @@ class Demo extends Component {
 
 	reset = () => {
 		this.setState({
-			selectedValue: ''
+			selectedValue: null
 		});
 	};
 

--- a/packages/zent/src/select/quirk.md
+++ b/packages/zent/src/select/quirk.md
@@ -1,0 +1,47 @@
+---
+order: 2.5
+zh-CN:
+	title: 怪异模式(不推荐，留作调试使用)
+	pla: 请选择
+	re: 重新渲染
+en-US:
+	title: Controlled Mode
+	pla: Select an option..
+	re: Rerender
+---
+
+```js
+import { Select, Button } from 'zent';
+
+const Option = Select.Option;
+const data = [
+	{ value: undefined, text: 'Option 1' },
+	{ value: '', text: 'Option 2' },
+	{ value: false, text: 'Option 3' },
+	{ value: 0, text: 'Option 3' }
+];
+
+class Demo extends Component {
+	reRender = () => {
+		this.forceUpdate();
+	};
+
+  render() {
+  	return (
+    	<div>
+				<Select
+					placeholder="{i18n.pla}"
+					data={data}
+					resetOption
+					initialValue={false} />
+				<Button onClick={this.reRender}>{i18n.re}</Button>
+    	</div>
+    );
+  }
+}
+
+ReactDOM.render(
+	<Demo />,
+	mountNode
+);
+```


### PR DESCRIPTION
- [x] 为Select提供一种重置已选项的快捷开关，resetOption 默认为`false`，resetText 默认为`'...'`。

- [x] 在Select的判断选中函数改为`===`，使用`null`作为重置标记与唯一假值。

- [ ] 考虑取消initalValue 与 initialIndex 两个 prop。