### PR TITLE
[new feature] Select: 增加重置选项开关和重置选项文本设置选项。

### DIFF
--- a/packages/zent/__tests__/select.js
+++ b/packages/zent/__tests__/select.js
@@ -291,4 +291,27 @@ describe('<Select />', () => {
   //   wrapper = mount(<Select data={data} initialIndex={2} />);
   //   expect(wrapper.state('selectedItem').value).toBe('2');
   // });
+
+  it('Reset Option', () => {
+    const data = ['1', '2', '3'];
+    const wrapper = mount(<Select data={data} resetOption />);
+    wrapper.find('SelectTrigger').simulate('click');
+    let pop = new ReactWrapper(wrapper.instance().popup, true);
+    expect(pop.find('Option').length).toBe(4);
+    pop
+      .find('Option')
+      .at(1)
+      .simulate('click');
+    expect(wrapper.state('selectedItem').value).toBe('1');
+    wrapper.find('SelectTrigger').simulate('click');
+    pop = new ReactWrapper(wrapper.instance().popup, true);
+    pop
+      .find('Option')
+      .at(0)
+      .simulate('click');
+    expect(wrapper.state('selectedItem').value).toBe(undefined);
+    expect(wrapper.find('.zent-select-text').text()).toBe(
+      wrapper.prop('placeholder')
+    );
+  });
 });

--- a/packages/zent/src/number-input/README_zh-CN.md
+++ b/packages/zent/src/number-input/README_zh-CN.md
@@ -20,7 +20,7 @@ group: 数据
 | value        | 输入值             | number        |          |    | 否    |
 | onChange     | change事件        | func(e:Event) |          |     | 否    |
 | showStepper  | 是否开启记步器         | bool        | `false` |    | 否    |
-| showStepper  | 是否开启加减号         | bool        | `false` |    | 否    |
+| showCounter  | 是否开启加减号         | bool        | `false` |    | 否    |
 | decimal      | 数值精度            | number        |          |     | 否    |
 | min      | 数值范围最小值            | number        |          |     | 否    |
 | max      | 数值范围最大值            | number        |          |     | 否    |

--- a/packages/zent/src/select/README_en-US.md
+++ b/packages/zent/src/select/README_en-US.md
@@ -51,6 +51,8 @@ Options list pop-up layer, is mainly responsible for display options, data filte
 | className | Optional, custom trigger additional classname | string | `''` | no |
 | popupClassName | Optional, custom popup classname | string | `''`    | no |
 | autoWidth | Whether to automatically set the width of pop-up layer equal with input-box's width | bool | `false` | no |
+| resetOption | Whether to add a reset option | bool | `false` | no |
+| resetText | Reset option text | string | `'请选择'` | no |
 | width |  input-box's width | string or number |  | no |
 | prefix | Custom prefix | string | `'zent'` | no |
 

--- a/packages/zent/src/select/README_zh-CN.md
+++ b/packages/zent/src/select/README_zh-CN.md
@@ -52,6 +52,8 @@ group: 数据
 | className | 可选，自定义trigger额外类名 | string | `''` | 否 |
 | popupClassName | 可选，自定义popup的类名 | string | `''`    | 否 |
 | autoWidth | 是否自动设置弹出层与输入框等宽 | bool | `false` | 否 |
+| resetOption | 是否加入一个重置选项 | bool | `false` | 否 |
+| resetText | 重置选项文本 | string | `'请选择'` | 否 |
 | width |  输入框宽度 | string or number |  | 否 |
 | prefix | 自定义前缀 | string | `'zent'` | 否 |
 
@@ -65,4 +67,4 @@ group: 数据
 | extraFilter | 是否自带过滤功能 | boolean | `false` | 否 |
 | open | 是否打开Popup | boolean | `false` | 否 |
 
-Trigger 可以通过调用 `this.props.onChange({...})` 通过改变 Popup 的 props 实现参数传递。 
+Trigger 可以通过调用 `this.props.onChange({...})` 通过改变 Popup 的 props 实现参数传递。

--- a/packages/zent/src/select/Select.js
+++ b/packages/zent/src/select/Select.js
@@ -98,8 +98,9 @@ class Select extends (PureComponent || Component) {
       resetText
     } = props;
 
+    // 在需要时插入重置选项。
     let uniformedData =
-      resetOption && data.length
+      resetOption && (data || children)
         ? [{ cid: '-1', value: null, text: resetText }] // insert reset option
         : [];
 
@@ -142,6 +143,7 @@ class Select extends (PureComponent || Component) {
         })
       );
     }
+
     return uniformedData;
   }
 

--- a/packages/zent/src/select/Select.js
+++ b/packages/zent/src/select/Select.js
@@ -65,7 +65,7 @@ class Select extends (PureComponent || Component) {
      * data支持字符串数组和对象数组两种模式
      *
      * 字符串数组默认value为下标
-     * 对象数组需提供value和text, 或者通过 optionValue-prop optionText-prop 自定义
+     * 对象数组需提供value和text, 或者通过 optionValue(prop) optionText(prop) 自定义
      *
      */
     this.uniformedData = this.uniformData(this.props);
@@ -89,42 +89,58 @@ class Select extends (PureComponent || Component) {
    * @memberof Select
    */
   uniformData(props) {
-    const { data, children, optionValue, optionText } = props;
-    let uniformedData = [];
+    const {
+      data,
+      children,
+      optionValue,
+      optionText,
+      resetOption,
+      resetText
+    } = props;
+
+    let uniformedData =
+      resetOption && data.length
+        ? [{ cid: '-1', value: null, text: resetText }] // insert reset option
+        : [];
 
     // data-prop 高优先级, 格式化 optionValue、optionText
     if (data) {
-      return (uniformedData = data.map((option, index) => {
-        // 处理字符串数组
-        if (typeof option !== 'object') {
-          return { text: option, value: option, cid: `${index}` };
-        }
+      uniformedData = uniformedData.concat(
+        data.map((option, index) => {
+          // 处理字符串数组
+          if (typeof option !== 'object') {
+            return { text: option, value: option, cid: `${index}` };
+          }
 
-        // hacky the quirk when optionText = 'value' and avoid modify props
-        const optCopy = cloneDeep(option);
+          // hacky the quirk when optionText = 'value' and avoid modify props
+          const optCopy = cloneDeep(option);
 
-        optCopy.cid = `${index}`;
-        if (optionValue) {
-          optCopy.value = option[optionValue];
-        }
-        if (optionText) {
-          optCopy.text = option[optionText];
-        }
-        return optCopy;
-      }));
+          optCopy.cid = `${index}`;
+          if (optionValue) {
+            optCopy.value = option[optionValue];
+          }
+          if (optionText) {
+            optCopy.text = option[optionText];
+          }
+          return optCopy;
+        })
+      );
+      return uniformedData;
     }
 
     // 格式化 child-element
     if (children) {
-      uniformedData = Children.map(children, (item, index) => {
-        let value = item.props.value;
-        value = typeof value === 'undefined' ? item : value;
-        return Object.assign({}, item.props, {
-          value,
-          cid: `${index}`,
-          text: item.props.children
-        });
-      });
+      uniformedData = uniformedData.concat(
+        Children.map(children, (item, index) => {
+          let value = item.props.value;
+          value = typeof value === 'undefined' ? item : value;
+          return Object.assign({}, item.props, {
+            value,
+            cid: `${index}`,
+            text: item.props.children
+          });
+        })
+      );
     }
     return uniformedData;
   }
@@ -132,7 +148,7 @@ class Select extends (PureComponent || Component) {
   /**
    * accept uniformed data to traverse then inject selected option or options to next state
    *
-   * @param {object[]} data - uniformedData
+   * @param {object[]} data - uniformed data
    * @param {object} props - props of Select
    * @memberof Select
    */
@@ -152,7 +168,7 @@ class Select extends (PureComponent || Component) {
     const selected = { sItem: selectedItem, sItems: [] };
 
     data.forEach((item, i) => {
-      // 处理 quirk 默认选项(initialIndex, initialValue)
+      // 处理 quirk 默认选项(initialIndex, initialValue) , 主要用于在非受控组件模式下指定默认值
       if (
         selectedItems.length === 0 &&
         !selectedItem.cid &&
@@ -182,7 +198,7 @@ class Select extends (PureComponent || Component) {
    * @param {object} item - option object after uniformed
    * @param {number} i - index of option in options list
    * @memberof Select
-  * */
+   * */
   locateSelected(state, coord, item, i) {
     const { value, index } = coord;
 
@@ -257,6 +273,9 @@ class Select extends (PureComponent || Component) {
       if (!selectedItems.some(item => item.cid === selectedItem.cid)) {
         selectedItems.push(selectedItem);
       }
+    } else if (selectedItem.value === null) {
+      // customize reset option
+      selectedItem = {};
     }
     this.setState(
       {
@@ -396,7 +415,13 @@ Select.propTypes = {
   width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 
   // 自动根据ref计算弹层宽度
-  autoWidth: PropTypes.bool
+  autoWidth: PropTypes.bool,
+
+  // 自动添加重置选项
+  resetOption: PropTypes.bool,
+
+  // 重置选项展示文本
+  resetText: PropTypes.string
 };
 
 Select.defaultProps = {
@@ -422,7 +447,11 @@ Select.defaultProps = {
   onOpen: noop,
   autoWidth: false,
 
-  // HACK
+  // 重置为默认值
+  resetOption: false,
+  resetText: '请选择',
+
+  // 内部状态标记，默认初始值为 null
   value: null,
   index: null,
   initialValue: null,

--- a/packages/zent/src/select/demos/array.md
+++ b/packages/zent/src/select/demos/array.md
@@ -1,10 +1,10 @@
 ---
 order: 4
 zh-CN:
-	title: 字符串数组
+	title: 字符串数组带重置选项
 	pla: 请选择
 en-US:
-	title: String Array
+	title: String Array with reset option
 	pla: Select an option
 ---
 
@@ -14,7 +14,7 @@ import { Select } from 'zent';
 const data = ['Option 1', 'Option 2', 'Option 3'];
 
 ReactDOM.render(
-	<Select placeholder="{i18n.pla}" data={data} />,
+	<Select resetOption resetText="..." placeholder="{i18n.pla}" data={data} />,
 	mountNode
 );
 ```

--- a/packages/zent/src/select/demos/callback.md
+++ b/packages/zent/src/select/demos/callback.md
@@ -3,9 +3,11 @@ order: 6
 zh-CN:
 	title: 支持自定义回调
 	pla: 请选择
+	deleted: 被删除了，它的值是
 en-US:
 	title: Custom Callback
 	pla: Select an option
+	deleted: was selected, and its value is
 ---
 
 ```js
@@ -19,7 +21,7 @@ const data = [
 
 function showOption(ev, data) {
   Dialog.openDialog({
-    children: `${data.name} was selected, and its value is ${data.id}.`
+    children: `${data.name} {i18n.deleted} ${data.id}`
   });
 }
 

--- a/packages/zent/src/select/demos/controlled.md
+++ b/packages/zent/src/select/demos/controlled.md
@@ -5,11 +5,13 @@ zh-CN:
 	pla: 请选择
 	reset: 重置为初始状态
 	re: 重新渲染
+	external: 外部状态
 en-US:
 	title: Controlled Mode
 	pla: Select an option..
 	reset: Reset
 	re: Rerender
+	external: External state
 ---
 
 ```js
@@ -49,7 +51,7 @@ class Demo extends Component {
   render() {
   	return (
     	<div>
-				<span>External State: {this.state.selectedValue}</span>
+				<span>{i18n.external}: {this.state.selectedValue}</span>
 				<br />
 				<br />
 				<Select

--- a/packages/zent/src/select/demos/dynamic.md
+++ b/packages/zent/src/select/demos/dynamic.md
@@ -4,10 +4,14 @@ zh-CN:
 	title: 动态修改选项数据
 	pla: 请选择
 	empty: 没有找到匹配项
+	blank: 空数组选项
+	reset: 重置
 en-US:
 	title: Modify the option data dynamically
 	pla: Select an option
 	empty: No matches found
+	blank: Empty option array
+	reset: Reset
 ---
 
 ```js
@@ -60,8 +64,8 @@ class Demo extends Component {
 					data={this.state.selectData}
 					onChange={this.selectChangeHandler}
 					value={this.state.selectedValue} />
-				<Button onClick={this.reset}>Blank option array</Button>
-				<Button onClick={this.refill}>Refill</Button>
+				<Button onClick={this.reset}>{i18n.blank}</Button>
+				<Button onClick={this.refill}>{i18n.reset}</Button>
     	</div>
     );
   }

--- a/packages/zent/src/select/demos/tag.md
+++ b/packages/zent/src/select/demos/tag.md
@@ -3,9 +3,19 @@ order: 13
 zh-CN:
 	title: 标签多选
 	pla: 请选择
+	reset: 重置
+	refill: 填充数据
+	external: 外部状态
+	optionDeleted: 被删除的选项是
+	optionAdded: 新加的选项是
 en-US:
 	title: Multiple Select with Tag
 	pla: Select options
+	reset: Reset
+	refill: Fill Data
+	external: External state
+	optionDeleted: The value of new deleted option is
+	optionAdded: The value of new added option is
 ---
 
 ```js
@@ -43,7 +53,7 @@ class TagsDemo extends Component {
 		this.setState({
 			value: this.state.selected.push(item.value)
 		});
-		Notify.success(<span>The value of new added option was {item.value}.</span>);
+		Notify.success(<span>{i18n.optionAdded} {item.value}</span>);
 	}
 
 	deleteHandler = (item) => {
@@ -55,13 +65,13 @@ class TagsDemo extends Component {
 		this.setState({
 			selected: newSelected
 		});
-		Notify.success(<span>The value of new deleted option was {item.value}.</span>);
+		Notify.success(<span>{i18n.optionDeleted} {item.value}</span>);
 	}
 
 	render() {
 		return (
 			<div>
-				<span>External State: {this.state.selected.join(',')}</span>
+				<span>{i18n.external}: {this.state.selected.join(',')}</span>
 					<br />
 					<br />
 				<Select
@@ -73,8 +83,8 @@ class TagsDemo extends Component {
 					tags
     			filter={(item, keyword) => item.text.indexOf(keyword) > -1}
 					value={this.state.selected} />
-				<Button onClick={this.reset}>Reset</Button>
-				<Button onClick={this.upgradeData}>Refill Data</Button>
+				<Button onClick={this.reset}>{i18n.reset}</Button>
+				<Button onClick={this.upgradeData}>{i18n.refill}</Button>
 			</div>
 		);
 	}


### PR DESCRIPTION
- [x] 为 Select 增加重置选项功能，resetOption 开关默认为`false`，resetText 默认为`'请选择'`，与placeholder 的默认值保持一致(容易造成混淆)。

- [x] 增加新功能所需的测试用例以及文档变更。

Fixes #544 