### PR TITLE
[bug fix] Form: scrollToError增加对Field的判断

### DIFF
--- a/packages/zent/src/form/utils.js
+++ b/packages/zent/src/form/utils.js
@@ -104,8 +104,14 @@ export function srcollToFirstError(fields) {
     const field = fields[i];
     if (!field.isValid()) {
       const node = field.getWrappedComponent().getControlInstance();
-      scrollToNode(node);
-      return false;
+      /*
+        stateless function components don't have ref
+        so can't get instance
+      */
+      if (node) {
+        scrollToNode(node);
+        return false;
+      }
     }
   }
 }


### PR DESCRIPTION
由于当 `Field` 的 `component` 是 `stateless function` 时，无法获取到它的 `ref`，所以增加了这个判断逻辑。
