### PR TITLE
[bug fix] Swiper : Modify `resetPosition` Functionality

### DIFF
--- a/packages/zent/src/swiper/Swiper.js
+++ b/packages/zent/src/swiper/Swiper.js
@@ -22,6 +22,7 @@ export default class Swiper extends (PureComponent || Component) {
     className: PropTypes.string,
     prefix: PropTypes.string,
     transitionDuration: PropTypes.number,
+    transitionForReset: PropTypes.number,
     autoplay: PropTypes.bool,
     autoplayInterval: PropTypes.number,
     dots: PropTypes.bool,
@@ -36,6 +37,7 @@ export default class Swiper extends (PureComponent || Component) {
     className: '',
     prefix: 'zent',
     transitionDuration: 300,
+    transitionForReset: 100,
     autoplay: false,
     autoplayInterval: 3000,
     dots: true,
@@ -116,7 +118,7 @@ export default class Swiper extends (PureComponent || Component) {
   };
 
   resetPosition = currentIndex => {
-    const { transitionDuration, children: { length } } = this.props;
+    const { transitionDuration, transitionForReset, children: { length } } = this.props;
     if (currentIndex < 0) {
       setTimeout(
         () =>
@@ -131,7 +133,7 @@ export default class Swiper extends (PureComponent || Component) {
           this.setState({
             currentIndex: 0
           }),
-        transitionDuration
+        transitionForReset
       );
     }
   };

--- a/packages/zent/src/swiper/Swiper.js
+++ b/packages/zent/src/swiper/Swiper.js
@@ -22,7 +22,6 @@ export default class Swiper extends (PureComponent || Component) {
     className: PropTypes.string,
     prefix: PropTypes.string,
     transitionDuration: PropTypes.number,
-    transitionForReset: PropTypes.number,
     autoplay: PropTypes.bool,
     autoplayInterval: PropTypes.number,
     dots: PropTypes.bool,
@@ -37,7 +36,6 @@ export default class Swiper extends (PureComponent || Component) {
     className: '',
     prefix: 'zent',
     transitionDuration: 300,
-    transitionForReset: 100,
     autoplay: false,
     autoplayInterval: 3000,
     dots: true,
@@ -118,23 +116,35 @@ export default class Swiper extends (PureComponent || Component) {
   };
 
   resetPosition = currentIndex => {
-    const { transitionDuration, transitionForReset, children: { length } } = this.props;
+    const { transitionDuration, children: { length } } = this.props;
     if (currentIndex < 0) {
-      setTimeout(
-        () =>
-          this.setState({
-            currentIndex: length - 1
-          }),
-        transitionDuration
-      );
+      !this.resetTimer &&
+        (this.resetTimer = setTimeout(
+          () =>
+            this.setState(
+              {
+                currentIndex: length - 1
+              },
+              () => {
+                this.resetTimer = undefined;
+              }
+            ),
+          transitionDuration
+        ));
     } else {
-      setTimeout(
-        () =>
-          this.setState({
-            currentIndex: 0
-          }),
-        transitionForReset
-      );
+      !this.resetTimer &&
+        (this.resetTimer = setTimeout(
+          () =>
+            this.setState(
+              {
+                currentIndex: 0
+              },
+              () => {
+                this.resetTimer = undefined;
+              }
+            ),
+          transitionDuration
+        ));
     }
   };
 


### PR DESCRIPTION
There will be a quivering effect if duration between two consecutive clicking is very short( time gap less than `transitionDuration` which is equivalent to 300ms ). 

This happens when Swiper enters into its maximum number and returns to its starting point. 
Here, you invoke `setTimeout` to asynchronously set component state. It's fine if the frequency of clicking `Swiper` dot is simply low. 
Yet, what if user click the second time within 300ms, which will trigger `resetPosition` once again. Hence, `currentIndex` will be very likely set back to 0 when it's stepping from 0 to 1 if you do the way I suggest. 
Hence, I'd like to shorten the `interval` when resetting position within the scope of `componentDidUpdate`, making it less than 100ms, during which user is unlikely to trigger multiple clicking events manually and naturally.