### PR TITLE
[new feature] Loading: Remove loading background when no children is supplied

### DIFF
--- a/packages/zent/assets/loading.pcss
+++ b/packages/zent/assets/loading.pcss
@@ -47,6 +47,12 @@
   .zent-page-mask {
     background: $theme-mask-black-2;
   }
+
+  &.zent-loading-container--empty {
+    .zent-page-mask {
+      background: transparent;
+    }
+  }
 }
 
 @keyframes loading {

--- a/packages/zent/src/loading/Loading.js
+++ b/packages/zent/src/loading/Loading.js
@@ -1,4 +1,6 @@
 import React, { Component, PureComponent } from 'react';
+import cx from 'classnames';
+
 import { getElementLeft, getElementTop } from './getPosition';
 
 export default class Loading extends (PureComponent || Component) {
@@ -69,20 +71,25 @@ export default class Loading extends (PureComponent || Component) {
   }
 
   render() {
-    let { prefix, className, containerClass } = this.props;
+    let { prefix, className, containerClass, children } = this.props;
 
     if (!this.props.float) {
       return (
         <div
-          className={`${prefix}-loading-container ${prefix}-loading-container-static ${containerClass}`}
+          className={cx(
+            `${prefix}-loading-container`,
+            `${prefix}-loading-container-static`,
+            containerClass,
+            {
+              [`${prefix}-loading-container--empty`]:
+                React.Children.count(children) === 0
+            }
+          )}
           style={{
-            height:
-              this.props.children || !this.state.show
-                ? 'initial'
-                : this.props.height
+            height: children || !this.state.show ? 'initial' : this.props.height
           }}
         >
-          {this.props.children}
+          {children}
           {this.state.show && (
             <div className={`${prefix}-page-loading ${className}`}>
               <div className={`${prefix}-page-mask`} />

--- a/packages/zent/src/loading/demos/wrapper-mode.md
+++ b/packages/zent/src/loading/demos/wrapper-mode.md
@@ -43,7 +43,7 @@ ReactDOM.render(<Wrapper />, mountNode);
 	margin-top: 10px;
 }
 .zent-loading-example-hello-world {
-	background-color: #e5e5e5;
+	background: #f8f8f8;
 	text-align: center;
 	height: 160px;
 	line-height: 160px;

--- a/site/src/components/Loadable.js
+++ b/site/src/components/Loadable.js
@@ -1,5 +1,5 @@
 import Loadable from 'react-loadable';
-import DocLoading from './loading';
+import DocLoading from './Loading';
 
 export default function DocLoadable(opts) {
   return Loadable(


### PR DESCRIPTION
Remove loading background when no children is supplied

Fixes #645 