### PR TITLE
[bugfix]Doc-site: 修复文档网站带 hash 地址 anchor 滚动不正确的 bug.

### DIFF
--- a/site/react-template.jstpl
+++ b/site/react-template.jstpl
@@ -15,6 +15,28 @@ function Style(props) {
   return <RawHtmlRenderer tag="style" html={props.style} />;
 }
 
+function scrollTo(element, to, duration) {
+  if (duration <= 0) return;
+  const difference = to - element.scrollTop;
+  const perTick = difference / duration * 10;
+
+  setTimeout(() => {
+    element.scrollTop = element.scrollTop + perTick;
+    if (element.scrollTop === to) return;
+    scrollTo(element, to, duration - 10);
+  }, 10);
+}
+
+function offsetY(element, offset) {
+  while(element) {
+    if (element.offsetTop && getComputedStyle(element)['position'] !== 'static') {
+      offset += element.offsetTop;
+    }
+    return offsetY(element.parentNode, offset);
+  }
+  return offset;
+}
+
 class Demo extends Component {
   state = {
     showCode: false
@@ -59,6 +81,14 @@ class Demo extends Component {
 }
 
 export default class ZentDocContainer extends Component {
+  componentDidMount() {
+    const hash = location.hash;
+    if (hash) {
+      const anchor = document.querySelector(`a[href="${hash}"]`);
+      scrollTo(document.documentElement, offsetY(anchor, -9), 400);
+    }
+  }
+
   render() {
     return React.createElement(
       'div',

--- a/site/react-template.jstpl
+++ b/site/react-template.jstpl
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import smoothScroll from 'utils/scroll';
 IMPORTS
 
 DEMO_DECLARATIONS
@@ -13,18 +14,6 @@ function Markdown(props) {
 
 function Style(props) {
   return <RawHtmlRenderer tag="style" html={props.style} />;
-}
-
-function scrollTo(element, to, duration) {
-  if (duration <= 0) return;
-  const difference = to - element.scrollTop;
-  const perTick = difference / duration * 10;
-
-  setTimeout(() => {
-    element.scrollTop = element.scrollTop + perTick;
-    if (element.scrollTop === to) return;
-    scrollTo(element, to, duration - 10);
-  }, 10);
 }
 
 function offsetY(element, offset) {
@@ -85,7 +74,7 @@ export default class ZentDocContainer extends Component {
     const hash = location.hash;
     if (hash) {
       const anchor = document.querySelector(`a[href="${hash}"]`);
-      scrollTo(document.documentElement, offsetY(anchor, -9), 400);
+      smoothScroll(document.documentElement, 0, offsetY(anchor, -9));
     }
   }
 

--- a/site/react-template.jstpl
+++ b/site/react-template.jstpl
@@ -74,7 +74,7 @@ export default class ZentDocContainer extends Component {
     const hash = location.hash;
     if (hash) {
       const anchor = document.querySelector(`a[href="${hash}"]`);
-      smoothScroll(document.documentElement, 0, offsetY(anchor, -9));
+      anchor && smoothScroll(document.documentElement, 0, offsetY(anchor, -9));
     }
   }
 


### PR DESCRIPTION
猜测 bug 是因为文档网站启用代码分割后, react-router 与 markdown 内容分开加载导致的.

通过在 ZentDocContainer 模板中增加了两个工具函数, 使用 React 的 ComponentDidMount 生命周期函数比较糙的 fix了这个问题.

#640 , fixed