### PR TITLE
[bug fix] Notify: 优化出场动画

### DIFF
--- a/packages/zent/assets/notify.pcss
+++ b/packages/zent/assets/notify.pcss
@@ -5,7 +5,7 @@
   position: fixed;
   min-width: 330px;
   max-width: 720px;
-  top: 80px;
+  bottom: 60%;
   left: 50%;
   transform: translateX(-50%);
 }
@@ -47,7 +47,7 @@
 
 @keyframes notifyMoveIn {
   0% {
-    transform: translateY(-100%);
+    transform: translateY(100%);
     opacity: 0;
   }
 


### PR DESCRIPTION
**说明：**

* [bug fix] Notify: fixed 定位由 top 改为 bottom，来避免多实例出场时产生的抖动效果。

详见 Issue #660 

**PS：**

> 检查 Notify 出现多个实例的出场动画，在消失时，上面的实例消失，会导致下面的实例往上排。这其中有一个抖动的效果，觉得效果可以优化，所以改动了这点。
>
> 改动前的效果：
>
>http://7xrzdx.com1.z0.glb.clouddn.com/zent.mov
>
> 改动后的效果：
>
> http://7xrzdx.com1.z0.glb.clouddn.com/zent/zent-after.mov
