### PR TITLE
[bugfix]Select: 修复win7下部分浏览器的兼容性 bug, 使用 popover 的 autoPosition 模式

### DIFF
--- a/packages/zent/assets/select.pcss
+++ b/packages/zent/assets/select.pcss
@@ -140,7 +140,7 @@ $errorBorderColor: $theme-error-2;
   left: 0;
   outline: none;
   overflow-y: auto;
-  position: absolute;
+  position: relative;
   width: 100%;
   z-index: 2000;
   margin-top: 2px;

--- a/packages/zent/src/pop/Pop.js
+++ b/packages/zent/src/pop/Pop.js
@@ -169,6 +169,10 @@ class Pop extends (PureComponent || Component) {
     closeOnClickOutside: PropTypes.bool,
     isClickOutside: PropTypes.func,
 
+    // 在 popover-content 进入屏幕内时触发, 声明周期内仅触发一次
+    onPositionReady: PropTypes.func,
+
+    // 在 popover-content 新位置计算完成时触发
     onPositionUpdated: PropTypes.func,
 
     prefix: PropTypes.string,
@@ -188,6 +192,7 @@ class Pop extends (PureComponent || Component) {
     mouseLeaveDelay: 200,
     mouseEnterDelay: 200,
     onPositionUpdated: noop,
+    onPositionReady: noop,
     className: '',
     wrapperClassName: '',
     prefix: 'zent',
@@ -314,7 +319,8 @@ class Pop extends (PureComponent || Component) {
       centerArrow,
       onBeforeClose,
       onBeforeShow,
-      onPositionUpdated
+      onPositionUpdated,
+      onPositionReady
     } = this.props;
     let { onVisibleChange } = this.props;
     if (trigger === 'none') {
@@ -339,6 +345,7 @@ class Pop extends (PureComponent || Component) {
         onBeforeClose={onBeforeClose}
         onBeforeShow={onBeforeShow}
         onPositionUpdated={onPositionUpdated}
+        onPositionReady={onPositionReady}
         ref={this.onPopoverRefChange}
       >
         {this.renderTrigger()}

--- a/packages/zent/src/pop/README_en-US.md
+++ b/packages/zent/src/pop/README_en-US.md
@@ -37,6 +37,7 @@ A floating card opened by clicking, hovering or focusing.
 | visible | Pop switch to controlled mode if this prop is set, must be used with `onVisibleChange` | bool | No | | |
 | onVisibleChange | Must be used with `visible` | func | No | | |
 | onPositionUpdated | callback after position updates, a position update does not imply a position change | func | No | `noop` | |
+| onPositionReady | callback after content enter viewport, only called once within the life cycle | func | No | `noop` | |
 | className | Custom class name | string | No | `''` |  |
 | wrapperClassName | Custom trigger wrapper class name | string | No | `''` |  |
 | prefix | Custom class name prefix | string | No | `'zent'` |  |

--- a/packages/zent/src/pop/README_zh-CN.md
+++ b/packages/zent/src/pop/README_zh-CN.md
@@ -37,7 +37,8 @@ group: 反馈
 | type | 影响确定按钮的样式 | string | 否  | `'primary'` | `'default'`, `'danger'`, `'success'` |
 | visible | 外部维护 `Pop` 的显示状态，此时外部拥有 `Pop` 的全部控制权，必须和 `onVisibleChange` 一起使用 | bool | 否 |  | |
 | onVisibleChange | 和 `visible` 一起使用 | func | 否 | | |
-| onPositionUpdated | 位置更新时的回调，不保证调用这个函数时位置一定变化 | func | No | `noop` | |
+| onPositionUpdated | 位置更新时的回调，不保证调用这个函数时位置一定变化 | func | 否 | `noop` | |
+| onPositionReady | 位置进入窗口时的回调，生命周期内只调用一次 | func | 否 | `noop` | |
 | className | 自定义类名 | string | 否 | `''` |  |
 | wrapperClassName | 自定义trigger包裹节点的类名 | string | 否 | `''` |  |
 | prefix | 自定义前缀 | string | 否 | `'zent'` |  |

--- a/packages/zent/src/popover/Content.js
+++ b/packages/zent/src/popover/Content.js
@@ -51,12 +51,20 @@ export default class PopoverContent extends (PureComponent || Component) {
     // defaults to body
     containerSelector: PropTypes.string,
 
-    onPositionUpdated: PropTypes.func
+    onPositionUpdated: PropTypes.func,
+
+    onPositionReady: PropTypes.func
   };
 
-  state = {
-    position: null
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      position: null
+    };
+
+    // 标记 content 的位置是否 ready
+    this.positionReady = false;
+  }
 
   getAnchor() {
     return this.props.getAnchor();
@@ -84,9 +92,9 @@ export default class PopoverContent extends (PureComponent || Component) {
         position: invisiblePlacement(this.props.prefix)
       });
       setTimeout(this.adjustPosition, 0);
-
       return;
     }
+
     const contentBoundingBox = content.getBoundingClientRect();
 
     const anchor = this.getAnchor();
@@ -130,7 +138,13 @@ export default class PopoverContent extends (PureComponent || Component) {
       {
         position
       },
-      this.props.onPositionUpdated
+      () => {
+        this.props.onPositionUpdated();
+        if (!this.positionReady) {
+          this.positionReady = true;
+          this.props.onPositionReady();
+        }
+      }
     );
   };
 
@@ -152,6 +166,9 @@ export default class PopoverContent extends (PureComponent || Component) {
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.visible && nextProps.visible !== this.props.visible) {
+      // reset position mark
+      this.positionReady = false;
+
       this.adjustPosition();
     }
   }

--- a/packages/zent/src/popover/Popover.js
+++ b/packages/zent/src/popover/Popover.js
@@ -100,7 +100,10 @@ export default class Popover extends (PureComponent || Component) {
     onVisibleChange: PropTypes.func,
 
     // 位置改变后会触发，可能存在实际位置没变但也触发的情况
-    onPositionUpdated: PropTypes.func
+    onPositionUpdated: PropTypes.func,
+
+    // content 第一次进入屏幕内时触发, 生命周期内只触发一次
+    onPositionReady: PropTypes.func
   };
 
   static defaultProps = {
@@ -114,7 +117,8 @@ export default class Popover extends (PureComponent || Component) {
     onShow: noop,
     cushion: 0,
     containerSelector: 'body',
-    onPositionUpdated: noop
+    onPositionUpdated: noop,
+    onPositionReady: noop
   };
 
   static contextTypes = PopoverContextType;
@@ -365,7 +369,8 @@ export default class Popover extends (PureComponent || Component) {
       position,
       cushion,
       width,
-      onPositionUpdated
+      onPositionUpdated,
+      onPositionReady
     } = this.props;
     const visible = this.getVisible();
 
@@ -396,7 +401,8 @@ export default class Popover extends (PureComponent || Component) {
           cushion,
           containerSelector,
           placement: position,
-          onPositionUpdated
+          onPositionUpdated,
+          onPositionReady
         })}
       </div>
     );

--- a/packages/zent/src/popover/README_en-US.md
+++ b/packages/zent/src/popover/README_en-US.md
@@ -15,7 +15,7 @@ The widget supports nested pop
 
 ### Guides
 
-* If `Pop` widget do not meet your needs, you can achieve custom trigger pop by using `Popover` 
+* If `Pop` widget do not meet your needs, you can achieve custom trigger pop by using `Popover`
 * Can be used as `Dropdown`
 
 ### API
@@ -33,6 +33,7 @@ The widget supports nested pop
 | visible | manual control pop's show or hide, must be used with `onVisibleChange`  | bool | | | No |
 | onVisibleChange | the callback when manual control, must be used with `visible`,  only triggered by user's open/close operation | func | | | No |
 | onPositionUpdated | callback after position updates, a position update does not imply a position change | func | `noop` | | No |
+| onPositionReady | callback after content enter viewport, only called once within the life cycle | func | `noop` |  | No |
 | className | custom extra class name | string | `''` |  | No |
 | wrapperClassName |  trigger outerline div classname | string | `''` |  | No |
 | width | width | string or number |  |  | No |

--- a/packages/zent/src/popover/README_zh-CN.md
+++ b/packages/zent/src/popover/README_zh-CN.md
@@ -33,6 +33,7 @@ group: 基础
 | visible | 手动控制弹层的显示隐藏, 必须和 `onVisibleChange` 一起使用 | bool | | | 否 |
 | onVisibleChange | 手动控制时的回调函数, 必须和`visible`一起使用, 只有用户手动触发的打开／关闭操作才会调用 | func | | | 否 |
 | onPositionUpdated | 位置更新时的回调，不保证调用这个函数时位置一定变化 | func | `noop` |  | 否 |
+| onPositionReady | content 位置进入窗口时的回调，生命周期内只调用一次 | func | `noop` |  | 否 |
 | className | 自定义额外类名 | string | `''` |  | 否 |
 | wrapperClassName | trigger外层包裹div的类名 | string | `''` |  | 否 |
 | width | 宽度 | string or number |  |  | 否 |

--- a/packages/zent/src/select/Popup.js
+++ b/packages/zent/src/select/Popup.js
@@ -2,7 +2,7 @@
  * Popup
  */
 
-import React, { Component, PureComponent } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import take from 'lodash/take';
 import trim from 'lodash/trim';
@@ -15,7 +15,7 @@ import Search from './components/Search';
 import Option from './components/Option';
 import { KEY_EN, KEY_UP, KEY_DOWN, KEY_ESC } from './constants';
 
-class Popup extends (PureComponent || Component) {
+class Popup extends Component {
   constructor(props) {
     super(props);
 
@@ -26,6 +26,7 @@ class Popup extends (PureComponent || Component) {
       keyword: props.keyword || '',
       style: {}
     };
+    this.focused = false;
   }
 
   componentWillMount() {
@@ -40,13 +41,15 @@ class Popup extends (PureComponent || Component) {
   }
 
   componentDidMount() {
-    if (!this.props.filter && !this.props.onAsyncFilter) {
-      this.popup.focus();
-    }
     this.popup.addEventListener('mousewheel', this.handleScroll);
   }
 
+  componentWillUnmount() {
+    this.popup.removeEventListener('mousewheel', this.handleScroll);
+  }
+
   handleScroll = evt => {
+    evt.stopPropagation();
     if (
       (this.popup.scrollTop === 0 && evt.deltaY < 0) ||
       (this.popup.scrollTop + this.popup.clientHeight ===
@@ -58,6 +61,20 @@ class Popup extends (PureComponent || Component) {
   };
 
   componentWillReceiveProps(nextProps) {
+    // 渲染时在 popover content ready 后延时触发 focus, 只触发一次
+    // NOTE: win7 360浏览器, 兼容性 bug 修复
+    if (
+      !this.focused &&
+      nextProps.ready &&
+      !nextProps.filter &&
+      !nextProps.onAsyncFilter
+    ) {
+      setTimeout(() => {
+        this.popup.focus();
+      }, 150);
+      this.focused = true;
+    }
+
     const keyword = nextProps.keyword;
     this.setState({
       data: nextProps.data,
@@ -192,7 +209,8 @@ class Popup extends (PureComponent || Component) {
       filter,
       onAsyncFilter,
       maxToShow,
-      autoWidth
+      autoWidth,
+      ready
     } = this.props;
 
     const { keyword, data, currentId } = this.state;
@@ -216,6 +234,9 @@ class Popup extends (PureComponent || Component) {
         onKeyDown={this.keydownHandler}
         tabIndex="0"
         style={autoWidth ? this.state.style : null}
+        onFocus={event => {
+          event.preventDefault();
+        }}
       >
         {!extraFilter && (filter || onAsyncFilter) ? (
           <Search

--- a/packages/zent/src/select/Popup.js
+++ b/packages/zent/src/select/Popup.js
@@ -244,6 +244,7 @@ class Popup extends Component {
             prefixCls={prefixCls}
             placeholder={searchPlaceholder}
             onChange={this.searchFilterHandler}
+            ready={ready}
           />
         ) : (
           ''

--- a/packages/zent/src/select/Select.js
+++ b/packages/zent/src/select/Select.js
@@ -2,7 +2,7 @@
  * Select
  */
 
-import React, { Component, PureComponent, Children } from 'react';
+import React, { Component, Children } from 'react';
 import omit from 'lodash/omit';
 import isEqual from 'lodash/isEqual';
 import isArray from 'lodash/isArray';
@@ -34,7 +34,7 @@ class PopoverClickTrigger extends Popover.Trigger.Click {
   }
 }
 
-class Select extends (PureComponent || Component) {
+class Select extends Component {
   constructor(props) {
     super(props);
 
@@ -54,7 +54,10 @@ class Select extends (PureComponent || Component) {
         selectedItem: {
           value: '',
           text: ''
-        }
+        },
+
+        // popover content 位置就绪可以进行 focus 操作的标记.
+        optionsReady: false
       },
       props
     );
@@ -341,6 +344,7 @@ class Select extends (PureComponent || Component) {
       selectedItems,
       selectedItem = {},
       extraFilter,
+      optionsReady,
       keyword = null
     } = this.state;
 
@@ -369,6 +373,11 @@ class Select extends (PureComponent || Component) {
             {...selectedItem}
             onChange={this.triggerChangeHandler}
             onDelete={this.triggerDeleteHandler}
+            onPositionReady={() => {
+              this.setState({
+                optionsReady: true
+              });
+            }}
           />
         </PopoverClickTrigger>
         <Popover.Content>
@@ -377,6 +386,7 @@ class Select extends (PureComponent || Component) {
             cid={cid}
             prefixCls={prefixCls}
             data={this.uniformedData}
+            ready={optionsReady}
             selectedItems={selectedItems}
             extraFilter={extraFilter}
             searchPlaceholder={searchPlaceholder}

--- a/packages/zent/src/select/components/Search.js
+++ b/packages/zent/src/select/components/Search.js
@@ -5,10 +5,16 @@ class Search extends (PureComponent || Component) {
   constructor(props) {
     super(props);
     this.changeHandler = this.changeHandler.bind(this);
+    this.focused = false;
   }
 
-  componentDidMount() {
-    this.input.focus();
+  componentWillReceiveProps(nextProps) {
+    if (!this.focused && nextProps.ready) {
+      setTimeout(() => {
+        this.input.focus();
+      }, 150);
+      this.focused = true;
+    }
   }
 
   changeHandler(ev) {


### PR DESCRIPTION
- [x] Popover 组件和 Pop 组件增加了`onPositionReady` props 来修复兼容性问题
- [x] Select 组件内部在 Popup 位置调整后再触发 focus
- [x] Select 组件的 PopupContent 部分使用相对定位, 激活 popover 自带的 autoPosition 功能.