### PR TITLE
[bug fix] Notify：多个Notify消失时动画不平滑问题

### DIFF
--- a/packages/zent/assets/design/components/image-ad/editor.pcss
+++ b/packages/zent/assets/design/components/image-ad/editor.pcss
@@ -115,7 +115,7 @@
     align-items: center;
     background: $theme-stroke-10;
     margin-top: 10px;
-    border: 1px solid $theme-stoke-7;
+    border: 1px solid $theme-stroke-7;
     padding-left: 10px;
     position: relative;
 

--- a/packages/zent/assets/notify.pcss
+++ b/packages/zent/assets/notify.pcss
@@ -11,24 +11,30 @@
 }
 
 .zent-notify {
-  padding: 0 25px;
-  margin-bottom: 10px;
-  line-height: 40px;
-  max-height: 200px;
-  overflow-y: auto;
-  font-size: 14px;
-  color: $theme-stroke-10;
-  text-align: center;
-  border-radius: 2px;
-  box-sizing: border-box;
-  min-height: 40px;
+  padding-bottom: 10px;
 
-  &.zent-notify-success {
-    background: $notify-success;
-  }
+  &-content {
+    padding: 0 25px;
+    line-height: 40px;
+    max-height: 200px;
+    overflow-y: auto;
+    font-size: 14px;
+    color: $theme-stroke-10;
+    text-align: center;
+    border-radius: 2px;
+    box-sizing: border-box;
 
-  &.zent-notify-error {
-    background: $notify-error;
+    &:empty:before {
+      content: "\200b";
+    }
+
+    &.zent-notify-content-success {
+      background: $notify-success;
+    }
+
+    &.zent-notify-content-error {
+      background: $notify-error;
+    }
   }
 }
 
@@ -46,12 +52,23 @@
 .notify-exit {
   animation-fill-mode: both;
   animation-play-state: paused;
+
+  .zent-notify-content {
+    animation-fill-mode: both;
+    animation-play-state: paused;
+  }
 }
 
 .notify-exit.notify-exit-active {
   animation-play-state: running;
   animation-name: notifyMoveOut;
   animation-duration: 0.3s;
+
+  .zent-notify-content {
+    animation-play-state: running;
+    animation-name: notifyContentMoveOut;
+    animation-duration: 0.3s;
+  }
 }
 
 @keyframes notifyMoveIn {
@@ -69,11 +86,22 @@
 @keyframes notifyMoveOut {
   0% {
     opacity: 1;
-    transform: translateY(0%);
+    max-height: 50px;
   }
 
   100% {
     opacity: 0;
+    max-height: 0;
+    padding: 0;
+  }
+}
+
+@keyframes notifyContentMoveOut {
+  0% {
+    transform: translateY(0%);
+  }
+
+  100% {
     transform: translateY(-100%);
   }
 }

--- a/packages/zent/src/notify/NotifyContent.js
+++ b/packages/zent/src/notify/NotifyContent.js
@@ -34,7 +34,13 @@ export default class NotifyContent extends (PureComponent || Component) {
           in={isIn}
           onExited={this.onExited}
         >
-          <div className={`zent-notify zent-notify-${status}`}>{text}</div>
+          <div className={`zent-notify`}>
+            <div
+              className={`zent-notify-content zent-notify-content-${status}`}
+            >
+              {text}
+            </div>
+          </div>
         </NotifyTransition>
       </Portal>
     );


### PR DESCRIPTION
Changes you made in this pull request:

- 更改Notify结构，增加了一层div，外层用于控制动画，内层用于显示内容
- 修改Notify消失时的动画，增加了max-height: 0，用于让下层消息平滑上移
