### PR TITLE
[bugfix]Select: 修复在修改 focus 逻辑后导致键盘事件失效的 bug.

### DIFF
--- a/packages/zent/src/select/Select.js
+++ b/packages/zent/src/select/Select.js
@@ -361,6 +361,11 @@ class Select extends Component {
         wrapperClassName={`${prefixCls} ${className} ${disabledCls}`}
         onVisibleChange={this.handlePopoverVisibleChange}
         width={width}
+        onPositionReady={() => {
+          this.setState({
+            optionsReady: true
+          });
+        }}
       >
         <PopoverClickTrigger>
           <Trigger
@@ -373,11 +378,6 @@ class Select extends Component {
             {...selectedItem}
             onChange={this.triggerChangeHandler}
             onDelete={this.triggerDeleteHandler}
-            onPositionReady={() => {
-              this.setState({
-                optionsReady: true
-              });
-            }}
           />
         </PopoverClickTrigger>
         <Popover.Content>


### PR DESCRIPTION
遗漏了一个 commit 在重构分支.. 

Popover 的 `onPositionReady` 属性现在只能挂载在 Popover 上.