### PR TITLE
[breaking change] Loading: Remove deprecated methods on/off/newInstance

### DIFF
--- a/packages/zent/__tests__/loading.js
+++ b/packages/zent/__tests__/loading.js
@@ -20,46 +20,6 @@ beforeAll(() => {
 /* eslint-enable */
 
 describe('Loading', () => {
-  it('Hack of global model', () => {
-    const wrapper = mount(
-      <div>
-        <button
-          onClick={() => {
-            Loading.on();
-          }}
-        />
-        <button
-          onClick={() => {
-            Loading.off();
-          }}
-        />
-      </div>
-    );
-    wrapper
-      .find('button')
-      .at(0)
-      .simulate('click');
-    jest.runOnlyPendingTimers();
-
-    wrapper
-      .find('button')
-      .at(1)
-      .simulate('click');
-    jest.runOnlyPendingTimers();
-
-    wrapper
-      .find('button')
-      .at(0)
-      .simulate('click');
-    jest.runOnlyPendingTimers();
-
-    wrapper
-      .find('button')
-      .at(1)
-      .simulate('click');
-    jest.runOnlyPendingTimers();
-  });
-
   it('Loading has static model, support containerClass and prefix...props', () => {
     const wrapper = mount(<Loading show={false} containerClass="foo" />);
     expect(wrapper.prop('height')).toBeUndefined();
@@ -115,5 +75,14 @@ describe('Loading', () => {
     };
     expect(getElementLeft(tree)).toBe(6);
     expect(getElementTop(tree)).toBe(60);
+  });
+
+  it('can have children', () => {
+    let wrapper = mount(
+      <Loading show>
+        <span>foobar</span>
+      </Loading>
+    );
+    expect(wrapper.find('.zent-loading-container').length).toBe(1);
   });
 });

--- a/packages/zent/src/loading/LoadingInstance.js
+++ b/packages/zent/src/loading/LoadingInstance.js
@@ -6,9 +6,6 @@ import PropTypes from 'prop-types';
 
 import Loading from './Loading';
 
-// Global loading instance
-let loadingInstance;
-
 export default class Instance extends (PureComponent || Component) {
   static propTypes = {
     prefix: PropTypes.string,
@@ -83,48 +80,6 @@ export default class Instance extends (PureComponent || Component) {
     // Return null to make React happy if Loading has no children
     return this.props.children || null;
   }
-}
-
-// Just a workaround
-// These methods should be considered deprecated, don't use them.
-Instance.on = on;
-Instance.off = off;
-Instance.newInstance = newInstance;
-
-function on({
-  prefix = 'zent',
-  className = '',
-  containerClass = '',
-  zIndex = 9998,
-} = {}) {
-  if (!isBrowser) return;
-
-  if (!loadingInstance) {
-    loadingInstance = newInstance({
-      show: true,
-      prefix,
-      className,
-      containerClass,
-      zIndex,
-      float: true,
-    });
-
-    return;
-  }
-
-  loadingInstance.then(({ show }) => {
-    show && show({ show: true });
-  });
-}
-
-function off() {
-  if (!isBrowser) return;
-
-  if (!loadingInstance) return;
-
-  loadingInstance.then(({ show }) => {
-    show && show({ show: false });
-  });
 }
 
 function newInstance(props) {

--- a/packages/zent/src/loading/LoadingInstance.js
+++ b/packages/zent/src/loading/LoadingInstance.js
@@ -96,7 +96,7 @@ function newInstance(props) {
         ref={loading => {
           if (loading) {
             resolve({
-              show: loading && loading.show,
+              show: loading.show,
               container: div,
             });
           }


### PR DESCRIPTION
`on`, `off` and `newInstance` are no longer available on `Loading`. These methods are considered anti-patterns.