### PR TITLE
[new fature] Form: Allow non stardard value in Field onChange and onBlur

### DIFF
--- a/packages/zent/__tests__/form/CreateForm-Field.js
+++ b/packages/zent/__tests__/form/CreateForm-Field.js
@@ -873,7 +873,14 @@ describe('CreateForm and Field', () => {
         const newValue = {
           country: e.target.value,
         };
-        this.props.onChange(newValue, { merge });
+        this.props.onChange(newValue, { merge, value: newValue });
+      };
+
+      onCountryBlur = e => {
+        this.props.onBlur(e, {
+          merge: this.props.merge,
+          value: e.target.value,
+        });
       };
 
       onPhoneChange = e => {
@@ -882,6 +889,12 @@ describe('CreateForm and Field', () => {
           mobile: e.target.value,
         };
         this.props.onChange(newValue, { merge });
+      };
+
+      onPhoneBlur = e => {
+        this.props.onBlur(e, {
+          merge: this.props.merge,
+        });
       };
 
       filterHandler = (item, keyword) => {
@@ -906,6 +919,7 @@ describe('CreateForm and Field', () => {
               placeholder="{i18n.phonePlaceholder}"
               value={value.country}
               onChange={this.onCountryChange}
+              onBlur={this.onCountryBlur}
             />
             <input
               className="mobile"
@@ -913,6 +927,7 @@ describe('CreateForm and Field', () => {
               placeholder="{i18n.phonePlaceholder}"
               value={value.mobile}
               onChange={this.onPhoneChange}
+              onBlur={this.onPhoneBlur}
             />
           </div>
         );
@@ -934,9 +949,16 @@ describe('CreateForm and Field', () => {
       }
     );
 
-    let mobileInput = wrapper.find('input.mobile');
+    const mobileInput = wrapper.find('input.mobile');
+    const countryInput = wrapper.find('input.country');
     mobileInput.simulate('change', { target: { value: '2' } });
     expect(wrapper.state('_value').country).toBe('1');
     expect(wrapper.state('_value').mobile).toBe('2');
+
+    countryInput.simulate('change', { target: { value: '3' } });
+    expect(wrapper.state('_value').country).toBe('3');
+
+    mobileInput.simulate('blur', { target: { value: '3' } });
+    countryInput.simulate('blur', { target: { value: '3' } });
   });
 });

--- a/packages/zent/__tests__/form/Utils.js
+++ b/packages/zent/__tests__/form/Utils.js
@@ -21,8 +21,7 @@ describe('Form-Utilities', () => {
       stopPropagation: () => {},
     };
 
-    // return arg[0]
-    expect(getValue(0, 1)).toBe(0);
+    expect(getValue(0, 1)).toBe(1);
     expect(getValue(emptyObj)).toBe(emptyObj);
 
     // arg[0] && arg[0].value return arg[0].value

--- a/packages/zent/src/form/Field.js
+++ b/packages/zent/src/form/Field.js
@@ -4,6 +4,7 @@ import { Component, createElement } from 'react';
 import isEqual from 'lodash/isEqual';
 import omit from 'lodash/omit';
 import assign from 'lodash/assign';
+import has from 'lodash/has';
 import PropTypes from 'prop-types';
 
 import { getValue, getCurrentValue, prefixName } from './utils';
@@ -212,9 +213,12 @@ class Field extends Component {
   handleChange = (event, options = { merge: false }) => {
     const { onChange, validateOnChange } = this.props;
     const previousValue = this.getValue();
-    const currentValue = options.merge
-      ? getCurrentValue(getValue(event), previousValue)
+    const val = has(options, 'value')
+      ? getValue(event, options.value)
       : getValue(event);
+    const currentValue = options.merge
+      ? getCurrentValue(val, previousValue)
+      : val;
     const newValue = this.normalize(currentValue);
     let preventSetValue = false;
 
@@ -254,9 +258,12 @@ class Field extends Component {
   handleBlur = (event, options = { merge: false }) => {
     const { onBlur, asyncValidation, validateOnBlur } = this.props;
     const previousValue = this.getValue();
-    const currentValue = options.merge
-      ? getCurrentValue(getValue(event), previousValue)
+    const val = has(options, 'value')
+      ? getValue(event, options.value)
       : getValue(event);
+    const currentValue = options.merge
+      ? getCurrentValue(val, previousValue)
+      : val;
     const newValue = this.normalize(currentValue);
     let preventSetValue = false;
 

--- a/packages/zent/src/form/utils.js
+++ b/packages/zent/src/form/utils.js
@@ -22,7 +22,11 @@ const getSelectedValues = options => {
 const isEvent = candidate =>
   !!(candidate && candidate.stopPropagation && candidate.preventDefault);
 
-export function getValue(event) {
+export function getValue(event, realValue) {
+  if (arguments.length >= 2) {
+    return realValue;
+  }
+
   // 简单判断是否是一个原生事件对象
   if (isEvent(event)) {
     const {


### PR DESCRIPTION
`onChange(event, {value: 'xxx'})` will use value instead of `event.target.value`. This is useful with custom components.