### PR TITLE
[bug fix] DatePicker: Remove onBlur and onFocus callback from date pickers

### DIFF
--- a/packages/zent/assets/datetimepicker.pcss
+++ b/packages/zent/assets/datetimepicker.pcss
@@ -439,6 +439,7 @@ $input_width: 183px;
         &--in-range {
           background: $light_blue;
           border: none;
+          border-radius: 0;
 
           &:before {
             content: '';
@@ -466,6 +467,7 @@ $input_width: 183px;
         &--in-selected {
           background: $light_blue;
           border: none;
+          border-radius: 0;
 
           &:before {
             content: '';

--- a/packages/zent/src/datetimepicker/DatePicker.js
+++ b/packages/zent/src/datetimepicker/DatePicker.js
@@ -359,8 +359,6 @@ class DatePicker extends PureComponent {
         name,
         placeholder,
         canClear,
-        onFocus,
-        onBlur,
       },
       state: { showPlaceholder, openPanel, value },
     } = this;
@@ -395,10 +393,9 @@ class DatePicker extends PureComponent {
                 >
                   <Input
                     name={name}
-                    value={showPlaceholder ? placeholder || i18n.date : value}
+                    placeholder={placeholder || i18n.date}
+                    value={value || ''}
                     onChange={noop}
-                    onFocus={onFocus}
-                    onBlur={onBlur}
                     disabled={disabled}
                   />
                   <span className="zenticon zenticon-calendar-o" />

--- a/packages/zent/src/datetimepicker/MonthPicker.js
+++ b/packages/zent/src/datetimepicker/MonthPicker.js
@@ -225,8 +225,6 @@ class MonthPicker extends PureComponent {
         prefix,
         width,
         canClear,
-        onFocus,
-        onBlur,
       },
       state: { openPanel, showPlaceholder, value },
     } = this;
@@ -250,17 +248,16 @@ class MonthPicker extends PureComponent {
               cushion={5}
               visible={openPanel}
               onVisibleChange={this.togglePicker}
-              className={`${prefix}-datetime-picker-popover ${className}    -popover`}
+              className={cx(`${prefix}-datetime-picker-popover`, className)}
               position={popPositionMap[popPosition.toLowerCase()]}
             >
               <Popover.Trigger.Click>
                 <div style={widthStyle} className={inputCls}>
                   <Input
                     name={name}
-                    value={showPlaceholder ? placeholder || i18n.month : value}
+                    placeholder={placeholder || i18n.month}
+                    value={value || ''}
                     onChange={noop}
-                    onFocus={onFocus}
-                    onBlur={onBlur}
                     disabled={disabled}
                   />
                   <span className="zenticon zenticon-calendar-o" />

--- a/packages/zent/src/datetimepicker/QuarterPicker.js
+++ b/packages/zent/src/datetimepicker/QuarterPicker.js
@@ -217,8 +217,6 @@ class QuarterPicker extends PureComponent {
         prefix,
         width,
         canClear,
-        onFocus,
-        onBlur,
       },
       state: { openPanel, selected, showPlaceholder, value },
     } = this;
@@ -263,10 +261,9 @@ class QuarterPicker extends PureComponent {
                   <div style={widthStyle} className={inputCls}>
                     <Input
                       name={name}
-                      value={showPlaceholder ? placeholderText : inputVal}
+                      placeholder={placeholderText}
+                      value={inputVal}
                       onChange={noop}
-                      onFocus={onFocus}
-                      onBlur={onBlur}
                       disabled={disabled}
                     />
                     <span className="zenticon zenticon-calendar-o" />

--- a/packages/zent/src/datetimepicker/TimePicker.js
+++ b/packages/zent/src/datetimepicker/TimePicker.js
@@ -395,8 +395,6 @@ export default class TimePicker extends PureComponent {
         placeholder,
         value,
         canClear,
-        onFocus,
-        onBlur,
       },
       state: { isPanelOpen },
     } = this;
@@ -440,8 +438,6 @@ export default class TimePicker extends PureComponent {
                     value={formattedValue}
                     placeholder={placeholder || i18n.time}
                     onChange={noop}
-                    onFocus={onFocus}
-                    onBlur={onBlur}
                     disabled={disabled}
                   />
                   <span className="zenticon zenticon-clock-o" />

--- a/packages/zent/src/datetimepicker/WeekPicker.js
+++ b/packages/zent/src/datetimepicker/WeekPicker.js
@@ -326,8 +326,6 @@ class WeekPicker extends PureComponent {
         prefix,
         width,
         canClear,
-        onFocus,
-        onBlur,
       },
       state: { openPanel, showPlaceholder, value },
     } = this;
@@ -362,14 +360,9 @@ class WeekPicker extends PureComponent {
                 >
                   <Input
                     name={name}
-                    value={
-                      showPlaceholder
-                        ? placeholder || i18n.week
-                        : value.join(` ${i18n.to} `)
-                    }
+                    placeholder={placeholder || i18n.week}
+                    value={value ? value.join(` ${i18n.to} `) : ''}
                     onChange={noop}
-                    onFocus={onFocus}
-                    onBlur={onBlur}
                     disabled={disabled}
                   />
 

--- a/packages/zent/src/datetimepicker/YearPicker.js
+++ b/packages/zent/src/datetimepicker/YearPicker.js
@@ -209,8 +209,6 @@ class YearPicker extends PureComponent {
         prefix,
         width,
         canClear,
-        onFocus,
-        onBlur,
       },
       state: { openPanel, showPlaceholder, value },
     } = this;
@@ -242,10 +240,9 @@ class YearPicker extends PureComponent {
                 {i18n => (
                   <Input
                     name={name}
-                    value={showPlaceholder ? placeholder || i18n.year : value}
+                    placeholder={placeholder || i18n.year}
+                    value={value || ''}
                     onChange={noop}
-                    onFocus={onFocus}
-                    onBlur={onBlur}
                     disabled={disabled}
                   />
                 )}

--- a/packages/zent/src/datetimepicker/constants/index.js
+++ b/packages/zent/src/datetimepicker/constants/index.js
@@ -39,8 +39,6 @@ export const commonProps = {
   onChange: noop,
   isFooterVisble: false,
   canClear: true,
-  onBlur: noop,
-  onFocus: noop,
 };
 
 export const commonPropTypes = {


### PR DESCRIPTION
1. Remove `onBlur` and `onFocus` from all date pickers
2. Handle `placeholder` correctly