### PR TITLE
Improve typingss where TypeScript strict mode complains

### DIFF
--- a/packages/zent/typings/libs/ColorPicker.d.ts
+++ b/packages/zent/typings/libs/ColorPicker.d.ts
@@ -6,7 +6,7 @@ declare module 'zent/lib/colorpicker' {
     showAlpha?: boolean
     type?: 'default'|'simple'
     presetColors?: Array<string>
-    onChange?: (string) => any
+    onChange?: (string: string) => any
     className?: string
     wrapperClassName?: string
     prefix?: string
@@ -18,7 +18,7 @@ declare module 'zent/lib/colorpicker' {
     interface IColorBoardProps {
       color: string
       showAlpha?: boolean
-      onChange?: (string) => any
+      onChange?: (string: string) => any
       className?: string
       prefix?: string
     }

--- a/packages/zent/typings/libs/DateTimePicker.d.ts
+++ b/packages/zent/typings/libs/DateTimePicker.d.ts
@@ -47,7 +47,7 @@ declare module 'zent/lib/datetimepicker/MonthPicker' {
 declare module 'zent/lib/datetimepicker/DateRangePicker' {
   interface IDateRangePickerProps extends IDateCommonProps {
     showTime: boolean
-    value?: Array,
+    value?: Array<Date | number | string>,
     disabledTime?: Function,
   }
 

--- a/packages/zent/typings/libs/Input.d.ts
+++ b/packages/zent/typings/libs/Input.d.ts
@@ -18,6 +18,6 @@ declare module 'zent/lib/input' {
   }
 
   export default class Input extends React.Component<IInputProps, any> {
-    focus()
+    focus(): void
   }
 }

--- a/packages/zent/typings/libs/Mention.d.ts
+++ b/packages/zent/typings/libs/Mention.d.ts
@@ -3,7 +3,7 @@
 declare module 'zent/lib/mention' {
   interface ICompoundMentionSuggestion {
     value: any
-    content?: node
+    content?: any
     isGroup?: boolean
     isDivider?: boolean
     icon?: string
@@ -12,10 +12,10 @@ declare module 'zent/lib/mention' {
 
   interface IMentionProps {
     value: string;
-    onChange: (string) => any;
+    onChange: (string: string) => any;
     multiLine?: boolean;
     position?: 'top' | 'bottom';
-    onSearchChange?: (string) => any;
+    onSearchChange?: (string: string) => any;
     suggestions: string | number | ICompoundMentionSuggestion;
     suggestionNotFoundContent?: React.ReactNode;
     triggerText?: string;

--- a/packages/zent/typings/libs/Pagination.d.ts
+++ b/packages/zent/typings/libs/Pagination.d.ts
@@ -5,7 +5,7 @@ declare module 'zent/lib/pagination' {
     current: number
     totalItem: number
     pageSize?: number
-    onPageSizeChange?: (number) => any
+    onPageSizeChange?: (number: number) => any
     maxPageToShow?: number
     onChange?: (value: number) => void
     className?: string

--- a/packages/zent/typings/libs/Popover.d.ts
+++ b/packages/zent/typings/libs/Popover.d.ts
@@ -35,7 +35,7 @@ declare module 'zent/lib/popover' {
         close?: () => void
         contentVisible?: boolean
         onTriggerRefChange?: () => React.ReactInstance
-        getNodeForTriggerRefChange?: (HTMLElement) => HTMLElement
+        getNodeForTriggerRefChange?: (HTMLElement: HTMLElement) => HTMLElement
       }
 
       interface IClickProps extends IBaseProps {


### PR DESCRIPTION
Using Zent (6.0.1) with TypeScript in strict mode gives me these type errors:
```
ERROR in [at-loader] ./node_modules/zent/typings/libs/ColorPicker.d.ts:9:17
    TS7006: Parameter 'string' implicitly has an 'any' type.
ERROR in [at-loader] ./node_modules/zent/typings/libs/ColorPicker.d.ts:21:19
    TS7006: Parameter 'string' implicitly has an 'any' type.
ERROR in [at-loader] ./node_modules/zent/typings/libs/DateTimePicker.d.ts:50:13
    TS2314: Generic type 'Array<T>' requires 1 type argument(s).
ERROR in [at-loader] ./node_modules/zent/typings/libs/Input.d.ts:21:5
    TS7010: 'focus', which lacks return-type annotation, implicitly has an 'any' return type.
ERROR in [at-loader] ./node_modules/zent/typings/libs/Mention.d.ts:6:15
    TS2304: Cannot find name 'node'.
ERROR in [at-loader] ./node_modules/zent/typings/libs/Mention.d.ts:15:16
    TS7006: Parameter 'string' implicitly has an 'any' type.
ERROR in [at-loader] ./node_modules/zent/typings/libs/Mention.d.ts:18:23
    TS7006: Parameter 'string' implicitly has an 'any' type.
ERROR in [at-loader] ./node_modules/zent/typings/libs/Pagination.d.ts:8:25
    TS7006: Parameter 'number' implicitly has an 'any' type.
ERROR in [at-loader] ./node_modules/zent/typings/libs/Popover.d.ts:38:39
    TS7006: Parameter 'HTMLElement' implicitly has an 'any' type.
```

This is a suggestion of how to fix them.
Cheers!