### PR TITLE
添加对value值“.XX”形式的正则校验

### DIFF
--- a/packages/zent/src/number-input/NumberInput.js
+++ b/packages/zent/src/number-input/NumberInput.js
@@ -125,7 +125,8 @@ export default class NumberInput extends PureComponent {
       /^(\-|\+)?\d+(\.)?$/g.test(value) ||
       /^(\-|\+)?\d+(\.\d+)?$/g.test(value) ||
       /^\d+\.$/g.test(value) ||
-      /^(\-|\+)?$/g.test(value)
+      /^(\-|\+)?$/g.test(value) ||
+      /^\.\d+$/g.test(value)
     ) {
       this.setState({ value });
     }


### PR DESCRIPTION
修复光标定位删除到类似“.00”，对value的正则匹配，准许通过校验。