### PR TITLE
[new feature] menu 组件添加两个事件回调

### DIFF
--- a/packages/zent/__tests__/menu.js
+++ b/packages/zent/__tests__/menu.js
@@ -164,15 +164,16 @@ describe('Menu component', () => {
     let wrapper = mount(
       <Menu mode="inline" onSubMenuClick={subMenuClick}>
         <MenuItem key="1-1">食品分类</MenuItem>
-        <SubMenu key="333" title="美妆分类" className="submenu">
+        <SubMenu key="333" title="美妆分类" className="abc">
           <MenuItem key="3-1">眼影</MenuItem>
         </SubMenu>
       </Menu>
     );
     wrapper
-      .find('submenu')
+      .find('.abc > div')
       .at(0)
       .simulate('click');
+
     expect(subMenuClick.mock.calls[0][0]).toBe('333');
   });
 
@@ -194,16 +195,15 @@ describe('Menu component', () => {
       </Menu>
     );
     wrapper
-      .find('submenu')
+      .find('.submenu > div')
       .at(0)
       .simulate('click');
     expect(onExpandCallback.mock.calls[0][0]).toEqual(['444']);
 
     wrapper
-      .find('submenu')
+      .find('.submenu > div')
       .at(0)
       .simulate('click');
-
-    expect(onExpandCallback.mock.calls[0][0]).toEqual(['333', '444']);
+    expect(onExpandCallback.mock.calls[1][0]).toEqual(['333', '444']);
   });
 });

--- a/packages/zent/__tests__/menu.js
+++ b/packages/zent/__tests__/menu.js
@@ -158,4 +158,52 @@ describe('Menu component', () => {
     wrapper.find('SubMenu MenuItem').simulate('click');
     expect(wrapper.find('.zent-menu__inline-item-selected').length).toBe(1);
   });
+
+  it('can get subMenu id when subMenu is clicked', () => {
+    const subMenuClick = jest.fn();
+    let wrapper = mount(
+      <Menu mode="inline" onSubMenuClick={subMenuClick}>
+        <MenuItem key="1-1">食品分类</MenuItem>
+        <SubMenu key="333" title="美妆分类" className="submenu">
+          <MenuItem key="3-1">眼影</MenuItem>
+        </SubMenu>
+      </Menu>
+    );
+    wrapper
+      .find('submenu')
+      .at(0)
+      .simulate('click');
+    expect(subMenuClick.mock.calls[0][0]).toBe('333');
+  });
+
+  it('can emit the expanded ids when toggle expand', () => {
+    const onExpandCallback = jest.fn();
+    let wrapper = mount(
+      <Menu
+        mode="inline"
+        onExpandChange={onExpandCallback}
+        defaultExpandKeys={['333', '444']}
+      >
+        <MenuItem key="1-1">食品分类</MenuItem>
+        <SubMenu key="333" title="美妆分类" className="submenu">
+          <MenuItem key="3-1">眼影</MenuItem>
+        </SubMenu>
+        <SubMenu key="444" title="水果分类" className="submenu">
+          <MenuItem key="3-1">西红柿</MenuItem>
+        </SubMenu>
+      </Menu>
+    );
+    wrapper
+      .find('submenu')
+      .at(0)
+      .simulate('click');
+    expect(onExpandCallback.mock.calls[0][0]).toEqual(['444']);
+
+    wrapper
+      .find('submenu')
+      .at(0)
+      .simulate('click');
+
+    expect(onExpandCallback.mock.calls[0][0]).toEqual(['333', '444']);
+  });
 });

--- a/packages/zent/src/menu/Menu.js
+++ b/packages/zent/src/menu/Menu.js
@@ -17,6 +17,8 @@ export default class Menu extends CommonMenu {
     mode: PropTypes.string,
     className: PropTypes.string,
     prefix: PropTypes.string,
+    onSubMenuClick: PropTypes.func,
+    onExpandChange: PropTypes.func,
 
     // inline模式独有props
     defaultExpandKeys: PropTypes.array,
@@ -30,6 +32,8 @@ export default class Menu extends CommonMenu {
     mode: 'pop',
     inlineIndent: 24,
     defaultExpandKeys: [],
+    onSubMenuClick: noop,
+    onExpandChange: noop,
   };
 
   state = {
@@ -47,6 +51,7 @@ export default class Menu extends CommonMenu {
     this.setState({
       expandKeys: newExpandKeys,
     });
+    this.props.onExpandChange(newExpandKeys);
   };
 
   handleSelect = key => {
@@ -73,6 +78,7 @@ export default class Menu extends CommonMenu {
       expandKeys: this.state.expandKeys,
       handleSelect: this.handleSelect,
       toggleExpand: this.toggleExpand,
+      onSubMenuClick: this.props.onSubMenuClick,
     });
   };
 

--- a/packages/zent/src/menu/README_en-US.md
+++ b/packages/zent/src/menu/README_en-US.md
@@ -15,6 +15,8 @@ Menu, can be used to provide navigation.
 | Property | Description | Type | Default | Optional |
 |------|------|------|--------|---------|
 | onClick | Callback fires when a node of menu is clicked | func |  | |
+| onSubMenuClick | Callback fires when a SubMenu is clicked | func |  | |
+| onExpandChange | Callback fires when SubMenus toggle expand/collapsed, input param is the array of currently expanded SubMenu IDs | func |  | |
 | style | Custom inline styles | object |  | |
 | mode | the display mode | string | 'pop' | 'pop', 'inline' |
 | defaultExpandKeys | the default expand keys for SubMenu | array | | |
@@ -51,7 +53,7 @@ Menu, can be used to provide navigation.
 - A click event callback function, whose parameters are event and key(which is the key property of the node), is used as a unified agent.
 - When the `key` property is not set for the MenuItem, a unique identify of the node (starting from 0) is generated automatically in order and hierarchy, which will be saved on the `index` property as the second argument of the `onClick` function.
   When the `key` property is set manually, the property will be copied to the `index` property and will override  the unique identify generated. It's recommanded to manually set the `key` property to a proper value of MenuItem in the condition that the Menu is not complex.
-  
+
   ```
 	<Menu>
 		<MenuItem>   -------- 'item_0'

--- a/packages/zent/src/menu/README_zh-CN.md
+++ b/packages/zent/src/menu/README_zh-CN.md
@@ -16,6 +16,8 @@ group: 导航
 | 参数 | 说明 | 类型 | 默认值 | 可选值 |
 |------|------|------|--------|-----|
 | onClick | 点击菜单节点回调 | func |  | |
+| onSubMenuClick | 点击子菜单(非叶子节点)的回调, 入参为子菜单 ID | func |  | |
+| onExpandChange | 菜单展开/折叠时的回调, 入参为此时处于展开状态的 SubMenu id 数组 | func |  | |
 | style | 自定义内联样式 | object |  | |
 | mode | 模式 | string | 'pop' | 'pop', 'inline' |
 | defaultExpandKeys | 默认展开的SubMenu的keys | array | | |
@@ -52,7 +54,7 @@ group: 导航
 - 菜单组件使用统一代理的点击事件回调函数, 其参数为 event 和 key(实际上是节点的 index 属性值)。
 - 当 MenuItem 不设置 `key` 属性时的会按顺序和层级自动生成节点的唯一标识(从0开始)并保存在 `speckey` 属性上, 作为 `onClick` 函数的第二个参数。
   如果手动设置了 `key` 属性则会被复制到 `speckey` 属性, 覆盖自动生成的标识。建议在Menu不复杂的情况下手动为 MenuItem 设置格式合理的 `key` 属性。
-  
+
   ```
 	<Menu>
 		<MenuItem />   -------- 'item_0'

--- a/packages/zent/src/menu/SubMenu.js
+++ b/packages/zent/src/menu/SubMenu.js
@@ -16,6 +16,7 @@ export default class SubMenu extends CommonMenu {
     disabled: PropTypes.bool,
     onClick: PropTypes.func,
     isInline: PropTypes.bool,
+    onSubMenuClick: PropTypes.func,
 
     // inline模式独有props
     depth: PropTypes.number,
@@ -57,6 +58,7 @@ export default class SubMenu extends CommonMenu {
 
   titleClickHandler = e => {
     const { isInline, specKey, toggleExpand } = this.props;
+    this.props.onSubMenuClick(specKey);
     if (isInline) {
       toggleExpand(specKey);
     }
@@ -102,6 +104,7 @@ export default class SubMenu extends CommonMenu {
       expandKeys,
       handleSelect,
       toggleExpand,
+      onSubMenuClick: this.props.onSubMenuClick,
     });
   };
 
@@ -124,6 +127,7 @@ export default class SubMenu extends CommonMenu {
           onClick={this.handleClick}
           specKey={specKey}
           overlayCx={overlayClassName}
+          onSubMenuClick={this.props.onSubMenuClick}
         >
           {children}
         </SubPopupMenu>

--- a/packages/zent/src/menu/SubPopupMenu.js
+++ b/packages/zent/src/menu/SubPopupMenu.js
@@ -11,11 +11,18 @@ export default class PopupMenu extends CommonMenu {
     onClick: PropTypes.func,
     specKey: PropTypes.string,
     overlayCx: PropTypes.string,
+    onSubMenuClick: PropTypes.func,
   };
 
   handleClick = (e, specKey) => {
     const { onClick } = this.props;
     onClick(e, specKey);
+  };
+
+  onSubMenuClick = () => {
+    if (this.props.onSubMenuClick) {
+      this.props.onSubMenuClick(this.props.specKey);
+    }
   };
 
   renderSubMenuItems = (component, index) => {
@@ -35,6 +42,7 @@ export default class PopupMenu extends CommonMenu {
     return (
       <ul
         className={cx(`${prefix}-menu`, `${prefix}-submenu-content`, overlayCx)}
+        onClick={this.onSubMenuClick}
       >
         {React.Children.map(children, this.renderSubMenuItems)}
       </ul>

--- a/packages/zent/typings/libs/Menu.d.ts
+++ b/packages/zent/typings/libs/Menu.d.ts
@@ -3,6 +3,8 @@
 declare module 'zent/lib/menu' {
   interface IMenuProps {
     onClick?: (e: React.MouseEvent<HTMLDivElement|HTMLLIElement>, key: string) => void
+    onSubMenuClick?: (id?: string | number) => void
+    onExpandChange?: (expanded?: string[]) => void
     style?: React.CSSProperties
     mode?: 'pop' | 'inline'
     defaultExpandKeys?: Array<string>

--- a/packages/zent/typings/libs/Select.d.ts
+++ b/packages/zent/typings/libs/Select.d.ts
@@ -20,7 +20,7 @@ declare module 'zent/lib/select' {
     optionValue?: string
     onChange?: (event: { target: { type: any, value: any }, preventDefault: () => void, stopPropagation: () => void }, value: any) => void
     onDelete?: (date: any) => void
-    filter?: (item: any) => boolean
+    filter?: (item: any, keyword?: string) => boolean
     maxToShow?: number
     onAsyncFilter?: (keyword: string, callback: (data: any) => void) => void
     onEmptySelected?: (event: React.SyntheticEvent<HTMLSpanElement>, value: any) => void


### PR DESCRIPTION
 menu 组件添加2个 optional 的事件回调:
1. SubMenu 展开/折叠回调 `onExpandChange(expandedIds: string[]) => void`
2. SubMenu 被点击时回调 `onSubMenuClick(subMenuId: string) => void` 
