### PR TITLE
[new feature] 时间选择器支持disable函数来禁用特定时间的选择

### DIFF
--- a/packages/zent/assets/datetimepicker.pcss
+++ b/packages/zent/assets/datetimepicker.pcss
@@ -74,7 +74,7 @@ $input_width: 183px;
       width: 320px;
     }
 
-    &--filled {
+    &--show-clear-icon {
       color: $theme-stroke-1;
 
       &:hover {

--- a/packages/zent/src/datetimepicker/DatePicker.js
+++ b/packages/zent/src/datetimepicker/DatePicker.js
@@ -370,7 +370,7 @@ class DatePicker extends PureComponent {
     );
     const inputCls = cx({
       'picker-input': true,
-      'picker-input--filled': !showPlaceholder,
+      'picker-input--show-clear-icon': canClear && !showPlaceholder,
       'picker-input--disabled': disabled,
     });
     const widthStyle = getWidth(width);

--- a/packages/zent/src/datetimepicker/DateRangePicker.js
+++ b/packages/zent/src/datetimepicker/DateRangePicker.js
@@ -29,6 +29,7 @@ class DateRangePicker extends PureComponent {
     defaultTime: PropTypes.arrayOf(
       PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)])
     ),
+    disabledTime: PropTypes.func,
   };
 
   static defaultProps = {
@@ -39,6 +40,7 @@ class DateRangePicker extends PureComponent {
     value: [],
     openPanel: [],
     defaultTime: [TIME_BEGIN, TIME_BEGIN],
+    disabledTime: () => undefined,
   };
 
   onChange = type => {
@@ -68,6 +70,7 @@ class DateRangePicker extends PureComponent {
       openPanel,
       placeholder,
       value,
+      disabledTime,
       ...pickerProps
     } = this.props;
     let rangePicker;
@@ -92,6 +95,7 @@ class DateRangePicker extends PureComponent {
               onClose={() => onClose && onClose(START)}
               onChange={this.onChange(START)}
               disabledDate={val => disabledDate(val, START)}
+              disabledTime={() => disabledTime(START)}
             />
           )}
         </Receiver>
@@ -115,6 +119,7 @@ class DateRangePicker extends PureComponent {
               onClose={() => onClose && onClose(END)}
               onChange={this.onChange(END)}
               disabledDate={val => disabledDate(val, END)}
+              disabledTime={() => disabledTime(END)}
             />
           )}
         </Receiver>

--- a/packages/zent/src/datetimepicker/MonthPicker.js
+++ b/packages/zent/src/datetimepicker/MonthPicker.js
@@ -236,7 +236,7 @@ class MonthPicker extends PureComponent {
     );
     const inputCls = cx({
       'picker-input': true,
-      'picker-input--filled': !showPlaceholder,
+      'picker-input--show-clear-icon': canClear && !showPlaceholder,
       'picker-input--disabled': disabled,
     });
     const widthStyle = getWidth(width);

--- a/packages/zent/src/datetimepicker/QuarterPicker.js
+++ b/packages/zent/src/datetimepicker/QuarterPicker.js
@@ -228,7 +228,7 @@ class QuarterPicker extends PureComponent {
     );
     const inputCls = cx({
       'picker-input': true,
-      'picker-input--filled': !showPlaceholder,
+      'picker-input--show-clear-icon': canClear && !showPlaceholder,
       'picker-input--disabled': disabled,
     });
     const widthStyle = getWidth(width);

--- a/packages/zent/src/datetimepicker/README_en-US.md
+++ b/packages/zent/src/datetimepicker/README_en-US.md
@@ -106,6 +106,7 @@ Time pickers, provides basic time choosing functionality.
 
 | Property      | Description         | Type      | Default      | Required |
 | ------------ | ------------------------ | -------------- | --------------- | ---- |
+| disabledTime | Callback to check if specific time is disabled | func | `noop` | No    |
 | showSecond       | Whether to show second selector to not.          | boolean         | false  | No    |
 | format       | Time formatting string        | string         | `HH:mm:ss`  | No    |
 | min        | The minimum selectable time           | string/Date    |     | No    |
@@ -124,6 +125,7 @@ Time pickers, provides basic time choosing functionality.
 
 | Property      | Description         | Type      | Default      | Required |
 | ------------ | ------------------------ | -------------- | --------------- | ---- |
+| disabledTime | Callback to check if specific time is disabled | func | `noop` | No    |
 | showSecond       | Whether to show second selector to not.          | boolean         | false  | No    |
 | format       | Time formatting string        | string         | `HH:mm:ss`  | No    |
 | value        | Selected value   | array  | `[]`           | No    |

--- a/packages/zent/src/datetimepicker/TimePicker.js
+++ b/packages/zent/src/datetimepicker/TimePicker.js
@@ -43,6 +43,12 @@ function getFormat(props) {
   return format === DEFAULT_FORMAT ? defaultFormat : format;
 }
 
+const disabledMap = {
+  hour: 'disabledHour',
+  minute: 'disabledMinute',
+  second: 'disabledSecond',
+};
+
 export default class TimePicker extends PureComponent {
   static propTypes = {
     ...commonPropTypes,
@@ -52,6 +58,7 @@ export default class TimePicker extends PureComponent {
     minuteStep: PropTypes.number,
     secondStep: PropTypes.number,
     onBeforeConfirm: PropTypes.func,
+    disabledTime: PropTypes.func,
   };
 
   static defaultProps = {
@@ -62,6 +69,7 @@ export default class TimePicker extends PureComponent {
     hourStep: 1,
     minuteStep: 1,
     secondStep: 1,
+    disabledTime: () => {},
   };
 
   retType = 'string';
@@ -81,6 +89,7 @@ export default class TimePicker extends PureComponent {
 
     this.state = this.extractStateFromProps(props);
     this.state.tabKey = TIME_KEY.HOUR;
+    this.disabledTime = props.disabledTime() || {};
   }
 
   componentWillReceiveProps(next) {
@@ -221,7 +230,7 @@ export default class TimePicker extends PureComponent {
       maxSecond = maxDate.getSeconds();
     }
 
-    return {
+    const defaultHandlers = {
       [TIME_KEY.HOUR]: h => h < minHour || h > maxHour,
       [TIME_KEY.MINUTE]: m =>
         (value.getHours() === minHour && m < minMinute) ||
@@ -233,7 +242,9 @@ export default class TimePicker extends PureComponent {
         (value.getHours() === maxHour &&
           value.getMinutes() === maxMinute &&
           s > maxSecond),
-    }[type];
+    };
+
+    return this.disabledTime[disabledMap[type]] || defaultHandlers[type];
   };
 
   togglePicker = () => {
@@ -308,8 +319,6 @@ export default class TimePicker extends PureComponent {
       state: { value, isPanelOpen },
     } = this;
 
-    let datePicker;
-
     // 打开面板的时候才渲染
     if (isPanelOpen) {
       const linkCls = cx({
@@ -350,7 +359,7 @@ export default class TimePicker extends PureComponent {
           );
         });
 
-      datePicker = (
+      return (
         <div className="time-picker time-panel time-picker-panel">
           <div className="panel__header time-picker-panel__header">
             <div
@@ -380,7 +389,7 @@ export default class TimePicker extends PureComponent {
       );
     }
 
-    return datePicker;
+    return null;
   };
 
   render() {
@@ -411,7 +420,7 @@ export default class TimePicker extends PureComponent {
     );
     const inputCls = cx({
       'picker-input': true,
-      'picker-input--filled': !!formattedValue,
+      'picker-input--show-clear-icon': canClear && !!formattedValue,
       'picker-input--disabled': disabled,
       'time-picker-input': true,
     });

--- a/packages/zent/src/datetimepicker/TimeRangePicker.js
+++ b/packages/zent/src/datetimepicker/TimeRangePicker.js
@@ -38,6 +38,7 @@ export default class TimeRangePicker extends PureComponent {
     minuteStep: PropTypes.number,
     secondStep: PropTypes.number,
     showSecond: PropTypes.bool,
+    disabledTime: PropTypes.func,
   };
 
   static defaultProps = {
@@ -52,6 +53,7 @@ export default class TimeRangePicker extends PureComponent {
     value: [],
     openPanel: [],
     showSecond: false,
+    disabledTime: () => {},
   };
 
   onChange = type => {
@@ -76,6 +78,7 @@ export default class TimeRangePicker extends PureComponent {
       onOpen,
       placeholder,
       value,
+      disabledTime,
       ...pickerProps
     } = this.props;
     let rangePicker;
@@ -95,6 +98,7 @@ export default class TimeRangePicker extends PureComponent {
               onOpen={() => onOpen && onOpen(START)}
               onClose={() => onClose && onClose(START)}
               onChange={this.onChange(START)}
+              disabledTime={() => disabledTime(START)}
             />
           )}
         </Receiver>
@@ -114,6 +118,7 @@ export default class TimeRangePicker extends PureComponent {
               onOpen={() => onOpen && onOpen(END)}
               onClose={() => onClose && onClose(END)}
               onChange={this.onChange(END)}
+              disabledTime={() => disabledTime(END)}
             />
           )}
         </Receiver>

--- a/packages/zent/src/datetimepicker/WeekPicker.js
+++ b/packages/zent/src/datetimepicker/WeekPicker.js
@@ -364,7 +364,7 @@ class WeekPicker extends PureComponent {
       className
     );
     const inputCls = cx('picker-input', 'week-picker-input', {
-      'picker-input--filled': !showPlaceholder,
+      'picker-input--show-clear-icon': canClear && !showPlaceholder,
       'picker-input--disabled': disabled,
     });
     const widthStyle = getWidth(width);

--- a/packages/zent/src/datetimepicker/YearPicker.js
+++ b/packages/zent/src/datetimepicker/YearPicker.js
@@ -221,7 +221,7 @@ class YearPicker extends PureComponent {
     );
     const inputCls = cx({
       'picker-input': true,
-      'picker-input--filled': !showPlaceholder,
+      'picker-input--show-clear-icon': canClear && !showPlaceholder,
       'picker-input--disabled': disabled,
     });
     const widthStyle = getWidth(width);

--- a/packages/zent/src/datetimepicker/demos/basic.md
+++ b/packages/zent/src/datetimepicker/demos/basic.md
@@ -12,13 +12,13 @@ import { TimePicker, TimeRangePicker, DatePicker, MonthPicker, QuarterPicker, Da
 class Demo extends Component{
   state = {
   };
-	
+
   onChangeTime = (val) => {
     this.setState({
       timeValue: val
     })
   }
-      
+
   onChangeTimeRange = (val) => {
     this.setState({
       timeRangeValue: val
@@ -67,7 +67,7 @@ class Demo extends Component{
 
     return (
 			<div>
-        <TimePicker 
+        <TimePicker
           className="zent-picker-demo"
           value={timeValue}
           onChange={this.onChangeTime}

--- a/packages/zent/src/datetimepicker/demos/disabled-time.md
+++ b/packages/zent/src/datetimepicker/demos/disabled-time.md
@@ -1,0 +1,84 @@
+---
+order: 7
+zh-CN:
+	title: "禁用部分时间，可以通过传入 disabledTime 函数来实现，返回 true 表示禁用。"
+en-US:
+	title: "Disabled date can be controlled by disabledTime callback, return true to disable the specific date. You can use min/max to achieve simple disable logic."
+---
+
+```jsx
+import { TimePicker, TimeRangePicker } from 'zent';
+
+const now = new Date();
+const oneDay = 24 * 60 * 60 * 1000;
+
+class Demo extends Component {
+	state = {};
+
+	onChange = (val) => {
+		this.setState({
+			value: val
+		});
+	}
+
+	onRangeChange = (val) => {
+		this.setState({
+			rangeValue: val
+		})
+	}
+
+	disabledTime() {
+		const disabledHour = val => val % 2 === 0;
+		const disabledMinute = val => val > 30;
+		const disabledSecond = val => val % 30 === 0;
+
+		return {
+			disabledHour,
+			disabledMinute,
+			disabledSecond,
+		};
+	}
+
+	disabledRangeTime(type) {
+		const disabledHour = val => {
+			return type === 'start' ? val < 12 : val > 12;
+		};
+		const disabledMinute = val => {
+			return type === 'start' ? val > 30 : val > 30;
+		};
+		const disabledSecond = val => {
+			return type === 'start' ? val < 20 : val > 40;
+		};
+		return {
+			disabledHour,
+			disabledMinute,
+			disabledSecond,
+		};
+	}
+
+	render() {
+		const { value, rangeValue } = this.state;
+		return (
+			<div>
+				<TimePicker
+					className="zent-picker-demo"
+					value={value}
+					showSecond
+					disabledTime={this.disabledTime}
+					onChange={this.onChange}
+				/>
+				<br />
+				<TimeRangePicker
+					className="zent-picker-demo"
+					value={rangeValue}
+					showSecond
+					onChange={this.onRangeChange}
+					disabledTime={this.disabledRangeTime}
+				/>
+			</div>
+		);
+	}
+}
+
+ReactDOM.render(<Demo />, mountNode);
+```

--- a/packages/zent/src/datetimepicker/time/TimeCell.js
+++ b/packages/zent/src/datetimepicker/time/TimeCell.js
@@ -1,11 +1,11 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-
 import { noop } from '../constants';
 
 export default class TimeCell extends PureComponent {
   static propTypes = {
     onSelect: PropTypes.func,
+    cells: PropTypes.array,
   };
 
   static defaultProps = {

--- a/packages/zent/typings/libs/DateTimePicker.d.ts
+++ b/packages/zent/typings/libs/DateTimePicker.d.ts
@@ -88,6 +88,7 @@ declare module 'zent/lib/datetimepicker/TimePicker' {
     secondStep?: number,
     onBeforeConfirm?: () => boolean,
     onBeforeClear?: () => boolean,
+    disabledTime?: () => IDisabledTime
   }
 
   export default class TimePicker extends React.Component<ITimePickerProps, any> {}
@@ -100,6 +101,7 @@ declare module 'zent/lib/datetimepicker/TimeRangePicker' {
     hourStep?: number,
     minuteStep?: number,
     secondStep?: number,
+    disabledTime?: () => IDisabledTime
   }
 
   export default class TimeRangePicker extends React.Component<ITimeRangePickerProps, any> {}


### PR DESCRIPTION
feat:
时间选择器支持disable函数来禁用特定时间的选择 #920 
bugfix:
1、DatePicker canClear 为 `false` 时，hover上去 icon 的显示问题 
2、DateRangePicker disabledTime函数传入"start"/"end"参数 