### PR TITLE
修复infinite-scroller组件上会被反复触发loadmore的问题和文档的initialLoad初始值错误

### DIFF
--- a/packages/zent/src/infinite-scroller/InfiniteScroller.js
+++ b/packages/zent/src/infinite-scroller/InfiniteScroller.js
@@ -32,6 +32,7 @@ export default class InfiniteScroller extends PureComponent {
 
   stopLoading = () => {
     this.setState({ isLoadingShow: false });
+    this.isLoading = false;
   };
 
   calculateTopPosition = el => {
@@ -69,10 +70,10 @@ export default class InfiniteScroller extends PureComponent {
 
   handleScroll = () => {
     const { hasMore, loadMore } = this.props;
-    if (!hasMore || !this.isScrollAtBottom()) {
+    if (!hasMore || !this.isScrollAtBottom() || this.isLoading) {
       return;
     }
-
+    this.isLoading = true;
     this.setState({
       isLoadingShow: true,
     });
@@ -83,9 +84,11 @@ export default class InfiniteScroller extends PureComponent {
       loadMore()
         .then(() => {
           this.setState({ isLoadingShow: false });
+          this.isLoading = false;
         })
         .catch(() => {
           this.setState({ isLoadingShow: false });
+          this.isLoading = false;
         });
     }
   };

--- a/packages/zent/src/infinite-scroller/README_en-US.md
+++ b/packages/zent/src/infinite-scroller/README_en-US.md
@@ -18,7 +18,7 @@ Infinite scrolling widget
 | ------------------ | ---------------------------- | ------------------- | ---------------- | --------------------------------------------  |
 | hasMore            | if pass true, it will call loadMore function        | bool                | `true`           | `false`, `true`                               |
 | loadMore      		 | loadMore function, first argument is a callback to stop loading animation effect| func(stopLoading)   |                  |  							  |
-| initialLoad        | whether it should be call loadMore function when it initialize    | bool                |  `false`         | `false`, `true`                               |
+| initialLoad        | whether it should be call loadMore function when it initialize    | bool                |  `true`         | `false`, `true`                               |
 | useWindow          | if pass true, it will listens window scroll event, or it will listens it's DOM element scroll event | bool | `true` | `false`, `true`                        |
 | useCapture         | whether to capture event when scroll event triggers  | bool                | `false`          | `false`, `true`                               |
 | loader             | showing content when it is loaded                | node                | zent's Loading    |                                               |  

--- a/packages/zent/src/infinite-scroller/README_zh-CN.md
+++ b/packages/zent/src/infinite-scroller/README_zh-CN.md
@@ -19,7 +19,7 @@ group: 展示
 | ------------------ | ---------------------------- | ------------------- | ---------------- | --------------------------------------------  |
 | hasMore            | 是否可以调用loadMore回调        | bool                | `true`           | `false`, `true`                               |
 | loadMore      		 | 加载更多的回调函数，如果函数接收参数则会传入一个停止loading效果的回调| func(stopLoading)   |                  |  							  |
-| initialLoad        | 初始化时是否调用loadMore回调    | bool                |  `false`         | `false`, `true`                               |
+| initialLoad        | 初始化时是否调用loadMore回调    | bool                |  `true`         | `false`, `true`                               |
 | useWindow          | 是否监听window上的滚动事件，如果传入false，则监听该DOM元素上的滚动事件| bool | `true` | `false`, `true`                        |
 | useCapture         | 滚动事件是否在事件捕获阶段接收    | bool                | `false`          | `false`, `true`                               |
 | loader             | 加载时显示的内容                | node                | zent的Loading    |                                               |  


### PR DESCRIPTION
Changes you made in this pull request:

- add flag to control invoking loadmore function
- the default props of 'initialLoad' should be true
