### PR TITLE
[bug fix] NumberInput：修复在 Input 框输入时 onChange 事件不触发

### DIFF
--- a/packages/zent/__tests__/number-input.js
+++ b/packages/zent/__tests__/number-input.js
@@ -83,8 +83,6 @@ describe('NumberInput', () => {
     wrapper.find('.zent-number-input-arrowdown').simulate('click');
     expect(wrapper.state('value')).toBe('2');
 
-    wrapper.find('input').simulate('change');
-    expect(onChangeMock.mock.calls.length).toBe(2);
     wrapper.find('input').simulate('blur');
     expect(onBlurMock.mock.calls.length).toBe(1);
     wrapper.find('input').simulate('keyDown', { keyCode: 13 });
@@ -96,17 +94,65 @@ describe('NumberInput', () => {
     expect(wrapper.state('value')).toBe('0');
   });
 
-  it('NumberInput onchange value', () => {
-    const handleChange = e => {
-      expect(e.target.value).toBe('1');
-    };
+  it('NumberInput onChange value', () => {
+    const mockHandleChange = jest.fn(e => e.target.value);
 
-    const wrapper = mount(<NumberInput onChange={handleChange} value={1} />);
+    const wrapper = mount(
+      <NumberInput onChange={mockHandleChange} value={1} />
+    );
     wrapper.find('input').simulate('change', {
       target: {
-        value: '',
+        value: 2,
       },
     });
-    expect(wrapper.state('value')).toBe('');
+
+    expect(wrapper.state('value')).toBe(2);
+    expect(mockHandleChange.mock.calls[0][0].target.value).toBe(2);
+
+    wrapper.find('input').simulate('change', {
+      target: {
+        value: 3,
+      },
+    });
+
+    expect(wrapper.state('value')).toBe(3);
+    expect(mockHandleChange.mock.calls[1][0].target.value).toBe(3);
+  });
+
+  it('NumberInput only call onChange when number realy changed', () => {
+    const mockHandleChange = jest.fn();
+    const wrapper = mount(<NumberInput onChange={mockHandleChange} />);
+
+    wrapper.find('input').simulate('change', {
+      target: {
+        value: 1,
+      },
+    });
+
+    expect(mockHandleChange.mock.calls.length).toBe(1);
+
+    wrapper.find('input').simulate('change', {
+      target: {
+        value: 1,
+      },
+    });
+
+    expect(mockHandleChange.mock.calls.length).toBe(1);
+
+    wrapper.find('input').simulate('change', {
+      target: {
+        value: '1a',
+      },
+    });
+
+    expect(mockHandleChange.mock.calls.length).toBe(1);
+
+    wrapper.find('input').simulate('change', {
+      target: {
+        value: '11',
+      },
+    });
+
+    expect(mockHandleChange.mock.calls.length).toBe(2);
   });
 });

--- a/packages/zent/src/number-input/NumberInput.js
+++ b/packages/zent/src/number-input/NumberInput.js
@@ -8,6 +8,16 @@ import Input from 'input';
 import Icon from 'icon';
 import getWidth from 'utils/getWidth';
 
+const checkValidNumber = value => {
+  return (
+    /^(\-|\+)?\d+(\.)?$/g.test(value) ||
+    /^(\-|\+)?\d+(\.\d+)?$/g.test(value) ||
+    /^\d+\.$/g.test(value) ||
+    /^(\-|\+)?$/g.test(value) ||
+    /^\.\d+$/g.test(value)
+  );
+};
+
 export default class NumberInput extends PureComponent {
   static propTypes = {
     className: PropTypes.string,
@@ -74,7 +84,6 @@ export default class NumberInput extends PureComponent {
         upArrow,
         downArrow,
       });
-      this.onPropChange(num);
     }
   }
 
@@ -119,16 +128,12 @@ export default class NumberInput extends PureComponent {
 
   onChange = ev => {
     let value = ev.target.value;
-    if (!value) {
-      this.setState({ value });
-    } else if (
-      /^(\-|\+)?\d+(\.)?$/g.test(value) ||
-      /^(\-|\+)?\d+(\.\d+)?$/g.test(value) ||
-      /^\d+\.$/g.test(value) ||
-      /^(\-|\+)?$/g.test(value) ||
-      /^\.\d+$/g.test(value)
-    ) {
-      this.setState({ value });
+    if (!value || checkValidNumber(value)) {
+      const prevValue = this.state.value;
+      if (prevValue !== value) {
+        this.setState({ value });
+        this.onPropChange(value);
+      }
     }
   };
 
@@ -151,7 +156,6 @@ export default class NumberInput extends PureComponent {
       upArrow,
       downArrow,
     });
-    this.onPropChange(num);
     return num;
   }
 
@@ -185,7 +189,6 @@ export default class NumberInput extends PureComponent {
       upArrow,
       downArrow,
     });
-    this.onPropChange(num);
   }
 
   inc = () => {


### PR DESCRIPTION
- onChange 事件的触发统一由 Component#onChange 方法处理
- 更新测试用例
