### PR TITLE
Support tree shaking in babel-plugin-zent

### DIFF
--- a/packages/babel-plugin-zent/README_en-US.md
+++ b/packages/babel-plugin-zent/README_en-US.md
@@ -34,6 +34,7 @@ In your component Javascript files, use zent like this: `import { Button, Dialog
 ### Options
 
 - `moduleMapppingFile`: absolute path of module mapping config for zent.
+- `noModuleRewrite`: disable JavaScript module import rewrite，use with bundle tool's tree-shaking feature.
 - `automaticStyleImport`: `true` to enable styles imports for component.
 - `useRawStyle`: should be used with `automaticStyleImport`, imports postcss source files if set to `true`. **Requires Zent >= 3.8.1**
 
@@ -41,6 +42,7 @@ In your component Javascript files, use zent like this: `import { Button, Dialog
 // defaults
 {
 	moduleMappingFile: 'zent/lib/module-mapping.json',
+	noModuleRewrite: false,
 	automaticStyleImport: false,
 	useRawStyle: false
 }

--- a/packages/babel-plugin-zent/README_zh-CN.md
+++ b/packages/babel-plugin-zent/README_zh-CN.md
@@ -32,6 +32,7 @@
 ### 配置
 
 - `moduleMapppingFile`: Zent 模块映射文件的绝对路径，默认是当前项目下的 Zent 安装目录。
+- `noModuleRewrite`: 关闭 JavaScript 模块重写，一般配合打包工具的 tree-shaking 使用。 
 - `automaticStyleImport`: 设置为 `true` 启用样式自动引入。
 - `useRawStyle`: 配合 `automaticStyleImport` 使用, 设置为 `true` 自动引入样式源文件(PostCSS). **需要 Zent >= 3.8.1**
 
@@ -39,6 +40,7 @@
 // 默认值
 {
 	moduleMappingFile: 'zent/lib/module-mapping.json',
+	noModuleRewrite: false,
 	automaticStyleImport: false,
 	useRawStyle: false
 }

--- a/packages/babel-plugin-zent/src/index.js
+++ b/packages/babel-plugin-zent/src/index.js
@@ -70,7 +70,12 @@ module.exports = function(babel) {
             throw path.buildCodeFrameError('Unexpected import type');
           }, []);
 
-          path.replaceWithMultiple(replacement);
+          const { opts: options } = state;
+          if (options.noModuleRewrite) {
+            path.insertAfter(replacement);
+          } else {
+            path.replaceWithMultiple(replacement);
+          }
         }
       },
     },
@@ -91,12 +96,14 @@ function buildImportReplacement(specifier, types, state, originalPath) {
     const rule = data.MODULE_MAPPING[importedName];
 
     // js
-    replacement.push(
-      types.importDeclaration(
-        [types.importDefaultSpecifier(types.identifier(localName))],
-        types.stringLiteral(rule.js)
-      )
-    );
+    if (!options.noModuleRewrite) {
+      replacement.push(
+        types.importDeclaration(
+          [types.importDefaultSpecifier(types.identifier(localName))],
+          types.stringLiteral(rule.js)
+        )
+      );
+    }
 
     // style
     if (options.automaticStyleImport) {

--- a/packages/zent/package.json
+++ b/packages/zent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zent",
-  "version": "6.3.0-beta1",
+  "version": "6.3.0-beta2",
   "description": "一套前端设计语言和基于React的实现",
   "bugs": "https://github.com/youzan/zent/issues",
   "repository": {

--- a/packages/zent/package.json
+++ b/packages/zent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zent",
-  "version": "6.3.0-beta2",
+  "version": "6.3.0-beta1",
   "description": "一套前端设计语言和基于React的实现",
   "bugs": "https://github.com/youzan/zent/issues",
   "repository": {

--- a/packages/zent/scripts/build.sh
+++ b/packages/zent/scripts/build.sh
@@ -24,6 +24,7 @@ cp -fp .es-babelrc .babelrc
 cross-env BABEL_ENV=es babel src --out-dir es
 cp -fp .babelrc .es-babelrc
 cp -fp .babelrc.bak .babelrc
+rm -rf .babelrc.bak
 
 # build umd output
 cross-env NODE_ENV=production webpack --progress

--- a/packages/zent/src/copy-button/CopyToClipboard.js
+++ b/packages/zent/src/copy-button/CopyToClipboard.js
@@ -64,4 +64,4 @@ function copy(text) {
   return success;
 }
 
-module.exports = copy;
+export default copy;

--- a/packages/zent/src/upload/utils/file-type/index.js
+++ b/packages/zent/src/upload/utils/file-type/index.js
@@ -11,7 +11,7 @@ const xpiZipFilename = toBytes('META-INF/mozilla.rsa');
 const oxmlContentTypes = toBytes('[Content_Types].xml');
 const oxmlRels = toBytes('_rels/.rels');
 
-module.exports = input => {
+const getFileType = input => {
   const buf = input instanceof Uint8Array ? input : new Uint8Array(input);
 
   if (!(buf && buf.length > 1)) {
@@ -939,3 +939,5 @@ module.exports = input => {
 
   return null;
 };
+
+export default getFileType;


### PR DESCRIPTION
Add `noModuleRewrite` option to work with es modules.

Tree shaking automatically removes unused components so we don't have to rewrite module imports.