### PR TITLE
fix js indentation of packages/zent/src/dialog/demos/basic.md

### DIFF
--- a/packages/zent/src/dialog/demos/basic.md
+++ b/packages/zent/src/dialog/demos/basic.md
@@ -34,13 +34,13 @@ class Example extends React.Component {
 					{i18n.show}
 				</Button>
 				<Dialog
-                    visible={this.state.visible}
-                    onClose={() => this.triggerDialog(false)}
-                    title="{i18n.title1}"
-                >
-                    <p>{i18n.content}</p>
-                    <p>{i18n.content1}</p>
-                </Dialog>
+					visible={this.state.visible}
+					onClose={() => this.triggerDialog(false)}
+					title="{i18n.title1}"
+				>	
+					<p>{i18n.content}</p>
+					<p>{i18n.content1}</p>
+			</Dialog>
 			</div>
 		);
 	}


### PR DESCRIPTION
[bug fix] Dialog：修改Dialog组件demo/basic.md中js demo的缩进问题

Changes you made in this pull request:

- packages/zent/src/dialog/demos/basic.md
