### PR TITLE
[new feature] Table: support render indeterminate status in checkbox

### DIFF
--- a/packages/zent/src/table/README_en-US.md
+++ b/packages/zent/src/table/README_en-US.md
@@ -83,6 +83,7 @@ onChange will throw an object containing pagination and sorting parameters：
 | Props              | Description              | Type    |  Default | Required |
 | --------------- | --------------- | ----- | ---- | ----- |
 | selectedRowKeys | Selected by default            | array |  | no    |
+| indeterminateRowKeys | indeterminate rows | array | no |
 | isSingleSelection | Radio or not           | bool | `false` | no    |
 | needCrossPage |   Cross-page multiple choice or not | bool | `false` | no    |
 | onSelect(@selectedkeys, @selectedRows, @currentRow) | Check callback | func  |  | no    |

--- a/packages/zent/src/table/README_zh-CN.md
+++ b/packages/zent/src/table/README_zh-CN.md
@@ -85,6 +85,7 @@ onChange会抛出一个对象，这个对象包含分页变化和排序的的参
 | 参数              | 说明              | 类型    |  默认值 | 是否必须 |
 | --------------- | --------------- | ----- | ---- | ----- |
 | selectedRowKeys | 默认选中            | array |  | 否    |
+| indeterminateRowKeys | 半选状态的行 | array | 否 |
 | isSingleSelection | 是否是单选            | bool | `false` | 否    |
 | needCrossPage |   是否需要跨页的时候多选            | bool | `false` | 否    |
 | onSelect(@selectedkeys, @selectedRows, @currentRow)        | 每次check的时候触发的函数 | func  |  | 否    |

--- a/packages/zent/src/table/Table.js
+++ b/packages/zent/src/table/Table.js
@@ -397,7 +397,7 @@ export default class Table extends PureComponent {
       isSingleSelection = selection.isSingleSelection || false;
     }
     let selectedRowKeys = [];
-    let indeterminatedRowKeys = [];
+    let indeterminateRowKeys = [];
 
     let canSelectAll = false;
     let isSelectAll = false;
@@ -423,7 +423,7 @@ export default class Table extends PureComponent {
       });
 
       selectedRowKeys = selection.selectedRowKeys || [];
-      indeterminatedRowKeys = selection.indeterminatedRowKeys || [];
+      indeterminateRowKeys = selection.indeterminateRowKeys || [];
       canSelectAll = canSelectRowKeysArr.length > 0;
       canRowSelect = selection.canRowSelect;
       isSelectAll =
@@ -475,7 +475,7 @@ export default class Table extends PureComponent {
                     selection={{
                       needSelect,
                       selectedRowKeys,
-                      indeterminatedRowKeys,
+                      indeterminateRowKeys,
                       isSingleSelection,
                       onSelect: this.onSelectOneRow,
                       canRowSelect,

--- a/packages/zent/src/table/Table.js
+++ b/packages/zent/src/table/Table.js
@@ -397,6 +397,7 @@ export default class Table extends PureComponent {
       isSingleSelection = selection.isSingleSelection || false;
     }
     let selectedRowKeys = [];
+    let indeterminatedRowKeys = [];
 
     let canSelectAll = false;
     let isSelectAll = false;
@@ -422,6 +423,7 @@ export default class Table extends PureComponent {
       });
 
       selectedRowKeys = selection.selectedRowKeys || [];
+      indeterminatedRowKeys = selection.indeterminatedRowKeys || [];
       canSelectAll = canSelectRowKeysArr.length > 0;
       canRowSelect = selection.canRowSelect;
       isSelectAll =
@@ -473,6 +475,7 @@ export default class Table extends PureComponent {
                     selection={{
                       needSelect,
                       selectedRowKeys,
+                      indeterminatedRowKeys,
                       isSingleSelection,
                       onSelect: this.onSelectOneRow,
                       canRowSelect,

--- a/packages/zent/src/table/demos/indeterminate.md
+++ b/packages/zent/src/table/demos/indeterminate.md
@@ -1,0 +1,91 @@
+---
+order: 10
+zh-CN:
+	title: 支持半选状态
+en-US:
+	title: Support indeterminate status
+---
+
+```jsx
+import { Table } from 'zent';
+
+const datasets = [
+	{
+		item_id: '5024217',
+		bro_uvpv: '0/0',
+		stock_num: 0,
+		sold_num: 1,
+	},
+	{
+		item_id: '5024277',
+		bro_uvpv: '0/0',
+		stock_num: 59,
+		sold_num: 0,
+	},
+	{
+		item_id: '13213123',
+		bro_uvpv: '0/0',
+		stock_num: 159,
+		sold_num: 0,
+	},
+];
+
+const columns = [
+	{
+		title: 'Product',
+		name: 'item_id',
+	},
+	{
+		title: 'PV',
+		name: 'bro_uvpv',
+	},
+	{
+		title: 'Stock',
+		name: 'stock_num',
+	},
+	{
+		title: 'Sales',
+		name: 'sold_num',
+	}
+];
+
+class Indeterminate extends React.Component {
+	state = {
+		page: {
+			pageSize: 3,
+			current: 0,
+			totalItem: 3,
+		},
+		datasets,
+		selectedRowKeys: ['5024217'],
+		indeterminatedRowKeys: ['5024277'],
+	};
+
+	onSelect = (selectedRowKeys) => {
+		console.log('selectedRowKeys: ', selectedRowKeys);
+		this.setState({
+			selectedRowKeys,
+		});
+	}
+
+	render() {
+		return (
+			<Table
+				rowKey="item_id"
+				columns={columns}
+				datasets={this.state.datasets}
+				pageInfo={this.state.page}
+				selection={{
+					selectedRowKeys: this.state.selectedRowKeys,
+					indeterminatedRowKeys: this.state.indeterminatedRowKeys,
+					onSelect: (selectedRowKeys, selectedRows, currentRow) => {
+						this.onSelect(selectedRowKeys, selectedRows, currentRow);
+					}
+				}}
+			/>
+		);
+	}
+}
+
+ReactDOM.render(<Indeterminate />, mountNode);
+```

--- a/packages/zent/src/table/demos/indeterminate.md
+++ b/packages/zent/src/table/demos/indeterminate.md
@@ -58,7 +58,7 @@ class Indeterminate extends React.Component {
 		},
 		datasets,
 		selectedRowKeys: ['5024217'],
-		indeterminatedRowKeys: ['5024277'],
+		indeterminateRowKeys: ['5024277'],
 	};
 
 	onSelect = (selectedRowKeys) => {
@@ -77,7 +77,7 @@ class Indeterminate extends React.Component {
 				pageInfo={this.state.page}
 				selection={{
 					selectedRowKeys: this.state.selectedRowKeys,
-					indeterminatedRowKeys: this.state.indeterminatedRowKeys,
+					indeterminateRowKeys: this.state.indeterminateRowKeys,
 					onSelect: (selectedRowKeys, selectedRows, currentRow) => {
 						this.onSelect(selectedRowKeys, selectedRows, currentRow);
 					}

--- a/packages/zent/src/table/demos/selection.md
+++ b/packages/zent/src/table/demos/selection.md
@@ -132,8 +132,8 @@ class Selection extends React.Component {
 				selection={{
 					selectedRowKeys: this.state.selectedRowKeys,
 					needCrossPage: true,
-					onSelect: (selectedRowkeys, selectedRows, currentRow) => {
-						self.onSelect(selectedRowkeys, selectedRows, currentRow);
+					onSelect: (selectedRowKeys, selectedRows, currentRow) => {
+						self.onSelect(selectedRowKeys, selectedRows, currentRow);
 					},
 				}}
 			/>

--- a/packages/zent/src/table/modules/Body.js
+++ b/packages/zent/src/table/modules/Body.js
@@ -104,6 +104,7 @@ export default class Body extends PureComponent {
               isSingleSelection: selection.isSingleSelection,
               canSelect,
               selectedRowKeys: selection.selectedRowKeys,
+              indeterminatedRowKeys: selection.indeterminatedRowKeys,
               onSelect: selection.onSelect,
             }}
           />

--- a/packages/zent/src/table/modules/Body.js
+++ b/packages/zent/src/table/modules/Body.js
@@ -104,7 +104,7 @@ export default class Body extends PureComponent {
               isSingleSelection: selection.isSingleSelection,
               canSelect,
               selectedRowKeys: selection.selectedRowKeys,
-              indeterminatedRowKeys: selection.indeterminatedRowKeys,
+              indeterminateRowKeys: selection.indeterminateRowKeys,
               onSelect: selection.onSelect,
             }}
           />

--- a/packages/zent/src/table/modules/Td.js
+++ b/packages/zent/src/table/modules/Td.js
@@ -49,7 +49,7 @@ export default class Td extends PureComponent {
           className="select-check"
           checked={selection.selectedRowKeys.indexOf(data[rowKey]) !== -1}
           indeterminate={
-            selection.indeterminatedRowKeys.indexOf(data[rowKey]) !== -1
+            selection.indeterminateRowKeys.indexOf(data[rowKey]) !== -1
           }
           disabled={!canSelect}
           onChange={this.onSelect}

--- a/packages/zent/src/table/modules/Td.js
+++ b/packages/zent/src/table/modules/Td.js
@@ -48,6 +48,9 @@ export default class Td extends PureComponent {
         <Checkbox
           className="select-check"
           checked={selection.selectedRowKeys.indexOf(data[rowKey]) !== -1}
+          indeterminate={
+            selection.indeterminatedRowKeys.indexOf(data[rowKey]) !== -1
+          }
           disabled={!canSelect}
           onChange={this.onSelect}
         />

--- a/packages/zent/typings/libs/Table.d.ts
+++ b/packages/zent/typings/libs/Table.d.ts
@@ -28,6 +28,7 @@ declare module 'zent/lib/table' {
     emptyLabel?: string
     selection?: {
       selectedRowKeys?: Array<string>
+      indeterminateRowKeys?: Array<string>
       isSingleSelection?: boolean
       needCrossPage?: boolean
       onSelect?: (selectedkeys: string, selectedRows: Array<any>, currentRow: number) => void


### PR DESCRIPTION
- support render indeterminate status in Table's checkbox via pass `indeterminatedRowKeys` which should be maintained by users
- add related demo

