### PR TITLE
[bug fix] DateTimePicker: IDateCommonProps 添加 value 类型

### DIFF
--- a/packages/zent/typings/libs/DateTimePicker.d.ts
+++ b/packages/zent/typings/libs/DateTimePicker.d.ts
@@ -19,6 +19,7 @@ interface IDateCommonProps {
   format?: string,
   openPanel?: boolean,
   defaultTime?: string,
+  value?: string|Date,
   // onChange 返回值类型, date | number | string， 默认 string
   valueType?: 'date' | 'number' | 'string',
   popPosition?: 'left' | 'right',


### PR DESCRIPTION
`IDatePickerProps`、`IWeekPickerProps`、`ITimePickerProps` 等等几个时间选择器的 props type 都 extends `IDateCommonProps` 这个 interface，但是这个 interface 上没有 value 类型，在 ts 下会报错