### PR TITLE
[bug fix] Form: 修复 asyncValidation 结果处理对后续校验的影响

### DIFF
--- a/packages/zent/src/form/createForm.js
+++ b/packages/zent/src/form/createForm.js
@@ -603,7 +603,7 @@ const createForm = (config = {}) => {
           field.setState({
             _isValidating: false,
             _isValid: !rejected && field.state._validationError.length === 0,
-            _externalError: error ? [error] : null,
+            _externalError: rejected && error ? [error] : null,
             _asyncValidated: true,
           });
 


### PR DESCRIPTION
[bug fix] Form: 修复 asyncValidation 结果处理对后续校验的影响
- asyncValidation 的结果处理中，_externalError 的设置基于 Promise 是否被 rejected 来决定