### PR TITLE
[refactor] DatePicker: 重构 willReceiveProps

### DIFF
--- a/packages/zent/src/datetimepicker/DatePicker.tsx
+++ b/packages/zent/src/datetimepicker/DatePicker.tsx
@@ -33,7 +33,7 @@ function extractStateFromProps(props: IDatePickerProps) {
   let selected;
   let actived;
   let showPlaceholder;
-  const { openPanel, value, format, defaultValue, defaultTime } = props;
+  const { openPanel = false, value, format, defaultValue, defaultTime } = props;
 
   if (value) {
     const tmp = parseDate(value, format);
@@ -107,6 +107,24 @@ export class DatePicker extends PureComponent<IDatePickerProps, any> {
   static parseDate = parseDate;
   static formatDate = formatDate;
 
+  static getDerivedStateFromProps(props, state) {
+    if (props.value !== undefined) {
+      const nextState = extractStateFromProps(props);
+
+      if (nextState.value !== state.value) {
+        return nextState;
+      }
+    }
+
+    if (props.openPanel !== undefined && props.openPanel !== state.openPanel) {
+      return {
+        openPanel: props.openPanel,
+      };
+    }
+
+    return null;
+  }
+
   isfooterShow: boolean;
 
   retType = 'string';
@@ -127,11 +145,6 @@ export class DatePicker extends PureComponent<IDatePickerProps, any> {
     this.state = extractStateFromProps(props);
     // 没有footer的逻辑
     this.isfooterShow = showTime || isFooterVisible;
-  }
-
-  componentWillReceiveProps(next) {
-    const state = extractStateFromProps(next);
-    this.setState(state);
   }
 
   getDate = () => {

--- a/packages/zent/src/datetimepicker/DatePicker.tsx
+++ b/packages/zent/src/datetimepicker/DatePicker.tsx
@@ -33,7 +33,7 @@ function extractStateFromProps(props: IDatePickerProps) {
   let selected;
   let actived;
   let showPlaceholder;
-  const { openPanel = false, value, format, defaultValue, defaultTime } = props;
+  const { openPanel, value, format, defaultValue, defaultTime } = props;
 
   if (value) {
     const tmp = parseDate(value, format);
@@ -81,6 +81,7 @@ function extractStateFromProps(props: IDatePickerProps) {
     activedTime: selected || actived,
     openPanel,
     showPlaceholder,
+    prevProps: props,
   };
 }
 
@@ -108,20 +109,9 @@ export class DatePicker extends PureComponent<IDatePickerProps, any> {
   static formatDate = formatDate;
 
   static getDerivedStateFromProps(props: IDatePickerProps, state: any) {
-    if (props.value !== undefined) {
-      const nextState = extractStateFromProps(props);
-
-      if (nextState.value !== state.value) {
-        return nextState;
-      }
+    if (props !== state.prevProps) {
+      return extractStateFromProps(props);
     }
-
-    if (props.openPanel !== undefined && props.openPanel !== state.openPanel) {
-      return {
-        openPanel: props.openPanel,
-      };
-    }
-
     return null;
   }
 

--- a/packages/zent/src/datetimepicker/DatePicker.tsx
+++ b/packages/zent/src/datetimepicker/DatePicker.tsx
@@ -107,7 +107,7 @@ export class DatePicker extends PureComponent<IDatePickerProps, any> {
   static parseDate = parseDate;
   static formatDate = formatDate;
 
-  static getDerivedStateFromProps(props, state) {
+  static getDerivedStateFromProps(props: IDatePickerProps, state: any) {
     if (props.value !== undefined) {
       const nextState = extractStateFromProps(props);
 
@@ -125,7 +125,7 @@ export class DatePicker extends PureComponent<IDatePickerProps, any> {
     return null;
   }
 
-  isfooterShow: boolean;
+  isFooterShow: boolean;
 
   retType = 'string';
 
@@ -144,7 +144,7 @@ export class DatePicker extends PureComponent<IDatePickerProps, any> {
 
     this.state = extractStateFromProps(props);
     // 没有footer的逻辑
-    this.isfooterShow = showTime || isFooterVisible;
+    this.isFooterShow = showTime || isFooterVisible || false;
   }
 
   getDate = () => {
@@ -178,7 +178,7 @@ export class DatePicker extends PureComponent<IDatePickerProps, any> {
         activedTime,
       },
       () => {
-        if (!this.isfooterShow) {
+        if (!this.isFooterShow) {
           this.onConfirm();
         }
       }
@@ -323,7 +323,7 @@ export class DatePicker extends PureComponent<IDatePickerProps, any> {
       });
       const datePickerCls = cx({
         'date-picker': true,
-        small: this.isfooterShow,
+        small: this.isFooterShow,
       });
 
       datePicker = (
@@ -339,7 +339,7 @@ export class DatePicker extends PureComponent<IDatePickerProps, any> {
             onNext={this.onChangeMonth('next')}
             i18n={i18n}
           />
-          {this.isfooterShow ? (
+          {this.isFooterShow ? (
             <PanelFooter
               buttonText={confirmText || i18n.confirm}
               onClickButton={this.onConfirm}

--- a/packages/zent/src/datetimepicker/MonthPicker.tsx
+++ b/packages/zent/src/datetimepicker/MonthPicker.tsx
@@ -63,7 +63,7 @@ export class MonthPicker extends PureComponent<IMonthPickerProps, any> {
   retType = 'string';
   picker?: HTMLDivElement | null = null;
 
-  static getDerivedStateFromProps(props, state) {
+  static getDerivedStateFromProps(props: IMonthPickerProps, state: any) {
     if (props.value !== undefined) {
       const nextState = extractStateFromProps(props);
 

--- a/packages/zent/src/datetimepicker/MonthPicker.tsx
+++ b/packages/zent/src/datetimepicker/MonthPicker.tsx
@@ -63,6 +63,24 @@ export class MonthPicker extends PureComponent<IMonthPickerProps, any> {
   retType = 'string';
   picker?: HTMLDivElement | null = null;
 
+  static getDerivedStateFromProps(props, state) {
+    if (props.value !== undefined) {
+      const nextState = extractStateFromProps(props);
+
+      if (nextState.value !== state.value) {
+        return nextState;
+      }
+    }
+
+    if (props.openPanel !== undefined && props.openPanel !== state.openPanel) {
+      return {
+        openPanel: props.openPanel,
+      };
+    }
+
+    return null;
+  }
+
   constructor(props: IMonthPickerProps) {
     super(props);
     this.state = extractStateFromProps(props);
@@ -74,11 +92,6 @@ export class MonthPicker extends PureComponent<IMonthPickerProps, any> {
       if (typeof value === 'number') this.retType = 'number';
       if (value instanceof Date) this.retType = 'date';
     }
-  }
-
-  componentWillReceiveProps(next) {
-    const state = extractStateFromProps(next);
-    this.setState(state);
   }
 
   getReturnValue = date => {

--- a/packages/zent/src/datetimepicker/MonthPicker.tsx
+++ b/packages/zent/src/datetimepicker/MonthPicker.tsx
@@ -50,6 +50,7 @@ function extractStateFromProps(props: IMonthPickerProps) {
     selected,
     openPanel: false,
     showPlaceholder,
+    prevProps: props,
   };
 }
 
@@ -64,20 +65,9 @@ export class MonthPicker extends PureComponent<IMonthPickerProps, any> {
   picker?: HTMLDivElement | null = null;
 
   static getDerivedStateFromProps(props: IMonthPickerProps, state: any) {
-    if (props.value !== undefined) {
-      const nextState = extractStateFromProps(props);
-
-      if (nextState.value !== state.value) {
-        return nextState;
-      }
+    if (props !== state.prevProps) {
+      return extractStateFromProps(props);
     }
-
-    if (props.openPanel !== undefined && props.openPanel !== state.openPanel) {
-      return {
-        openPanel: props.openPanel,
-      };
-    }
-
     return null;
   }
 

--- a/packages/zent/src/datetimepicker/QuarterPicker.tsx
+++ b/packages/zent/src/datetimepicker/QuarterPicker.tsx
@@ -91,7 +91,7 @@ export class QuarterPicker extends PureComponent<IQuarterPickerProps, any> {
     format: 'YYYY-MM-DD',
   };
 
-  static getDerivedStateFromProps(props, state) {
+  static getDerivedStateFromProps(props: IQuarterPickerProps, state: any) {
     if (props.value !== undefined) {
       const nextState = extractStateFromProps(props);
 

--- a/packages/zent/src/datetimepicker/QuarterPicker.tsx
+++ b/packages/zent/src/datetimepicker/QuarterPicker.tsx
@@ -81,6 +81,7 @@ function extractStateFromProps(props: IQuarterPickerProps) {
     selected,
     openPanel: false,
     showPlaceholder,
+    prevProps: props,
   };
 }
 
@@ -92,20 +93,9 @@ export class QuarterPicker extends PureComponent<IQuarterPickerProps, any> {
   };
 
   static getDerivedStateFromProps(props: IQuarterPickerProps, state: any) {
-    if (props.value !== undefined) {
-      const nextState = extractStateFromProps(props);
-
-      if (nextState.value !== state.value) {
-        return nextState;
-      }
+    if (props !== state.prevProps) {
+      return extractStateFromProps(props);
     }
-
-    if (props.openPanel !== undefined && props.openPanel !== state.openPanel) {
-      return {
-        openPanel: props.openPanel,
-      };
-    }
-
     return null;
   }
 

--- a/packages/zent/src/datetimepicker/QuarterPicker.tsx
+++ b/packages/zent/src/datetimepicker/QuarterPicker.tsx
@@ -91,6 +91,24 @@ export class QuarterPicker extends PureComponent<IQuarterPickerProps, any> {
     format: 'YYYY-MM-DD',
   };
 
+  static getDerivedStateFromProps(props, state) {
+    if (props.value !== undefined) {
+      const nextState = extractStateFromProps(props);
+
+      if (nextState.value !== state.value) {
+        return nextState;
+      }
+    }
+
+    if (props.openPanel !== undefined && props.openPanel !== state.openPanel) {
+      return {
+        openPanel: props.openPanel,
+      };
+    }
+
+    return null;
+  }
+
   retType = 'string';
   picker: HTMLDivElement | null = null;
 
@@ -105,11 +123,6 @@ export class QuarterPicker extends PureComponent<IQuarterPickerProps, any> {
       if (typeof value === 'number') this.retType = 'number';
       if (value instanceof Date) this.retType = 'date';
     }
-  }
-
-  componentWillReceiveProps(next) {
-    const state = extractStateFromProps(next);
-    this.setState(state);
   }
 
   getReturnValue = (date: Date) => {

--- a/packages/zent/src/datetimepicker/TimePicker.tsx
+++ b/packages/zent/src/datetimepicker/TimePicker.tsx
@@ -43,17 +43,14 @@ const disabledMap = {
   second: 'disabledSecond',
 };
 
-function getStateFromProps(props: ITimePickerProps) {
+function getValueFromProps(props: ITimePickerProps) {
   const parsedDate = parseDate(props.value || '', getFormat(props));
 
   if (!parsedDate) {
     console.warn("time and format don't match."); // eslint-disable-line
   }
 
-  return {
-    value: parsedDate || dayStart(),
-    isPanelOpen: props.openPanel || false,
-  };
+  return parsedDate || dayStart();
 }
 
 export interface ITimePickerProps extends DatePickers.ICommonProps {
@@ -83,17 +80,24 @@ export class TimePicker extends PureComponent<ITimePickerProps, any> {
   disabledTime: Partial<DatePickers.IDisabledTime>;
 
   static getDerivedStateFromProps(props: ITimePickerProps, state: any) {
+    let nextState = null;
     if (props.value !== undefined) {
-      const nextState = getStateFromProps(props);
-      if (state.value !== nextState.value) {
-        return nextState;
+      const value = getValueFromProps(props);
+      if (state.value !== value) {
+        nextState = {
+          value,
+        };
       }
     }
 
     if (props.openPanel !== undefined && props.openPanel !== state.openPanel) {
-      return {
-        isPanelOpen: props.openPanel,
-      };
+      if (nextState) {
+        nextState.isPanelOpen = props.openPanel;
+      } else {
+        nextState = {
+          isPanelOpen: props.openPanel,
+        };
+      }
     }
 
     return null;
@@ -111,7 +115,9 @@ export class TimePicker extends PureComponent<ITimePickerProps, any> {
       if (typeof value === 'number') this.retType = 'number';
       if (value instanceof Date) this.retType = 'date';
     }
-    const state: any = getStateFromProps(props);
+    const state: any = {};
+    state.value = getValueFromProps(props);
+    state.isPanelOpen = state.isPanelOpen || false;
     state.tabKey = TIME_KEY.HOUR;
     this.state = state;
     this.disabledTime = (props.disabledTime && props.disabledTime()) || {};
@@ -271,7 +277,7 @@ export class TimePicker extends PureComponent<ITimePickerProps, any> {
 
   resetTime = () => {
     this.setState({
-      value: getStateFromProps(this.props).value,
+      value: getValueFromProps(this.props),
     });
   };
 

--- a/packages/zent/src/datetimepicker/TimePicker.tsx
+++ b/packages/zent/src/datetimepicker/TimePicker.tsx
@@ -114,7 +114,6 @@ export class TimePicker extends PureComponent<ITimePickerProps, any> {
       if (value instanceof Date) this.retType = 'date';
     }
     const state: any = getStateFromProps(props);
-    state.isPanelOpen = false;
     state.tabKey = TIME_KEY.HOUR;
     this.state = state;
     this.disabledTime = props.disabledTime() || {};

--- a/packages/zent/src/datetimepicker/TimePicker.tsx
+++ b/packages/zent/src/datetimepicker/TimePicker.tsx
@@ -274,7 +274,7 @@ export class TimePicker extends PureComponent<ITimePickerProps, any> {
 
   resetTime = () => {
     this.setState({
-      value: this.state.valueFormProps,
+      value: getStateFromProps(this.props).value,
     });
   };
 

--- a/packages/zent/src/datetimepicker/TimePicker.tsx
+++ b/packages/zent/src/datetimepicker/TimePicker.tsx
@@ -43,14 +43,18 @@ const disabledMap = {
   second: 'disabledSecond',
 };
 
-function getValueFromProps(props: ITimePickerProps) {
+function extractStateFromProps(props: ITimePickerProps) {
   const parsedDate = parseDate(props.value || '', getFormat(props));
 
   if (!parsedDate) {
     console.warn("time and format don't match."); // eslint-disable-line
   }
 
-  return parsedDate || dayStart();
+  return {
+    value: parsedDate || dayStart(), // 利用传入的format解析value，失败则返回默认值
+    isPanelOpen: false,
+    prevProps: props,
+  };
 }
 
 export interface ITimePickerProps extends DatePickers.ICommonProps {
@@ -80,26 +84,9 @@ export class TimePicker extends PureComponent<ITimePickerProps, any> {
   disabledTime: Partial<DatePickers.IDisabledTime>;
 
   static getDerivedStateFromProps(props: ITimePickerProps, state: any) {
-    let nextState = null;
-    if (props.value !== undefined) {
-      const value = getValueFromProps(props);
-      if (state.value !== value) {
-        nextState = {
-          value,
-        };
-      }
+    if (props !== state.prevProps) {
+      return extractStateFromProps(props);
     }
-
-    if (props.openPanel !== undefined && props.openPanel !== state.openPanel) {
-      if (nextState) {
-        nextState.isPanelOpen = props.openPanel;
-      } else {
-        nextState = {
-          isPanelOpen: props.openPanel,
-        };
-      }
-    }
-
     return null;
   }
 
@@ -115,9 +102,7 @@ export class TimePicker extends PureComponent<ITimePickerProps, any> {
       if (typeof value === 'number') this.retType = 'number';
       if (value instanceof Date) this.retType = 'date';
     }
-    const state: any = {};
-    state.value = getValueFromProps(props);
-    state.isPanelOpen = state.isPanelOpen || false;
+    const state: any = extractStateFromProps(props);
     state.tabKey = TIME_KEY.HOUR;
     this.state = state;
     this.disabledTime = (props.disabledTime && props.disabledTime()) || {};
@@ -277,7 +262,7 @@ export class TimePicker extends PureComponent<ITimePickerProps, any> {
 
   resetTime = () => {
     this.setState({
-      value: getValueFromProps(this.props),
+      value: extractStateFromProps(this.props),
     });
   };
 

--- a/packages/zent/src/datetimepicker/TimePicker.tsx
+++ b/packages/zent/src/datetimepicker/TimePicker.tsx
@@ -43,14 +43,17 @@ const disabledMap = {
   second: 'disabledSecond',
 };
 
-function getValueFromProps(props) {
+function getStateFromProps(props) {
   const parsedDate = parseDate(props.value || '', getFormat(props));
 
   if (!parsedDate) {
     console.warn("time and format don't match."); // eslint-disable-line
   }
 
-  return parsedDate || dayStart();
+  return {
+    value: parsedDate || dayStart(),
+    isPanelOpen: props.isPanelOpen || false,
+  };
 }
 
 export interface ITimePickerProps extends DatePickers.ICommonProps {
@@ -83,12 +86,9 @@ export class TimePicker extends PureComponent<ITimePickerProps, any> {
 
   static getDerivedStateFromProps(props, state) {
     if (props.value !== undefined) {
-      const valueFromProps = getValueFromProps(props);
-      if (valueFromProps && state.valueFromProps !== valueFromProps) {
-        return {
-          value: valueFromProps,
-          valueFromProps,
-        };
+      const nextState = getStateFromProps(props);
+      if (state.value !== nextState.value) {
+        return nextState;
       }
     }
 
@@ -113,10 +113,7 @@ export class TimePicker extends PureComponent<ITimePickerProps, any> {
       if (typeof value === 'number') this.retType = 'number';
       if (value instanceof Date) this.retType = 'date';
     }
-    const valueFromProps = getValueFromProps(props);
-    const state: any = {};
-    state.value = valueFromProps;
-    state.valueFromProps = valueFromProps;
+    const state: any = getStateFromProps(props);
     state.isPanelOpen = false;
     state.tabKey = TIME_KEY.HOUR;
     this.state = state;

--- a/packages/zent/src/datetimepicker/TimePicker.tsx
+++ b/packages/zent/src/datetimepicker/TimePicker.tsx
@@ -43,7 +43,7 @@ const disabledMap = {
   second: 'disabledSecond',
 };
 
-function getStateFromProps(props) {
+function getStateFromProps(props: ITimePickerProps) {
   const parsedDate = parseDate(props.value || '', getFormat(props));
 
   if (!parsedDate) {
@@ -52,7 +52,7 @@ function getStateFromProps(props) {
 
   return {
     value: parsedDate || dayStart(),
-    isPanelOpen: props.isPanelOpen || false,
+    isPanelOpen: props.openPanel || false,
   };
 }
 
@@ -80,11 +80,9 @@ export class TimePicker extends PureComponent<ITimePickerProps, any> {
   };
 
   retType = 'string';
-  disabledTime: {
-    [key: string]: boolean;
-  };
+  disabledTime: Partial<DatePickers.IDisabledTime>;
 
-  static getDerivedStateFromProps(props, state) {
+  static getDerivedStateFromProps(props: ITimePickerProps, state: any) {
     if (props.value !== undefined) {
       const nextState = getStateFromProps(props);
       if (state.value !== nextState.value) {
@@ -94,14 +92,14 @@ export class TimePicker extends PureComponent<ITimePickerProps, any> {
 
     if (props.openPanel !== undefined && props.openPanel !== state.openPanel) {
       return {
-        openPanel: props.openPanel,
+        isPanelOpen: props.openPanel,
       };
     }
 
     return null;
   }
 
-  constructor(props) {
+  constructor(props: ITimePickerProps) {
     super(props);
     const { value, valueType } = props;
     /**
@@ -116,7 +114,7 @@ export class TimePicker extends PureComponent<ITimePickerProps, any> {
     const state: any = getStateFromProps(props);
     state.tabKey = TIME_KEY.HOUR;
     this.state = state;
-    this.disabledTime = props.disabledTime() || {};
+    this.disabledTime = (props.disabledTime && props.disabledTime()) || {};
   }
 
   onChangeTime = (val, type) => {

--- a/packages/zent/src/datetimepicker/TimeRangePicker.tsx
+++ b/packages/zent/src/datetimepicker/TimeRangePicker.tsx
@@ -75,6 +75,7 @@ export class TimeRangePicker extends PureComponent<ITimeRangePickerProps> {
       placeholder,
       value,
       disabledTime,
+      openPanel,
       ...pickerProps
     } = this.props;
     let rangePicker;
@@ -87,6 +88,7 @@ export class TimeRangePicker extends PureComponent<ITimeRangePickerProps> {
           {i18n => (
             <TimePicker
               {...pickerProps}
+              openPanel={openPanel[0]}
               placeholder={placeholder[0] || i18n.startTime}
               max={value[1] || pickerProps.max}
               defaultValue={defaultValueArr[0]}
@@ -107,6 +109,7 @@ export class TimeRangePicker extends PureComponent<ITimeRangePickerProps> {
           {i18n => (
             <TimePicker
               {...pickerProps}
+              openPanel={openPanel[1]}
               placeholder={placeholder[1] || i18n.endTime}
               min={value[0] || pickerProps.min}
               defaultValue={defaultValueArr[1]}

--- a/packages/zent/src/datetimepicker/WeekPicker.tsx
+++ b/packages/zent/src/datetimepicker/WeekPicker.tsx
@@ -72,7 +72,7 @@ function isDisabled(val, props: IWeekPickerProps) {
   return false;
 }
 
-function extractStateFromProps(props) {
+function extractStateFromProps(props: IWeekPickerProps) {
   let selected;
   let actived;
   let showPlaceholder;
@@ -144,7 +144,7 @@ export class WeekPicker extends PureComponent<IWeekPickerProps, any> {
     startDay: 1,
   };
 
-  static getDerivedStateFromProps(props, state) {
+  static getDerivedStateFromProps(props: IWeekPickerProps, state: any) {
     if (props.value !== undefined) {
       const nextState = extractStateFromProps(props);
 
@@ -163,7 +163,7 @@ export class WeekPicker extends PureComponent<IWeekPickerProps, any> {
   }
 
   retType = 'string';
-  isfooterShow: boolean;
+  isFooterShow: boolean;
 
   constructor(props: IWeekPickerProps) {
     super(props);
@@ -178,7 +178,7 @@ export class WeekPicker extends PureComponent<IWeekPickerProps, any> {
 
     this.state = extractStateFromProps(props);
     // 没有footer的逻辑
-    this.isfooterShow = showTime || isFooterVisible;
+    this.isFooterShow = showTime || isFooterVisible || false;
   }
 
   onChangeDate = val => {
@@ -212,7 +212,7 @@ export class WeekPicker extends PureComponent<IWeekPickerProps, any> {
         selected: week,
       },
       () => {
-        if (!this.isfooterShow) {
+        if (!this.isFooterShow) {
           this.onConfirm();
         }
       }
@@ -317,7 +317,7 @@ export class WeekPicker extends PureComponent<IWeekPickerProps, any> {
 
       const weekPickerCls = cx({
         'week-picker': true,
-        small: this.isfooterShow,
+        small: this.isFooterShow,
       });
 
       weekPicker = (
@@ -337,7 +337,7 @@ export class WeekPicker extends PureComponent<IWeekPickerProps, any> {
               i18n={i18n}
             />
           </div>
-          {this.isfooterShow ? (
+          {this.isFooterShow ? (
             <PanelFooter
               buttonText={confirmText || i18n.confirm}
               onClickButton={this.onConfirm}

--- a/packages/zent/src/datetimepicker/WeekPicker.tsx
+++ b/packages/zent/src/datetimepicker/WeekPicker.tsx
@@ -125,6 +125,7 @@ function extractStateFromProps(props: IWeekPickerProps) {
     selected,
     openPanel,
     showPlaceholder,
+    prevProps: props,
   };
 }
 
@@ -145,20 +146,9 @@ export class WeekPicker extends PureComponent<IWeekPickerProps, any> {
   };
 
   static getDerivedStateFromProps(props: IWeekPickerProps, state: any) {
-    if (props.value !== undefined) {
-      const nextState = extractStateFromProps(props);
-
-      if (nextState.value !== state.value) {
-        return nextState;
-      }
+    if (props !== state.prevProps) {
+      return extractStateFromProps(props);
     }
-
-    if (props.openPanel !== undefined && props.openPanel !== state.openPanel) {
-      return {
-        openPanel: props.openPanel,
-      };
-    }
-
     return null;
   }
 

--- a/packages/zent/src/datetimepicker/YearPicker.tsx
+++ b/packages/zent/src/datetimepicker/YearPicker.tsx
@@ -69,7 +69,7 @@ export class YearPicker extends PureComponent<IYearPickerProps, any> {
     needConfirm: false,
   };
 
-  static getDerivedStateFromProps(props, state) {
+  static getDerivedStateFromProps(props: IYearPickerProps, state: any) {
     if (props.value !== undefined) {
       const nextState = extractStateFromProps(props);
 

--- a/packages/zent/src/datetimepicker/YearPicker.tsx
+++ b/packages/zent/src/datetimepicker/YearPicker.tsx
@@ -69,16 +69,29 @@ export class YearPicker extends PureComponent<IYearPickerProps, any> {
     needConfirm: false,
   };
 
+  static getDerivedStateFromProps(props, state) {
+    if (props.value !== undefined) {
+      const nextState = extractStateFromProps(props);
+
+      if (nextState.value !== state.value) {
+        return nextState;
+      }
+    }
+
+    if (props.openPanel !== undefined && props.openPanel !== state.openPanel) {
+      return {
+        openPanel: props.openPanel,
+      };
+    }
+
+    return null;
+  }
+
   picker: HTMLDivElement | null = null;
 
   constructor(props: IYearPickerProps) {
     super(props);
     this.state = extractStateFromProps(props);
-  }
-
-  componentWillReceiveProps(next) {
-    const state = extractStateFromProps(next);
-    this.setState(state);
   }
 
   onChangeYear = val => {

--- a/packages/zent/src/datetimepicker/YearPicker.tsx
+++ b/packages/zent/src/datetimepicker/YearPicker.tsx
@@ -58,6 +58,7 @@ function extractStateFromProps(props: IYearPickerProps) {
     selected,
     openPanel: false,
     showPlaceholder,
+    prevProps: props,
   };
 }
 
@@ -70,20 +71,9 @@ export class YearPicker extends PureComponent<IYearPickerProps, any> {
   };
 
   static getDerivedStateFromProps(props: IYearPickerProps, state: any) {
-    if (props.value !== undefined) {
-      const nextState = extractStateFromProps(props);
-
-      if (nextState.value !== state.value) {
-        return nextState;
-      }
+    if (props !== state.prevProps) {
+      return extractStateFromProps(props);
     }
-
-    if (props.openPanel !== undefined && props.openPanel !== state.openPanel) {
-      return {
-        openPanel: props.openPanel,
-      };
-    }
-
     return null;
   }
 

--- a/packages/zent/src/datetimepicker/constants/index.ts
+++ b/packages/zent/src/datetimepicker/constants/index.ts
@@ -35,7 +35,7 @@ export const commonProps = {
   confirmText: '',
   format: 'YYYY-MM-DD',
   popPosition: 'left',
-  // openPanel: false,
+  openPanel: false,
   onChange: noop,
   isFooterVisble: false,
   canClear: true,

--- a/packages/zent/src/datetimepicker/constants/index.ts
+++ b/packages/zent/src/datetimepicker/constants/index.ts
@@ -35,7 +35,7 @@ export const commonProps = {
   confirmText: '',
   format: 'YYYY-MM-DD',
   popPosition: 'left',
-  openPanel: false,
+  // openPanel: false,
   onChange: noop,
   isFooterVisble: false,
   canClear: true,


### PR DESCRIPTION
#1060 

Changes you made in this pull request:

## Changes

- 迁移```DatePicker```中几个组件的```willReceiveProps```到```getDerivedStateFromProps```
- 移除了```defaultProps```中的```openPanel```，如果default中有这个值的话gdsfp中没法判断open是否是受控的。（虽然应该没人把openPanel设置成受控的）
- ```WeekPicker```改动比较大，因为要把耦合在类里的逻辑抽出来

