### PR TITLE
[new feature] Grid: bodyRender 可获取到当前所在列的固定状态。

### DIFF
--- a/packages/zent/src/grid/README_en-US.md
+++ b/packages/zent/src/grid/README_en-US.md
@@ -54,7 +54,7 @@ onChange will throw an object, which includes parameters about the change part o
 | title       | column title                                                                                        | ReactNode                                                          | Yes      |
 | name        | key for the corresponding data(recommanded to be set). Nested description like `a.b.c` is supported | string                                                             | No       |
 | width       | column width                                                                                        | string \| number                                                   | No       |
-| bodyRender  | Render complex component                                                                            | ((data: any, pos: number, name: string) => ReactNode) \| ReactNode | No       |
+| bodyRender  | Render complex component                                                                            | ((data: any, pos: {row: number, column: number, fixed: undefined|'left'|'right'}, name: string) => ReactNode) \| ReactNode | No       |
 | className   | class name of the column title                                                                      | string                                                             | No       |
 | needSort    | whether to support sorting                                                                          | bool                                                               | No       |
 | colSpan     | span of columns. It won't be rendered if the value is set to 0                                      | number                                                             | No       |

--- a/packages/zent/src/grid/README_en-US.md
+++ b/packages/zent/src/grid/README_en-US.md
@@ -54,7 +54,7 @@ onChange will throw an object, which includes parameters about the change part o
 | title       | column title                                                                                        | ReactNode                                                          | Yes      |
 | name        | key for the corresponding data(recommanded to be set). Nested description like `a.b.c` is supported | string                                                             | No       |
 | width       | column width                                                                                        | string \| number                                                   | No       |
-| bodyRender  | Render complex component                                                                            | ((data: any, pos: {row: number, column: number, fixed: undefined|'left'|'right'}, name: string) => ReactNode) \| ReactNode | No       |
+| bodyRender  | Render complex component                                                                            | ((data: any, pos: {row: number, column: number, fixed?: 'left'|'right'}, name: string) => ReactNode) \| ReactNode | No       |
 | className   | class name of the column title                                                                      | string                                                             | No       |
 | needSort    | whether to support sorting                                                                          | bool                                                               | No       |
 | colSpan     | span of columns. It won't be rendered if the value is set to 0                                      | number                                                             | No       |

--- a/packages/zent/src/grid/README_zh-CN.md
+++ b/packages/zent/src/grid/README_zh-CN.md
@@ -55,7 +55,7 @@ onChange 会抛出一个对象，这个对象包含分页变化的参数：
 | title       | 列头的名称                                                        | ReactNode                                                          | 是       |
 | name        | 对应数据中的 key (建议设置) 支持 `a.b.c` 的嵌套写法               | string                                                             | 否       |
 | width       | 列表宽度                                                          | string \| number                                                   | 否       |
-| bodyRender  | 渲染复杂组件                                                      | ((data: any, pos: number, name: string) => ReactNode) \| ReactNode | 否       |
+| bodyRender  | 渲染复杂组件                                                      | ((data: any, pos: {row: number, column: number, fixed: undefined|'left'|'right'}, name: string) => ReactNode) \| ReactNode | 否       |
 | className   | 列头的 className                                                  | string                                                             | 否       |
 | needSort    | 是否支持排序 (使用此功能 请设置 name)                             | bool                                                               | 否       |
 | colSpan     | 列合并 当为 0 时不渲染                                            | number                                                             | 否       |

--- a/packages/zent/src/grid/README_zh-CN.md
+++ b/packages/zent/src/grid/README_zh-CN.md
@@ -55,7 +55,7 @@ onChange 会抛出一个对象，这个对象包含分页变化的参数：
 | title       | 列头的名称                                                        | ReactNode                                                          | 是       |
 | name        | 对应数据中的 key (建议设置) 支持 `a.b.c` 的嵌套写法               | string                                                             | 否       |
 | width       | 列表宽度                                                          | string \| number                                                   | 否       |
-| bodyRender  | 渲染复杂组件                                                      | ((data: any, pos: {row: number, column: number, fixed: undefined|'left'|'right'}, name: string) => ReactNode) \| ReactNode | 否       |
+| bodyRender  | 渲染复杂组件                                                      | ((data: any, pos: {row: number, column: number, fixed?: 'left'|'right'}, name: string) => ReactNode) \| ReactNode | 否       |
 | className   | 列头的 className                                                  | string                                                             | 否       |
 | needSort    | 是否支持排序 (使用此功能 请设置 name)                             | bool                                                               | 否       |
 | colSpan     | 列合并 当为 0 时不渲染                                            | number                                                             | 否       |

--- a/packages/zent/src/grid/Row.js
+++ b/packages/zent/src/grid/Row.js
@@ -40,7 +40,7 @@ class Row extends PureComponent {
       let pos = {
         row: rowIndex,
         column: columnIndex,
-        fixed: fixed,
+        fixed,
       };
 
       cells.push(

--- a/packages/zent/src/grid/Row.js
+++ b/packages/zent/src/grid/Row.js
@@ -40,6 +40,7 @@ class Row extends PureComponent {
       let pos = {
         row: rowIndex,
         column: columnIndex,
+        fixed: fixed,
       };
 
       cells.push(

--- a/packages/zent/typings/libs/Grid.d.ts
+++ b/packages/zent/typings/libs/Grid.d.ts
@@ -1,11 +1,17 @@
 /// <reference types="react" />
 
 declare module 'zent/lib/grid' {
+  interface IGridColumnBodyRenderPos {
+    row: number,
+    column: number,
+    fixed: undefined | 'left' | 'right'
+  }
+
   interface IGridColumn {
     title: React.ReactNode
     name?: string
     width?: number | string
-    bodyRender?: ((data: any, pos: number, name: string) => React.ReactNode) | React.ReactNode
+    bodyRender?: ((data: any, pos: IGridColumnBodyRenderPos, name: string) => React.ReactNode) | React.ReactNode
     className?: string
     needSort?: boolean
     colSpan?: number

--- a/packages/zent/typings/libs/Grid.d.ts
+++ b/packages/zent/typings/libs/Grid.d.ts
@@ -4,7 +4,7 @@ declare module 'zent/lib/grid' {
   interface IGridColumnBodyRenderPos {
     row: number,
     column: number,
-    fixed: undefined | 'left' | 'right'
+    fixed?: 'left' | 'right'
   }
 
   interface IGridColumn {


### PR DESCRIPTION
报表中第一行为“合计”行时，需要替换第一行内第一单元格的文案。
但当同时存在右侧固定列时，会造成右侧固定列中第一行第一单元格也被替换。
因此需要识别当前调用 bodyRender 的列是否为右侧固定。