### PR TITLE
[new feature] DateRangeQuickPicker: 支持选择任意时间范围

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "prettify-js": "prettier --write -- \"packages/*/{src,__tests__}/**/*.js\" \"site/{src,scripts,webpack,zent}/**/*.js\"",
     "prettify": "yarn prettify-js && yarn prettify-style",
     "postinstall": "./scripts/ensure-husky-hooks.sh",
+    "precommit": "lint-staged",
+    "prepush": "yarn lint && yarn test",
     "build": "lerna run build",
     "dev": "cd site && yarn dev",
     "deploy": "cd site && yarn deploy"

--- a/package.json
+++ b/package.json
@@ -17,8 +17,6 @@
     "prettify-js": "prettier --write -- \"packages/*/{src,__tests__}/**/*.js\" \"site/{src,scripts,webpack,zent}/**/*.js\"",
     "prettify": "yarn prettify-js && yarn prettify-style",
     "postinstall": "./scripts/ensure-husky-hooks.sh",
-    "precommit": "lint-staged",
-    "prepush": "yarn lint && yarn test",
     "build": "lerna run build",
     "dev": "cd site && yarn dev",
     "deploy": "cd site && yarn deploy"

--- a/packages/zent/src/date-range-quick-picker/DateRangeQuickPicker.js
+++ b/packages/zent/src/date-range-quick-picker/DateRangeQuickPicker.js
@@ -22,7 +22,6 @@ export default class DateRangeQuickPicker extends Component {
       PropTypes.arrayOf(PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.number,
-        PropTypes.instanceOf(Date),
       ])),
     ]),
     preset: PropTypes.arrayOf(PropTypes.shape({
@@ -32,7 +31,6 @@ export default class DateRangeQuickPicker extends Component {
         PropTypes.arrayOf(PropTypes.oneOfType([
           PropTypes.string,
           PropTypes.number,
-          PropTypes.instanceOf(Date),
         ])),
       ]),
     })),

--- a/packages/zent/src/date-range-quick-picker/DateRangeQuickPicker.js
+++ b/packages/zent/src/date-range-quick-picker/DateRangeQuickPicker.js
@@ -17,8 +17,25 @@ export default class DateRangeQuickPicker extends Component {
     value: PropTypes.array,
     valueType: PropTypes.oneOf(['date', 'number', 'string']),
     format: PropTypes.string,
-    chooseDays: PropTypes.number,
-    preset: PropTypes.array,
+    chooseDays: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.arrayOf(PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number,
+        PropTypes.instanceOf(Date),
+      ])),
+    ]),
+    preset: PropTypes.arrayOf(PropTypes.shape({
+      text: PropTypes.string,
+      value: PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.arrayOf(PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.number,
+          PropTypes.instanceOf(Date),
+        ])),
+      ]),
+    })),
     min: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number,

--- a/packages/zent/src/date-range-quick-picker/README_en-US.md
+++ b/packages/zent/src/date-range-quick-picker/README_en-US.md
@@ -23,6 +23,6 @@ As a filter control above list pages.
 | value          | starting and end time       | array           |   `[]`        |             |
 | valueType | Argument type of onChange | string | `''` | `'string'`, `'number'` |
 | format         | Format of returned Date string |  string          |   `'YYYY-MM-DD'`, `'YYYY-MM-DD HH:mm:ss'`   |           |
-| chooseDays     | Number of choosen days |  number          |               |         |
+| chooseDays     | Number of choosen days |  number/array          |               |         |
 | min            | Minimum value of optional date | string, Date  | `''`  |    |
 | max            | Maximum number of optional date  | string, Date  | `''`  |    |

--- a/packages/zent/src/date-range-quick-picker/README_zh-CN.md
+++ b/packages/zent/src/date-range-quick-picker/README_zh-CN.md
@@ -23,6 +23,6 @@ group: 数据
 | value          | 起始、结束时间       | array           |   `[]`        |             |
 | valueType | 设置 onChange 的返回值  | string     | `''` | `'string'`, `'number'` |
 | format         | 返回日期字符串格式   |  string          |   `'YYYY-MM-DD'` 或 `'YYYY-MM-DD HH:mm:ss'`   |           |
-| chooseDays     | 选择天数           |  number          |               |         |
+| chooseDays     | 选择天数           |  number/array          |               |         |
 | min            | 可选日期的最小值    | string/instanceOf(Date)  | `''`  |    |
 | max            | 可选日期的最大值    | string/instanceOf(Date)  | `''`  |    |

--- a/packages/zent/src/date-range-quick-picker/helper.js
+++ b/packages/zent/src/date-range-quick-picker/helper.js
@@ -3,19 +3,25 @@ import { NOW, TOMORROW, ONE_DAY, NOWDATE } from './constants';
 
 export function calculateTime(format, chooseDays, valueType) {
   let startTime;
-  if (chooseDays > 1) {
-    startTime = NOW - (chooseDays - 1) * ONE_DAY;
-  } else {
-    startTime = NOW - chooseDays * ONE_DAY;
-  }
-
   let endTime;
-  if (chooseDays === 0) {
-    endTime = TOMORROW - 1000;
-  } else if (chooseDays === 1) {
-    endTime = NOW - 1000;
+
+  if (Array.isArray(chooseDays)) {
+    startTime = chooseDays[0];
+    endTime = chooseDays[1];
   } else {
-    endTime = NOWDATE;
+    if (chooseDays > 1) {
+      startTime = NOW - (chooseDays - 1) * ONE_DAY;
+    } else {
+      startTime = NOW - chooseDays * ONE_DAY;
+    }
+  
+    if (chooseDays === 0) {
+      endTime = TOMORROW - 1000;
+    } else if (chooseDays === 1) {
+      endTime = NOW - 1000;
+    } else {
+      endTime = NOWDATE;
+    }
   }
 
   const startTimeRes = formatDate(startTime, format);

--- a/packages/zent/typings/libs/DateRangeQuickPicker.d.ts
+++ b/packages/zent/typings/libs/DateRangeQuickPicker.d.ts
@@ -4,9 +4,11 @@ declare module 'zent/lib/date-range-quick-picker' {
 
   type DateRangeQuickPickerValue = number | string
 
+  type DateRangeQuickPickerPresetValue = number | [DateRangeQuickPickerValue, DateRangeQuickPickerValue]
+
   interface IDateRangeQuickPickerPreset {
     text: string
-    value: number
+    value: DateRangeQuickPickerPresetValue
   }
 
   interface IDateRangeQuickPickerProps {
@@ -16,7 +18,7 @@ declare module 'zent/lib/date-range-quick-picker' {
     value?: Array<DateRangeQuickPickerValue>
     valueType?: 'string' | 'number'
     format?: string
-    chooseDays?: number
+    chooseDays?: DateRangeQuickPickerPresetValue
     preset?: Array<IDateRangeQuickPickerPreset>
     min?: string|number|Date
     max?: string|number|Date


### PR DESCRIPTION
chooseDays 和 preset 目前只支持设置相对于今天的偏移量。
报表为非实时数据，需要按照一定周期选择时间范围。
如果周期为一天，则快捷选择的时间范围，就需要相对于昨天。
如果周期为一周，则快捷选择需要支持“上一周”的功能。
通过支持任意时间范围选择，即可覆盖此类需要设置绝对时间的场景。