### PR TITLE
[new feature] DateRangeQuickPicker: 支持选择任意时间范围

### DIFF
--- a/packages/zent/src/date-range-quick-picker/DateRangeQuickPicker.js
+++ b/packages/zent/src/date-range-quick-picker/DateRangeQuickPicker.js
@@ -83,37 +83,12 @@ export default class DateRangeQuickPicker extends Component {
     onChange(value, num);
   };
 
-  isActiveBtn = value => {
-    const { chooseDays } = this.props;
-
-    if (Array.isArray(chooseDays) || Array.isArray(value)) {
-      const [st1, et1] = chooseDays;
-      const [st2, et2] = value;
-
-      let steq = false;
-      let eteq = false;
-      if (st1 instanceof Date && st2 instanceof Date) {
-        steq = st1.getTime() === st2.getTime();
-      } else {
-        steq = st1 === st2;
-      }
-      if (et1 instanceof Date && et2 instanceof Date) {
-        eteq = et1.getTime() === et2.getTime();
-      } else {
-        eteq = et1 === et2;
-      }
-
-      return steq && eteq;
-    }
-
-    return chooseDays === value;
-  };
-
   render() {
     const {
       className,
       format,
       value,
+      chooseDays,
       prefix,
       preset,
       ...pickerProps
@@ -140,7 +115,8 @@ export default class DateRangeQuickPicker extends Component {
                 <span
                   key={index}
                   className={cx(`${prefix}-date-range-picker__btn`, {
-                    active: this.isActiveBtn(item.value),
+                    active:
+                      JSON.stringify(chooseDays) === JSON.stringify(item.value),
                   })}
                   onClick={this.handleChooseDays.bind(this, item.value)}
                 >

--- a/packages/zent/src/date-range-quick-picker/DateRangeQuickPicker.js
+++ b/packages/zent/src/date-range-quick-picker/DateRangeQuickPicker.js
@@ -17,8 +17,23 @@ export default class DateRangeQuickPicker extends Component {
     value: PropTypes.array,
     valueType: PropTypes.oneOf(['date', 'number', 'string']),
     format: PropTypes.string,
-    chooseDays: PropTypes.number,
-    preset: PropTypes.array,
+    chooseDays: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.arrayOf(
+        PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+      ),
+    ]),
+    preset: PropTypes.arrayOf(
+      PropTypes.shape({
+        text: PropTypes.string,
+        value: PropTypes.oneOfType([
+          PropTypes.number,
+          PropTypes.arrayOf(
+            PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+          ),
+        ]),
+      })
+    ),
     min: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number,

--- a/packages/zent/src/date-range-quick-picker/DateRangeQuickPicker.js
+++ b/packages/zent/src/date-range-quick-picker/DateRangeQuickPicker.js
@@ -20,7 +20,11 @@ export default class DateRangeQuickPicker extends Component {
     chooseDays: PropTypes.oneOfType([
       PropTypes.number,
       PropTypes.arrayOf(
-        PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+        PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.number,
+          PropTypes.instanceOf(Date),
+        ])
       ),
     ]),
     preset: PropTypes.arrayOf(
@@ -29,7 +33,11 @@ export default class DateRangeQuickPicker extends Component {
         value: PropTypes.oneOfType([
           PropTypes.number,
           PropTypes.arrayOf(
-            PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+            PropTypes.oneOfType([
+              PropTypes.string,
+              PropTypes.number,
+              PropTypes.instanceOf(Date),
+            ])
           ),
         ]),
       })

--- a/packages/zent/src/date-range-quick-picker/DateRangeQuickPicker.js
+++ b/packages/zent/src/date-range-quick-picker/DateRangeQuickPicker.js
@@ -83,12 +83,37 @@ export default class DateRangeQuickPicker extends Component {
     onChange(value, num);
   };
 
+  isActiveBtn = value => {
+    const { chooseDays } = this.props;
+
+    if (Array.isArray(chooseDays) || Array.isArray(value)) {
+      const [st1, et1] = chooseDays;
+      const [st2, et2] = value;
+
+      let steq = false;
+      let eteq = false;
+      if (st1 instanceof Date && st2 instanceof Date) {
+        steq = st1.getTime() === st2.getTime();
+      } else {
+        steq = st1 === st2;
+      }
+      if (et1 instanceof Date && et2 instanceof Date) {
+        eteq = et1.getTime() === et2.getTime();
+      } else {
+        eteq = et1 === et2;
+      }
+
+      return steq && eteq;
+    }
+
+    return chooseDays === value;
+  };
+
   render() {
     const {
       className,
       format,
       value,
-      chooseDays,
       prefix,
       preset,
       ...pickerProps
@@ -115,7 +140,7 @@ export default class DateRangeQuickPicker extends Component {
                 <span
                   key={index}
                   className={cx(`${prefix}-date-range-picker__btn`, {
-                    active: chooseDays === item.value,
+                    active: this.isActiveBtn(item.value),
                   })}
                   onClick={this.handleChooseDays.bind(this, item.value)}
                 >

--- a/packages/zent/src/date-range-quick-picker/DateRangeQuickPicker.js
+++ b/packages/zent/src/date-range-quick-picker/DateRangeQuickPicker.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import map from 'lodash/map';
+import isEqual from 'lodash/isEqual';
 
 import DateRangePicker from 'datetimepicker/DateRangePicker';
 import { I18nReceiver as Receiver } from 'i18n';
@@ -115,8 +116,7 @@ export default class DateRangeQuickPicker extends Component {
                 <span
                   key={index}
                   className={cx(`${prefix}-date-range-picker__btn`, {
-                    active:
-                      JSON.stringify(chooseDays) === JSON.stringify(item.value),
+                    active: isEqual(chooseDays, item.value),
                   })}
                   onClick={this.handleChooseDays.bind(this, item.value)}
                 >

--- a/packages/zent/src/date-range-quick-picker/README_en-US.md
+++ b/packages/zent/src/date-range-quick-picker/README_en-US.md
@@ -23,6 +23,6 @@ As a filter control above list pages.
 | value          | starting and end time       | array           |   `[]`        |             |
 | valueType | Argument type of onChange | string | `''` | `'string'`, `'number'` |
 | format         | Format of returned Date string |  string          |   `'YYYY-MM-DD'`, `'YYYY-MM-DD HH:mm:ss'`   |           |
-| chooseDays     | Number of choosen days |  number          |               |         |
+| chooseDays     | Number of choosen days |  number/array          |               |         |
 | min            | Minimum value of optional date | string, Date  | `''`  |    |
 | max            | Maximum number of optional date  | string, Date  | `''`  |    |

--- a/packages/zent/src/date-range-quick-picker/README_en-US.md
+++ b/packages/zent/src/date-range-quick-picker/README_en-US.md
@@ -21,7 +21,7 @@ As a filter control above list pages.
 | preset         | custom quick option text      | array             | `[{text: '7 days', value: 7}, {text: '30 days', value: 30}]`    |           |
 | onChange       | change event callback  | func             |         |              |
 | value          | starting and end time       | array           |   `[]`        |             |
-| valueType | Argument type of onChange | string | `''` | `'string'`, `'number'` |
+| valueType | Argument type of onChange | string | `''` | `'date'`, `'string'`, `'number'` |
 | format         | Format of returned Date string |  string          |   `'YYYY-MM-DD'`, `'YYYY-MM-DD HH:mm:ss'`   |           |
 | chooseDays     | Number of choosen days |  number/array          |               |         |
 | min            | Minimum value of optional date | string, Date  | `''`  |    |

--- a/packages/zent/src/date-range-quick-picker/README_zh-CN.md
+++ b/packages/zent/src/date-range-quick-picker/README_zh-CN.md
@@ -23,6 +23,6 @@ group: 数据
 | value          | 起始、结束时间       | array           |   `[]`        |             |
 | valueType | 设置 onChange 的返回值  | string     | `''` | `'string'`, `'number'` |
 | format         | 返回日期字符串格式   |  string          |   `'YYYY-MM-DD'` 或 `'YYYY-MM-DD HH:mm:ss'`   |           |
-| chooseDays     | 选择天数           |  number          |               |         |
+| chooseDays     | 选择天数           |  number/array          |               |         |
 | min            | 可选日期的最小值    | string/instanceOf(Date)  | `''`  |    |
 | max            | 可选日期的最大值    | string/instanceOf(Date)  | `''`  |    |

--- a/packages/zent/src/date-range-quick-picker/README_zh-CN.md
+++ b/packages/zent/src/date-range-quick-picker/README_zh-CN.md
@@ -21,7 +21,7 @@ group: 数据
 | preset         | 自定义快捷选项      | array             | `[{text: '最近7天', value: 7}, {text: '最近30天', value: 30}]`    |           |
 | onChange       | 时间变更回调函数  | func             |         |              |
 | value          | 起始、结束时间       | array           |   `[]`        |             |
-| valueType | 设置 onChange 的返回值  | string     | `''` | `'string'`, `'number'` |
+| valueType | 设置 onChange 的返回值  | string     | `''` | `'date'`, `'string'`, `'number'` |
 | format         | 返回日期字符串格式   |  string          |   `'YYYY-MM-DD'` 或 `'YYYY-MM-DD HH:mm:ss'`   |           |
 | chooseDays     | 选择天数           |  number/array          |               |         |
 | min            | 可选日期的最小值    | string/instanceOf(Date)  | `''`  |    |

--- a/packages/zent/src/date-range-quick-picker/demos/preset.md
+++ b/packages/zent/src/date-range-quick-picker/demos/preset.md
@@ -1,0 +1,71 @@
+---
+order: 1
+zh-CN:
+	title: 快速选择时间范围
+	cycle: 上一周期
+	month: 一月
+en-US:
+	title: Quickly choose a time range
+	cycle: Previous cycle
+	month: January
+---
+
+```js
+import { DateRangeQuickPicker, Notify } from 'zent';
+
+class Simple extends Component {
+	state = {
+	};
+
+	handleChange = (value, chooseDays) => {
+		Notify.success(JSON.stringify({ value, chooseDays }));
+		this.setState({
+			value,
+			chooseDays
+		});
+	};
+
+	handleChange1 = (value, chooseDays) => {
+		Notify.success(JSON.stringify({ value, chooseDays }));
+		this.setState({
+			value1: value,
+			chooseDays1: chooseDays
+		});
+	}
+
+  render() {
+    const { value, chooseDays, value1, chooseDays1 } = this.state;
+
+    return (
+			<div>
+				<DateRangeQuickPicker
+					onChange={this.handleChange}
+					value={value}
+					format="YYYY-MM-DD HH:mm:ss"
+					valueType="number"
+					chooseDays={chooseDays}
+				/>
+				<br />
+				<DateRangeQuickPicker
+					onChange={this.handleChange1}
+					value={value1}
+					format="YYYY-MM-DD HH:mm:ss"
+					chooseDays={chooseDays1}
+					preset={[{
+						text: '{i18n.cycle}',
+						value: ['2019-01-01', '2019-01-02']
+					}, {
+						text: '{i18n.month}',
+						value: ['2019-01-01', '2019-01-31']
+					}]}
+				/>
+			</div>
+    );
+  }
+}
+
+ReactDOM.render(
+	<Simple />
+	, mountNode
+);
+```

--- a/packages/zent/src/date-range-quick-picker/helper.js
+++ b/packages/zent/src/date-range-quick-picker/helper.js
@@ -1,36 +1,45 @@
+import isArray from 'lodash/isArray';
 import formatDate from 'zan-utils/date/formatDate';
-import getValidDate from 'zan-utils/date/getValidDate';
+import parseDate from 'zan-utils/date/parseDate';
 import { NOW, TOMORROW, ONE_DAY, NOWDATE } from './constants';
 
-export function calculateTime(format, chooseDays, valueType) {
+export function calculateTime(format, choosedItem, valueType) {
+  // 起始时间结果
   let startTime;
   let endTime;
 
-  if (Array.isArray(chooseDays)) {
-    [startTime, endTime] = chooseDays;
+  if (isArray(choosedItem)) {
+    [startTime, endTime] = choosedItem;
   } else {
-    if (chooseDays > 1) {
-      startTime = NOW - (chooseDays - 1) * ONE_DAY;
+    if (choosedItem > 1) {
+      startTime = NOW - (choosedItem - 1) * ONE_DAY;
     } else {
-      startTime = NOW - chooseDays * ONE_DAY;
+      startTime = NOW - choosedItem * ONE_DAY;
     }
 
-    if (chooseDays === 0) {
+    if (choosedItem === 0) {
       endTime = TOMORROW - 1000;
-    } else if (chooseDays === 1) {
+    } else if (choosedItem === 1) {
       endTime = NOW - 1000;
     } else {
       endTime = NOWDATE;
     }
   }
 
+  // 先format成string
   const startTimeRes = formatDate(startTime, format);
   const endTimeRes = formatDate(endTime, format);
 
+  // 再转换为date
+  const startTimeDate = parseDate(startTimeRes, format);
+  const endTimeDate = parseDate(endTimeRes, format);
+
   if (valueType === 'number') {
-    const st = getValidDate(startTime);
-    const et = getValidDate(endTime);
-    return [st.getTime(), et.getTime()];
+    // 转时间戳
+    return [startTimeDate.getTime(), endTimeDate.getTime()];
+  } else if (valueType === 'date') {
+    // 转 Date 类型
+    return [startTimeDate, endTimeDate];
   }
   return [startTimeRes, endTimeRes];
 }

--- a/packages/zent/src/date-range-quick-picker/helper.js
+++ b/packages/zent/src/date-range-quick-picker/helper.js
@@ -6,8 +6,7 @@ export function calculateTime(format, chooseDays, valueType) {
   let endTime;
 
   if (Array.isArray(chooseDays)) {
-    startTime = chooseDays[0];
-    endTime = chooseDays[1];
+    [startTime, endTime] = chooseDays;
   } else {
     if (chooseDays > 1) {
       startTime = NOW - (chooseDays - 1) * ONE_DAY;

--- a/packages/zent/src/date-range-quick-picker/helper.js
+++ b/packages/zent/src/date-range-quick-picker/helper.js
@@ -3,19 +3,25 @@ import { NOW, TOMORROW, ONE_DAY, NOWDATE } from './constants';
 
 export function calculateTime(format, chooseDays, valueType) {
   let startTime;
-  if (chooseDays > 1) {
-    startTime = NOW - (chooseDays - 1) * ONE_DAY;
-  } else {
-    startTime = NOW - chooseDays * ONE_DAY;
-  }
-
   let endTime;
-  if (chooseDays === 0) {
-    endTime = TOMORROW - 1000;
-  } else if (chooseDays === 1) {
-    endTime = NOW - 1000;
+
+  if (Array.isArray(chooseDays)) {
+    startTime = chooseDays[0];
+    endTime = chooseDays[1];
   } else {
-    endTime = NOWDATE;
+    if (chooseDays > 1) {
+      startTime = NOW - (chooseDays - 1) * ONE_DAY;
+    } else {
+      startTime = NOW - chooseDays * ONE_DAY;
+    }
+
+    if (chooseDays === 0) {
+      endTime = TOMORROW - 1000;
+    } else if (chooseDays === 1) {
+      endTime = NOW - 1000;
+    } else {
+      endTime = NOWDATE;
+    }
   }
 
   const startTimeRes = formatDate(startTime, format);

--- a/packages/zent/src/date-range-quick-picker/helper.js
+++ b/packages/zent/src/date-range-quick-picker/helper.js
@@ -1,4 +1,5 @@
 import formatDate from 'zan-utils/date/formatDate';
+import getValidDate from 'zan-utils/date/getValidDate';
 import { NOW, TOMORROW, ONE_DAY, NOWDATE } from './constants';
 
 export function calculateTime(format, chooseDays, valueType) {
@@ -27,7 +28,9 @@ export function calculateTime(format, chooseDays, valueType) {
   const endTimeRes = formatDate(endTime, format);
 
   if (valueType === 'number') {
-    return [startTime, endTime];
+    const st = getValidDate(startTime);
+    const et = getValidDate(endTime);
+    return [st.getTime(), et.getTime()];
   }
   return [startTimeRes, endTimeRes];
 }

--- a/packages/zent/typings/libs/DateRangeQuickPicker.d.ts
+++ b/packages/zent/typings/libs/DateRangeQuickPicker.d.ts
@@ -16,7 +16,7 @@ declare module 'zent/lib/date-range-quick-picker' {
     className?: string
     onChange: (value: [DateRangeQuickPickerValue, DateRangeQuickPickerValue], choosePresetValue?: number) => void
     value?: Array<DateRangeQuickPickerValue>
-    valueType?: 'string' | 'number'
+    valueType?: 'date' | 'string' | 'number'
     format?: string
     chooseDays?: DateRangeQuickPickerPresetValue
     preset?: Array<IDateRangeQuickPickerPreset>

--- a/packages/zent/typings/libs/DateRangeQuickPicker.d.ts
+++ b/packages/zent/typings/libs/DateRangeQuickPicker.d.ts
@@ -4,9 +4,11 @@ declare module 'zent/lib/date-range-quick-picker' {
 
   type DateRangeQuickPickerValue = number | string
 
+  type DateRangeQuickPickerPresetValue = number | [DateRangeQuickPickerValue, DateRangeQuickPickerValue]
+
   interface IDateRangeQuickPickerPreset {
     text: string
-    value: number
+    value: DateRangeQuickPickerPresetValue
   }
 
   interface IDateRangeQuickPickerProps {
@@ -16,7 +18,7 @@ declare module 'zent/lib/date-range-quick-picker' {
     value?: Array<DateRangeQuickPickerValue>
     valueType?: 'string' | 'number'
     format?: string
-    chooseDays?: number
+    chooseDays?: DateRangeQuickPickerPresetValue
     preset?: Array<IDateRangeQuickPickerPreset>
     min?: string|number|Date
     max?: string|number|Date

--- a/packages/zent/typings/libs/DateRangeQuickPicker.d.ts
+++ b/packages/zent/typings/libs/DateRangeQuickPicker.d.ts
@@ -2,7 +2,7 @@
 
 declare module 'zent/lib/date-range-quick-picker' {
 
-  type DateRangeQuickPickerValue = number | string
+  type DateRangeQuickPickerValue = number | string | Date
 
   type DateRangeQuickPickerPresetValue = number | [DateRangeQuickPickerValue, DateRangeQuickPickerValue]
 


### PR DESCRIPTION
chooseDays 和 preset 目前只支持设置相对于今天的偏移量。
报表为非实时数据，需要按照一定周期选择时间范围。
如果周期为一天，则快捷选择的时间范围，就需要相对于昨天。
如果周期为一周，则快捷选择需要支持“上一周”的功能。
通过支持任意时间范围选择，即可覆盖此类需要设置绝对时间的场景。