### PR TITLE
[refactor] ClampLine、Menu: 移除即将废弃的生命周期componentWillReceiveProps

### DIFF
--- a/packages/zent/src/clamp-lines/ClampLines.tsx
+++ b/packages/zent/src/clamp-lines/ClampLines.tsx
@@ -64,27 +64,30 @@ export class ClampLines extends Component<IClampLinesProps, IClampLinesState> {
     };
   }
 
+  static getDerivedStateFromProps(props, state) {
+    const { text } = props;
+    if (state.original !== text) {
+      return {
+        original: text,
+        noClamp: false,
+      };
+    }
+
+    return null;
+  }
+
+  componentDidUpdate(prevProps) {
+    const { text } = prevProps;
+    if (text && text !== this.state.original) {
+      this.clampLines();
+    }
+  }
+
   componentDidMount() {
     const { text } = this.props;
     if (text && !this.ssr) {
       this.lineHeight = this.element.clientHeight + 1;
       this.clampLines();
-    }
-  }
-
-  componentWillReceiveProps(nextProps) {
-    if (this.state.original !== nextProps.text) {
-      this.setState(
-        {
-          original: nextProps.text,
-          noClamp: false,
-        },
-        () => {
-          if (nextProps.text) {
-            this.clampLines();
-          }
-        }
-      );
     }
   }
 

--- a/packages/zent/src/menu/SubMenu.tsx
+++ b/packages/zent/src/menu/SubMenu.tsx
@@ -26,10 +26,7 @@ export interface ISubMenuProps {
 }
 
 export interface ISubMenuState {
-  isExpand: boolean;
   subMenuVisible: boolean;
-  cachedSpecKey?: string;
-  cachedExpandKeys?: string[];
 }
 
 export default class SubMenu extends CommonMenu<ISubMenuProps, ISubMenuState> {
@@ -42,33 +39,8 @@ export default class SubMenu extends CommonMenu<ISubMenuProps, ISubMenuState> {
   enterTimer: number;
 
   state = {
-    isExpand:
-      this.props.isInline &&
-      this.props.expandKeys.indexOf(this.props.specKey) !== -1,
     subMenuVisible: false,
   };
-
-  static getDerivedStateFromProps(props: ISubMenuProps, state) {
-    const { cachedSpecKey, cachedExpandKeys } = state;
-    const { expandKeys, specKey } = props;
-    if (!cachedExpandKeys) {
-      return {
-        cachedExpandKeys: expandKeys,
-        cachedSpecKey: specKey,
-      };
-    }
-
-    if (cachedExpandKeys.length !== expandKeys.length) {
-      const isExpand = expandKeys.indexOf(cachedSpecKey) !== -1;
-      return {
-        cachedExpandKeys: expandKeys,
-        cachedSpecKey: specKey,
-        isExpand,
-      };
-    }
-
-    return null;
-  }
 
   getEventHanders = (disabled, isInline) => {
     let eventHanders = {};
@@ -148,9 +120,9 @@ export default class SubMenu extends CommonMenu<ISubMenuProps, ISubMenuState> {
       specKey,
       overlayClassName,
       isInline,
+      expandKeys,
     } = this.props;
-
-    const { isExpand } = this.state;
+    const isExpand = expandKeys && expandKeys.indexOf(specKey) !== -1;
 
     if (!isInline) {
       return (
@@ -185,8 +157,10 @@ export default class SubMenu extends CommonMenu<ISubMenuProps, ISubMenuState> {
       isInline,
       depth,
       inlineIndent,
+      expandKeys,
+      specKey,
     } = this.props;
-    const { isExpand } = this.state;
+    const isExpand = expandKeys && expandKeys.indexOf(specKey) !== -1;
 
     const eventHanders = this.getEventHanders(disabled, isInline);
     const styleObj = getExtraStyle({ isInline, depth, inlineIndent });

--- a/packages/zent/src/menu/SubMenu.tsx
+++ b/packages/zent/src/menu/SubMenu.tsx
@@ -14,18 +14,25 @@ export interface ISubMenuProps {
   className?: string;
   prefix?: string;
   isInline?: boolean;
-  onClick?: (e: React.MouseEvent, index: unknown) => void;
-  specKey?: unknown;
-  onSubMenuClick?: (index: unknown) => void;
-  toggleExpand?: (index: unknown) => void;
+  onClick?: (e: React.MouseEvent, index: string) => void;
+  specKey?: string;
+  onSubMenuClick?: (index?: string | number) => void;
+  toggleExpand?: (index: string) => void;
   depth?: number;
-  expandKeys?: unknown[];
+  expandKeys?: string[];
   inlineIndent?: number;
-  selectedKey?: unknown;
-  handleSelect?: (specKey: unknown) => void;
+  selectedKey?: string;
+  handleSelect?: (specKey: string) => void;
 }
 
-export default class SubMenu extends CommonMenu<ISubMenuProps, any> {
+export interface ISubMenuState {
+  isExpand: boolean;
+  subMenuVisible: boolean;
+  cachedSpecKey?: string;
+  cachedExpandKeys?: string[];
+}
+
+export default class SubMenu extends CommonMenu<ISubMenuProps, ISubMenuState> {
   static defaultProps = {
     className: '',
     prefix: 'zent',

--- a/packages/zent/src/menu/SubMenu.tsx
+++ b/packages/zent/src/menu/SubMenu.tsx
@@ -41,6 +41,28 @@ export default class SubMenu extends CommonMenu<ISubMenuProps, any> {
     subMenuVisible: false,
   };
 
+  static getDerivedStateFromProps(props: ISubMenuProps, state) {
+    const { cachedSpecKey, cachedExpandKeys } = state;
+    const { expandKeys, specKey } = props;
+    if (!cachedExpandKeys) {
+      return {
+        cachedExpandKeys: expandKeys,
+        cachedSpecKey: specKey,
+      };
+    }
+
+    if (cachedExpandKeys.length !== expandKeys.length) {
+      const isExpand = expandKeys.indexOf(cachedSpecKey) !== -1;
+      return {
+        cachedExpandKeys: expandKeys,
+        cachedSpecKey: specKey,
+        isExpand,
+      };
+    }
+
+    return null;
+  }
+
   getEventHanders = (disabled, isInline) => {
     let eventHanders = {};
 
@@ -145,21 +167,6 @@ export default class SubMenu extends CommonMenu<ISubMenuProps, any> {
         </ul>
       </AnimateHeight>
     );
-  }
-
-  componentWillReceiveProps({ expandKeys: nextExpandKeys }: ISubMenuProps) {
-    const { specKey, expandKeys } = this.props;
-
-    // 一次只能展开一个subMenu，因此可以只通过length判断是否改变
-    if (expandKeys.length === nextExpandKeys.length) {
-      return;
-    }
-
-    const isExpand = nextExpandKeys.indexOf(specKey) !== -1;
-
-    this.setState({
-      isExpand,
-    });
   }
 
   render() {


### PR DESCRIPTION
#1060 

Changes you made in this pull request:

## Changes

- 迁移```ClampLine```组件中的```componentWillReceiveProps```到```getDerivedStateFromProps```
- 迁移```Menu```组件中```SubMenu```的```componentWillReceiveProps```到```getDerivedStateFromProps```
- 补齐```Menu```组件中```SubMenu```的变量定义

