### PR TITLE
feat: fix uploader width overflow when screen width is narrow

### DIFF
--- a/packages/zent/assets/upload.scss
+++ b/packages/zent/assets/upload.scss
@@ -42,6 +42,7 @@
   padding: 0;
   overflow-y: auto;
   width: 760px;
+  max-width: 100%;
   height: 480px;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
 [bug fix] Uploader: 屏幕分辨率过窄时，写死宽度会导致内容超出，需加上个max-width