### PR TITLE
Add missing props to TabPanel, a temporary workaround, needs rewrite

### DIFF
--- a/packages/zent/src/tabs/components/TabPanel.tsx
+++ b/packages/zent/src/tabs/components/TabPanel.tsx
@@ -6,6 +6,7 @@ export interface ITabPanelProps {
   className?: string;
   prefix?: string;
   actived?: boolean;
+  disabled?: boolean;
   tab: React.ReactNode;
   id: string | number;
   onTabReady?: (id: string | number) => void;


### PR DESCRIPTION
Add `disabled` to TabPanel