### PR TITLE
[Refactor] BlockHeader

### DIFF
--- a/packages/zent/RELEASE_NEXT.md
+++ b/packages/zent/RELEASE_NEXT.md
@@ -95,6 +95,12 @@ import { LayoutRow as Row, LayoutCol as Col, LayoutGrid as Grid } from 'zent';
 - 删除`closeButtonFontColor`，添加`closeButtonStyle`
 - 预设主题色属性从 `color` 改名为 `theme`，移除 `darkgreen` 主题色，且不再支持自定义颜色传递，需要自定义样式可改用 `style`
 
+### `BlockHeader`
+
+- 整体布局改为 flex 布局
+- 删除 `content` 和 `childAlign`，改用 `leftContent` 和 `rightContent` 来控制左右侧额外展示的内容
+- 不再渲染 `children` 中的内容
+
 #### `Portal`
 
 ```js

--- a/packages/zent/__tests__/block-header.js
+++ b/packages/zent/__tests__/block-header.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import Enzyme, { mount } from 'enzyme';
+import BlockHeader from 'block-header';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe('BlockHeader', () => {
+  it('BlockHeader has title', () => {
+    const wrapper = mount(<BlockHeader title="title" />);
+    expect(wrapper.find('.zent-block-header').length).toBe(1);
+    expect(wrapper.find('.zent-block-header__title').length).toBe(1);
+    expect(wrapper.find('.zent-block-header__pop').length).toBe(0);
+    expect(wrapper.find('.zent-block-header__content').length).toBe(0);
+  });
+
+  it('BlockHeader has tooltip', () => {
+    const wrapper = mount(
+      <BlockHeader title="title" tooltip={<span>tooltip</span>} />
+    );
+    expect(wrapper.find('.zent-block-header__pop').length).toBe(1);
+    expect(wrapper.find('.zent-block-header__tooltip-trigger').length).toBe(1);
+  });
+
+  it('BlockHeader has left content', () => {
+    const wrapper = mount(
+      <BlockHeader title="title" leftContent={<span>left content</span>} />
+    );
+    expect(wrapper.find('.zent-block-header__content').length).toBe(1);
+    expect(wrapper.find('.zent-block-header__content-left').length).toBe(1);
+  });
+
+  it('BlockHeader has right content', () => {
+    const wrapper = mount(
+      <BlockHeader title="title" rightContent={<span>right content</span>} />
+    );
+    expect(wrapper.find('.zent-block-header__content').length).toBe(1);
+    expect(wrapper.find('.zent-block-header__content-right').length).toBe(1);
+  });
+});

--- a/packages/zent/assets/block-header.scss
+++ b/packages/zent/assets/block-header.scss
@@ -2,48 +2,50 @@
 @import './theme/font';
 
 .zent-block-header {
-  position: relative;
-  margin-bottom: 20px;
-  padding: 15px;
+  display: flex;
+  justify-content: flex-start;
+  align-content: center;
+  margin-bottom: 16px;
+  padding: 10px;
   background-color: $theme-stroke-8;
-  height: 50px;
+  min-height: 40px;
   box-sizing: border-box;
 
-  &__left {
-    display: inline-block;
+  &__title {
+    display: flex;
+    align-items: center;
 
-    &:before {
+    &::before {
       content: '';
-      display: inline-block;
       width: 3px;
       height: 14px;
-      position: relative;
-      top: 2px;
       background: $theme-primary-2;
     }
 
     h3 {
-      display: inline-block;
-      margin: 0;
-      padding-left: 5px;
-      font-weight: normal;
-      font-size: $font-size-normal;
+      @include font-normal;
+      font-weight: $font-weight-normal;
+      padding-left: 8px;
     }
   }
 
   &__content {
-    display: inline-block;
-    margin-left: 10px;
+    display: flex;
+    align-items: center;
+    margin-left: 8px;
 
     &-right {
-      float: right;
+      flex-grow: 1;
+      justify-content: flex-end;
     }
   }
 
   &__pop {
-    display: inline-block;
+    @include font-large;
+    margin-left: 8px;
+    display: flex;
+    align-items: center;
     color: $theme-stroke-4;
-    font-size: $font-size-large;
   }
 
   &__tooltip {
@@ -51,9 +53,8 @@
     word-wrap: normal;
 
     &-trigger {
+      @include font-normal;
       color: $theme-stroke-5;
-      margin-left: 10px;
-      font-size: $font-size-normal;
       cursor: pointer;
     }
   }

--- a/packages/zent/src/block-header/BlockHeader.tsx
+++ b/packages/zent/src/block-header/BlockHeader.tsx
@@ -11,37 +11,33 @@ export interface IBlockHeaderProps {
   position?: PopPositions;
   leftContent?: ReactNode;
   rightContent?: ReactNode;
-  prefix?: string;
 }
 
 export class BlockHeader extends Component<IBlockHeaderProps> {
   static defaultProps = {
-    prefix: 'zent',
     className: '',
     position: 'top-right',
   };
 
   private renderTitle() {
-    const { title, prefix } = this.props;
+    const { title } = this.props;
     return (
-      <div className={`${prefix}-block-header__title`}>
+      <div className="zent-block-header__title">
         <h3>{title}</h3>
       </div>
     );
   }
 
   private renderTooltip() {
-    const { tooltip, position, prefix } = this.props;
+    const { tooltip, position } = this.props;
     return (
-      <div className={`${prefix}-block-header__pop`}>
+      <div className="zent-block-header__pop">
         <Pop
           trigger="hover"
           centerArrow
           position={position}
-          content={
-            <div className={`${prefix}-block-header__tooltip`}>{tooltip}</div>
-          }
-          wrapperClassName={`${prefix}-block-header__tooltip-trigger`}
+          content={<div className="zent-block-header__tooltip">{tooltip}</div>}
+          wrapperClassName="zent-block-header__tooltip-trigger"
         >
           <Icon type="help-circle" />
         </Pop>
@@ -50,12 +46,12 @@ export class BlockHeader extends Component<IBlockHeaderProps> {
   }
 
   private renderLeftContent() {
-    const { leftContent, prefix } = this.props;
+    const { leftContent } = this.props;
     return (
       <div
         className={cx(
-          `${prefix}-block-header__content`,
-          `${prefix}-block-header__content-left`
+          'zent-block-header__content',
+          'zent-block-header__content-left'
         )}
       >
         {leftContent}
@@ -64,12 +60,12 @@ export class BlockHeader extends Component<IBlockHeaderProps> {
   }
 
   private renderRightContent() {
-    const { rightContent, prefix } = this.props;
+    const { rightContent } = this.props;
     return (
       <div
         className={cx(
-          `${prefix}-block-header__content`,
-          `${prefix}-block-header__content-right`
+          'zent-block-header__content',
+          'zent-block-header__content-right'
         )}
       >
         {rightContent}
@@ -78,15 +74,9 @@ export class BlockHeader extends Component<IBlockHeaderProps> {
   }
 
   render() {
-    const {
-      prefix,
-      leftContent,
-      rightContent,
-      tooltip,
-      className,
-    } = this.props;
+    const { leftContent, rightContent, tooltip, className } = this.props;
     return (
-      <div className={cx(`${prefix}-block-header`, className)}>
+      <div className={cx('zent-block-header', className)}>
         {this.renderTitle()}
         {tooltip && this.renderTooltip()}
         {leftContent && this.renderLeftContent()}

--- a/packages/zent/src/block-header/BlockHeader.tsx
+++ b/packages/zent/src/block-header/BlockHeader.tsx
@@ -5,68 +5,92 @@ import Pop, { PopPositions } from '../pop';
 import Icon from '../icon';
 
 export interface IBlockHeaderProps {
-  className?: string;
   title: string;
+  className?: string;
   tooltip?: ReactNode;
-  content: ReactNode;
-  childAlign?: 'left' | 'right';
-  position: PopPositions;
-  prefix: string;
+  position?: PopPositions;
+  leftContent?: ReactNode;
+  rightContent?: ReactNode;
+  prefix?: string;
 }
 
 export class BlockHeader extends Component<IBlockHeaderProps> {
   static defaultProps = {
     prefix: 'zent',
     className: '',
-    childAlign: 'left',
     position: 'top-right',
-    tooltip: '',
-    content: '',
   };
+
+  private renderTitle() {
+    const { title, prefix } = this.props;
+    return (
+      <div className={`${prefix}-block-header__title`}>
+        <h3>{title}</h3>
+      </div>
+    );
+  }
+
+  private renderTooltip() {
+    const { tooltip, position, prefix } = this.props;
+    return (
+      <div className={`${prefix}-block-header__pop`}>
+        <Pop
+          trigger="hover"
+          centerArrow
+          position={position}
+          content={
+            <div className={`${prefix}-block-header__tooltip`}>{tooltip}</div>
+          }
+          wrapperClassName={`${prefix}-block-header__tooltip-trigger`}
+        >
+          <Icon type="help-circle" />
+        </Pop>
+      </div>
+    );
+  }
+
+  private renderLeftContent() {
+    const { leftContent, prefix } = this.props;
+    return (
+      <div
+        className={cx(
+          `${prefix}-block-header__content`,
+          `${prefix}-block-header__content-left`
+        )}
+      >
+        {leftContent}
+      </div>
+    );
+  }
+
+  private renderRightContent() {
+    const { rightContent, prefix } = this.props;
+    return (
+      <div
+        className={cx(
+          `${prefix}-block-header__content`,
+          `${prefix}-block-header__content-right`
+        )}
+      >
+        {rightContent}
+      </div>
+    );
+  }
 
   render() {
     const {
       prefix,
-      content,
-      title,
+      leftContent,
+      rightContent,
       tooltip,
-      childAlign,
-      position,
       className,
-      children,
     } = this.props;
     return (
       <div className={cx(`${prefix}-block-header`, className)}>
-        {title && (
-          <div className={`${prefix}-block-header__left`}>
-            <h3>{title}</h3>
-          </div>
-        )}
-        <div className={`${prefix}-block-header__pop`}>
-          {tooltip && (
-            <Pop
-              trigger="hover"
-              centerArrow
-              position={position}
-              content={
-                <div className={`${prefix}-block-header__tooltip`}>
-                  {tooltip}
-                </div>
-              }
-              wrapperClassName={`${prefix}-block-header__tooltip-trigger`}
-            >
-              <Icon type="help-circle" />
-            </Pop>
-          )}
-        </div>
-        <div
-          className={cx(`${prefix}-block-header__content`, {
-            [`${prefix}-block-header__content-right`]: childAlign === 'right',
-          })}
-        >
-          {content && content}
-          {children && children}
-        </div>
+        {this.renderTitle()}
+        {tooltip && this.renderTooltip()}
+        {leftContent && this.renderLeftContent()}
+        {rightContent && this.renderRightContent()}
       </div>
     );
   }

--- a/packages/zent/src/block-header/README_en-US.md
+++ b/packages/zent/src/block-header/README_en-US.md
@@ -12,7 +12,6 @@ This is a block header.
 
 | Property     | Description          | Type      | Default     | Alternative |
 | ------------ | -------------------- | --------- | ----------- | ----------- |
-| prefix       | custom prefix        | string    | `'zent'`    |             |
 | className    | custom class name    | string    | ''          |             |
 | title        | title                | string    |             |             |
 | tooltip      | content of the pop   | ReactNode |             |             |

--- a/packages/zent/src/block-header/README_en-US.md
+++ b/packages/zent/src/block-header/README_en-US.md
@@ -10,12 +10,12 @@ This is a block header.
 
 ## API
 
-| Property            | Description               | Type             | Default      | Alternative     |
-|------          |------              |------            |--------    |--------   |
-| prefix         | custom prefix           | string          | `'zent'`    |           |
-| className      | custom class name          | string            |   ''    |              |
-| title          | title               | string            |         |              |
-| tooltip        | content of the pop         | node             |          |             |
-| content        | custom content       | node             |            |           |
-| childAlign     | popsition of children | string | `'left'`  | `'left'、'right'` |
-| position       | pop position       | string           | 'top-right' |          |
+| Property     | Description          | Type      | Default     | Alternative |
+| ------------ | -------------------- | --------- | ----------- | ----------- |
+| prefix       | custom prefix        | string    | `'zent'`    |             |
+| className    | custom class name    | string    | ''          |             |
+| title        | title                | string    |             |             |
+| tooltip      | content of the pop   | ReactNode |             |             |
+| position     | pop position         | string    | 'top-right' |             |
+| leftContent  | left custom content  | ReactNode |             |             |
+| rightContent | right custom content | ReactNode |             |             |

--- a/packages/zent/src/block-header/README_zh-CN.md
+++ b/packages/zent/src/block-header/README_zh-CN.md
@@ -13,7 +13,6 @@ group: 展示
 
 | 参数         | 说明           | 类型      | 默认值      | 备选值 |
 | ------------ | -------------- | --------- | ----------- | ------ |
-| prefix       | 自定义前缀     | string    | `'zent'`    |        |
 | className    | 自定义类名     | string    | ''          |        |
 | title        | 标题           | string    |             |        |
 | tooltip      | pop 显示内容   | ReactNode |             |        |

--- a/packages/zent/src/block-header/README_zh-CN.md
+++ b/packages/zent/src/block-header/README_zh-CN.md
@@ -11,13 +11,12 @@ group: 展示
 
 ## API
 
-| 参数            | 说明               | 类型             | 默认值      | 备选值     |
-|------          |------              |------            |--------    |--------   |
-| prefix         | 自定义前缀           | string          | `'zent'`    |           |
-| className      | 自定义类名          | string            |   ''    |              |
-| title          | 标题               | string            |         |              |
-| tooltip        | pop显示内容         | node             |          |             |
-| content        | 自定义content       | node             |            |           |
-| childAlign     | 子元素对齐方式 | string | `'left'`  | `'left'、'right'` |
-| position       | pop posotion       | string           | 'top-right' |          |
-
+| 参数         | 说明           | 类型      | 默认值      | 备选值 |
+| ------------ | -------------- | --------- | ----------- | ------ |
+| prefix       | 自定义前缀     | string    | `'zent'`    |        |
+| className    | 自定义类名     | string    | ''          |        |
+| title        | 标题           | string    |             |        |
+| tooltip      | pop 显示内容   | ReactNode |             |        |
+| position     | pop 显示位置   | string    | 'top-right' |        |
+| leftContent  | 左侧自定义内容 | ReactNode |             |        |
+| rightContent | 右侧自定义内容 | ReactNode |             |        |

--- a/packages/zent/src/block-header/demos/basic.md
+++ b/packages/zent/src/block-header/demos/basic.md
@@ -18,11 +18,6 @@ class Simple extends React.Component {
 				<BlockHeader
 					title="{i18n.content}"
 					tooltip={<span>test</span>}
-					content={
-						<a className="zent-link" href="/">
-							content
-						</a>
-					}
 					position="top-center"
 				/>
 				<br />
@@ -30,23 +25,22 @@ class Simple extends React.Component {
 					className="test-class"
 					title="{i18n.content}"
 					position="top-center"
-				>
-					<a className="zent-link" href="/">
-						children
-					</a>
-				</BlockHeader>
+					leftContent={
+						<a className="zent-link" href="/">
+							left content
+						</a>
+					}
+				/>
 				<br />
 				<BlockHeader
 					title="{i18n.content}"
-					tooltip={
-						<div>
-							<p>test1</p>
-							<p>test2</p>
-						</div>
-					}
-					content={<a href="/">content</a>}
+					tooltip={<span>test</span>}
 					position="top-center"
-					childAlign="right"
+					rightContent={
+						<a className="zent-link" href="/">
+							right content
+						</a>
+					}
 				/>
 				<br />
 				<BlockHeader
@@ -54,12 +48,17 @@ class Simple extends React.Component {
 					title="{i18n.content}"
 					tooltip={<span>test</span>}
 					position="top-center"
-					childAlign="right"
-				>
-					<a className="zent-link" href="/">
-						children
-					</a>
-				</BlockHeader>
+					leftContent={
+						<a className="zent-link" href="/">
+							left content
+						</a>
+					}
+					rightContent={
+						<a className="zent-link" href="/">
+							right content
+						</a>
+					}
+				/>
 			</div>
 		);
 	}

--- a/packages/zent/src/tag/README_en-US.md
+++ b/packages/zent/src/tag/README_en-US.md
@@ -16,17 +16,16 @@ Tag is suitable for marking and sorting。
 
 ### API
 
-| Property         | Description                                                  | Type                | Default  | Alternative                                                |
-| ---------------- | ------------------------------------------------------------ | ------------------- | -------- | ---------------------------------------------------------- |
-| theme            | The preset color of tag                                      | string              | `'red'`  | `'red'` \| `'green'` \| `'yellow'` \| `'blue'` \| `'grey'` |
-| outline          | The style with colorful border and transparent backgound.    | bool                | `false`  | `true` \| `false`                                          |
-| rounded          | Whether the tag is rounded or not                            | bool                | `true`   | `true` \| `false`                                          |
-| closable         | Whether the tag can be closed                                | bool                | `false`  | `true` \| `false`                                          |
-| onClose          | The callback function that is trigged when the tag is closed | func                | `noop`   |
-| visible          | Tag is visible                                               | bool                | `true`   | `false`                                                    |  |
-| closeButtonStyle | Style of close button                                        | React.CSSProperties |          |                                                            |
-| className        | The custom classname                                         | string              |          |                                                            |
-| prefix           | The custom prefix                                            | string              | `'zent'` |
-| style            | The custom style                                             | React.CSSProperties |          |                                                            |
+| Property         | Description                                                  | Type                | Default | Alternative                                                |
+| ---------------- | ------------------------------------------------------------ | ------------------- | ------- | ---------------------------------------------------------- |
+| theme            | The preset color of tag                                      | string              | `'red'` | `'red'` \| `'green'` \| `'yellow'` \| `'blue'` \| `'grey'` |
+| outline          | The style with colorful border and transparent backgound.    | bool                | `false` | `true` \| `false`                                          |
+| rounded          | Whether the tag is rounded or not                            | bool                | `true`  | `true` \| `false`                                          |
+| closable         | Whether the tag can be closed                                | bool                | `false` | `true` \| `false`                                          |
+| onClose          | The callback function that is trigged when the tag is closed | func                | `noop`  |
+| visible          | Tag is visible                                               | bool                | `true`  | `false`                                                    |  |
+| closeButtonStyle | Style of close button                                        | React.CSSProperties |         |                                                            |
+| className        | The custom classname                                         | string              |         |                                                            |
+| style            | The custom style                                             | React.CSSProperties |         |                                                            |
 
 > All props are optional, a tag can be closed by using `visible` and `onClose` together.

--- a/packages/zent/src/tag/README_zh-CN.md
+++ b/packages/zent/src/tag/README_zh-CN.md
@@ -17,17 +17,16 @@ group: 展示
 
 ### API
 
-| 参数             | 说明               | 类型                | 默认值   | 备选值                                                     |
-| ---------------- | ------------------ | ------------------- | -------- | ---------------------------------------------------------- |
-| theme            | 标签的预置颜色     | string              | `'red'`  | `'red'` \| `'green'` \| `'yellow'` \| `'blue'` \| `'grey'` |
-| outline          | 边框有颜色，无底色 | bool                | `false`  | `true` \| `false`                                          |
-| rounded          | 是否有圆角         | bool                | `true`   | `true` \| `false`                                          |
-| closable         | 是否可以关闭       | bool                | `false`  | `true` \| `false`                                          |
-| visible          | 是否显示           | bool                | `true`   | `false`                                                    |
-| onClose          | 关闭时的回调       | func                | `noop`   |                                                            |
-| closeButtonStyle | 关闭按钮样式       | React.CSSProperties |          |                                                            |
-| className        | 自定义额外类名     | string              |          |                                                            |
-| prefix           | 自定义前缀         | string              | `'zent'` |                                                            |
-| style            | 自定义样式         | React.CSSProperties |          |                                                            |
+| 参数             | 说明               | 类型                | 默认值  | 备选值                                                     |
+| ---------------- | ------------------ | ------------------- | ------- | ---------------------------------------------------------- |
+| theme            | 标签的预置颜色     | string              | `'red'` | `'red'` \| `'green'` \| `'yellow'` \| `'blue'` \| `'grey'` |
+| outline          | 边框有颜色，无底色 | bool                | `false` | `true` \| `false`                                          |
+| rounded          | 是否有圆角         | bool                | `true`  | `true` \| `false`                                          |
+| closable         | 是否可以关闭       | bool                | `false` | `true` \| `false`                                          |
+| visible          | 是否显示           | bool                | `true`  | `false`                                                    |
+| onClose          | 关闭时的回调       | func                | `noop`  |                                                            |
+| closeButtonStyle | 关闭按钮样式       | React.CSSProperties |         |                                                            |
+| className        | 自定义额外类名     | string              |         |                                                            |
+| style            | 自定义样式         | React.CSSProperties |         |                                                            |
 
 > 所有参数都是可选，搭配 `visible` 和 `onClose` 可以实现关闭效果


### PR DESCRIPTION
- 整体布局改为 flex 布局
- 删除 `content` 和 `childAlign`，改用 `leftContent` 和 `rightContent` 来控制左右侧额外展示的内容
- 不再渲染 `children` 中的内容
