### PR TITLE
[bugfix] Pagination: 修复分页组件 double 属性的 warning

### DIFF
--- a/packages/zent/src/pagination/components/button/ArrowButton.tsx
+++ b/packages/zent/src/pagination/components/button/ArrowButton.tsx
@@ -79,7 +79,7 @@ class DoubleArrowButton extends Component<
   };
 
   render() {
-    const { direction, active, bordered, ...rest } = this.props;
+    const { direction, active, bordered, double: _, ...rest } = this.props;
     const { showArrow } = this.state;
     let Arrow = (null as unknown) as React.FC;
     if (direction === 'left') {


### PR DESCRIPTION
- 修复分页组件 double 属性传递到基础 react 元素上时 warning 信息报警
