### PR TITLE
fix: 重新实现check计算，并只保留受控模式break change

### DIFF
--- a/packages/zent/__tests__/tree.js
+++ b/packages/zent/__tests__/tree.js
@@ -525,13 +525,21 @@ describe('new Tree', () => {
     wrapper.setProps({ data: updatedData });
     expect(wrapper.find('li').length).toBe(9);
 
+    let onCheckedData;
+
     const checkableWrapper = mount(
       <NewTree
         dataType="plain"
         data={updatedData}
         checkable
-        defaultCheckedKeys={[3, 6]}
+        checkedKeys={[3, 6]}
         disabledCheckedKeys={[4, 5]}
+        onCheck={checkedData => {
+          onCheckedData = checkedData;
+          wrapper.setProps({
+            checkedKeys: onCheckedData,
+          });
+        }}
       />
     );
 
@@ -969,19 +977,22 @@ describe('new Tree', () => {
     ];
 
     let onCheckedData;
-    const onCheck = checkedData => {
-      onCheckedData = checkedData;
-    };
 
     const wrapper = mount(
       <NewTree
         data={data}
-        defaultCheckedKeys={[6, 7]}
+        checkedKeys={[6, 7]}
         checkable
         disabledCheckedKeys={[7]}
-        onCheck={onCheck}
+        onCheck={checkedData => {
+          onCheckedData = checkedData;
+          wrapper.setProps({
+            checkedKeys: onCheckedData,
+          });
+        }}
       />
     );
+
     expect(
       wrapper
         .find('Checkbox')
@@ -1077,11 +1088,58 @@ describe('new Tree', () => {
         .find('Checkbox')
         .at(6)
         .prop('checked')
-    ).toBe(true);
+    ).toBe(false);
   });
 
-  it('Tree will handle checkbox click properly with controlled', () => {
-    const data = [
+  it('Tree disabled check', () => {
+    const disabledData = [
+      {
+        id: 1,
+        title: 'root',
+        children: [
+          {
+            id: 2,
+            title: 'son',
+          },
+          {
+            id: 3,
+            title: 'daughter',
+          },
+        ],
+      },
+    ];
+
+    const disabledWrapper = mount(
+      <NewTree
+        data={disabledData}
+        checkable
+        checkedKeys={[]}
+        disabledCheckedKeys={[2, 3]}
+      />
+    );
+
+    expect(
+      disabledWrapper
+        .find('Checkbox')
+        .at(0)
+        .prop('disabled')
+    ).toBe(true);
+
+    expect(
+      disabledWrapper
+        .find('Checkbox')
+        .at(1)
+        .prop('disabled')
+    ).toBe(true);
+
+    expect(
+      disabledWrapper
+        .find('Checkbox')
+        .at(2)
+        .prop('disabled')
+    ).toBe(true);
+
+    const disabledData2 = [
       {
         id: 1,
         title: 'root',
@@ -1124,146 +1182,44 @@ describe('new Tree', () => {
 
     let onCheckedData;
 
-    const wrapper = mount(
+    const disabledWrapper2 = mount(
       <NewTree
-        data={data}
-        defaultCheckedKeys={[6, 7]}
-        controlled
+        data={disabledData2}
+        checkedKeys={[4, 5, 10]}
         checkable
-        disabledCheckedKeys={[7]}
+        disabledCheckedKeys={[6, 7]}
         onCheck={checkedData => {
           onCheckedData = checkedData;
-          wrapper.setProps({
-            defaultCheckedKeys: onCheckedData,
+          disabledWrapper2.setProps({
+            checkedKeys: onCheckedData,
           });
         }}
       />
     );
 
     expect(
-      wrapper
-        .find('Checkbox')
-        .at(4)
-        .prop('checked')
-    ).toBe(false);
-
-    expect(
-      wrapper
+      disabledWrapper2
         .find('Checkbox')
         .at(0)
-        .prop('indeterminate')
-    ).toBe(false);
-
-    wrapper
-      .find('Checkbox input')
-      .at(0)
-      .simulate('change', { target: { checked: true } });
-    expect(
-      wrapper
-        .find('Checkbox')
-        .not({ disabled: true })
-        .everyWhere(n => n.prop('checked'))
-    ).toBe(false);
-    expect(
-      wrapper
-        .find('Checkbox')
-        .at(6)
-        .prop('checked')
-    ).toBe(true);
-    expect(onCheckedData.length).toBe(3);
-
-    wrapper
-      .find('Checkbox input')
-      .at(0)
-      .simulate('change', { target: { checked: false } });
-    expect(
-      wrapper
-        .find('Checkbox')
-        .at(6)
         .prop('checked')
     ).toBe(true);
 
     expect(
-      wrapper
-        .find('Checkbox')
-        .everyWhere(n => n.prop('checked') && n.prop('indeterminate'))
-    ).toBe(false);
-    expect(onCheckedData.length).toBe(2);
-
-    wrapper
-      .find('Checkbox input')
-      .at(1)
-      .simulate('change', { target: { checked: true } });
-    expect(
-      wrapper
-        .find('Checkbox')
-        .at(1)
-        .prop('checked')
-    ).toBe(true);
-    expect(
-      wrapper
-        .find('Checkbox')
-        .at(2)
-        .prop('checked')
-    ).toBe(false);
-    expect(
-      wrapper
-        .find('Checkbox')
-        .at(3)
-        .prop('checked')
-    ).toBe(false);
-    expect(
-      wrapper
-        .find('Checkbox')
-        .at(6)
-        .prop('checked')
-    ).toBe(true);
-    expect(onCheckedData.length).toBe(3);
-
-    wrapper
-      .find('Checkbox input')
-      .at(1)
-      .simulate('change', { target: { checked: false } });
-    expect(
-      wrapper
-        .find('Checkbox')
-        .at(6)
-        .prop('checked')
-    ).toBe(true);
-    expect(onCheckedData.length).toBe(2);
-
-    wrapper.setProps({ controlled: false });
-    expect(
-      wrapper
+      disabledWrapper2
         .find('Checkbox')
         .at(4)
-        .prop('checked')
+        .prop('disabled')
     ).toBe(true);
 
-    const disabledData = [
-      {
-        id: 1,
-        title: 'root',
-        children: [
-          {
-            id: 2,
-            title: 'son',
-          },
-          {
-            id: 3,
-            title: 'daughter',
-          },
-        ],
-      },
-    ];
-    const disabledWrapper = mount(
-      <NewTree data={disabledData} checkable disabledCheckedKeys={[2, 3]} />
-    );
+    disabledWrapper2
+      .find('Checkbox input')
+      .at(4)
+      .simulate('change', { target: { checked: false } });
 
     expect(
-      disabledWrapper
+      disabledWrapper2
         .find('Checkbox')
-        .at(0)
+        .at(4)
         .prop('disabled')
     ).toBe(true);
   });

--- a/packages/zent/src/tree/README_en-US.md
+++ b/packages/zent/src/tree/README_en-US.md
@@ -21,14 +21,13 @@ Tree widget is used to build and manipulate trees. such as files, organization s
 | ------------------- | --------------------------------------------------------------------------------------------------- | ------------------ | ---------- | -------------------- |
 | dataType            | data structure, default is tree                                                                     | string             | `'tree'`   | `'plain'`            |
 | data                | required, input data, identified by dataType                                                        | array              |            |                      |
-| renderKey           | (userNew)the key map for render node, see the following table                                       | object             |            |                      |
+| renderKey           | the key map for render node, see the following table                                                | object             |            |                      |
 | render              | you can customize function to render tree , the parameter is node data (includings children tree)   | func(data)         |            |                      |
 | operations          | custom operate, includes `name`, `icon`, `action`, `shouldRender` attributes                        | array[object]      |            |                      |
 | foldable            | whether to support item show and hide                                                               | bool               | `true`     |                      |
 | onCheck             | when you click checkbox, callback function will call, params is a array includes all nodes id array | func(data)         |            |                      |
-| checkable           | whether to support checkbox                                                                         | bool               | `true`     |                      |
-| controlled          | (useNew)with checkable, whether to support defaultCheckedKeys and defaultCheckedKeys controlled     | bool               | `false`    |                      |
-| defaultCheckedKeys  | default checked node id array                                                                       | array              |            |                      |
+| checkable           | whether to support checkbox                                                                         | bool               | `true`     |                      |                     |
+| checkedKeys         | checked node id array                                                                               | array              |            |                      |
 | disabledCheckedKeys | default disabled selected node id array                                                             | array              |            |                      |
 | size                | size                                                                                                | string             | `'medium'` | `'small'`, `'large'` |
 | commonStyle         | set entire tree style                                                                               | object             |            |                      |
@@ -39,7 +38,7 @@ Tree widget is used to build and manipulate trees. such as files, organization s
 | isRoot              | plain data, to determine whether the node is the api of the root node                               | func(node)         |            |                      |
 | loadMore            | return Promise func, support thenable callback, be used to asynchronously load more content         | func(data)         |            |                      |
 
-#### renderKey (useNew)
+#### renderKey
 
 The Key for customized for `data`.
 

--- a/packages/zent/src/tree/README_en-US.md
+++ b/packages/zent/src/tree/README_en-US.md
@@ -25,7 +25,7 @@ Tree widget is used to build and manipulate trees. such as files, organization s
 | render              | you can customize function to render tree , the parameter is node data (includings children tree)   | func(data)         |            |                      |
 | operations          | custom operate, includes `name`, `icon`, `action`, `shouldRender` attributes                        | array[object]      |            |                      |
 | foldable            | whether to support item show and hide                                                               | bool               | `true`     |                      |
-| onCheck             | when you click checkbox, callback function will call, params is a array includes all nodes id array | func(data)         |            |                      |
+| onCheck             | when you click checkbox, callback function will call, params is a checked id list and help info     | func(ids, helpInfo)|            |                      |
 | checkable           | whether to support checkbox                                                                         | bool               | `true`     |                      |                     |
 | checkedKeys         | checked node id array                                                                               | array              |            |                      |
 | disabledCheckedKeys | default disabled selected node id array                                                             | array              |            |                      |

--- a/packages/zent/src/tree/README_zh-CN.md
+++ b/packages/zent/src/tree/README_zh-CN.md
@@ -22,14 +22,13 @@ group: 导航
 | ------------------- | ----------------------------------------------------------- | ------------------ | ---------- | -------------------- |
 | dataType            | 数据类型, 默认为tree类型                                       | string             | `'tree'`   | `'plain'`            |
 | data                | 必填, 实际传入的数据, 根据dataType进行识别                       | array              |            |                      |
-| renderKey           | (新版)渲染节点所用到的key集合, 具体看下表                         | object             |            |                      |
+| renderKey           | 渲染节点所用到的key集合, 具体看下表                              | object             |            |                      |
 | render              | 自定义树条目渲染方法, 传入参数为该节点数据 (包含子树)               | func(data)         |            |                      |
 | operations          | 自定义操作, 包含 `name`, `icon`, `action`, `shouldRender` 属性 | array[object]      |            |                      |
 | foldable            | 是否支持点击条目时展开与收起动作                                 | bool               | `true`     |                      |
 | onCheck             | 点击checkbox的回调函数, 传入包含所有点击节点id数组                 | func(data)         |            |                      |
-| checkable           | 是否支持checkbox选择																					| bool               | `true`     |                      |
-| controlled          | (新版)checkable模式下，默认选中、禁选是否受控                     | bool               | `false`    |                      | 
-| defaultCheckedKeys  | 默认选中节点id数组                                             | array              |            |                      |
+| checkable           | 是否支持checkbox选择																					| bool               | `true`     |                      |                   | 
+| checkedKeys         | 选中节点id数组                                                | array              |            |                      |
 | disabledCheckedKeys | 默认禁选节点id数组                                             | array              |            |                      |
 | size                | 大小                                                         | string             | `'medium'` | `'small'`, `'large'` |
 | commonStyle         | 设置整个tree的外层style                                        | object             |            |                      |
@@ -40,7 +39,7 @@ group: 导航
 | isRoot              | plain数据类型，判断节点是否为根节点的api                          | func(node)         |            |                      |
 | loadMore            | 返回Promise的函数，必须支持then的回调, 用于节点异步加载更多内容      |  func(data)        |            |                      |
 
-#### renderKey (useNew)
+#### renderKey
 
 针对 `data` 使用到的部分key，定制化。
 

--- a/packages/zent/src/tree/README_zh-CN.md
+++ b/packages/zent/src/tree/README_zh-CN.md
@@ -26,7 +26,7 @@ group: 导航
 | render              | 自定义树条目渲染方法, 传入参数为该节点数据 (包含子树)               | func(data)         |            |                      |
 | operations          | 自定义操作, 包含 `name`, `icon`, `action`, `shouldRender` 属性 | array[object]      |            |                      |
 | foldable            | 是否支持点击条目时展开与收起动作                                 | bool               | `true`     |                      |
-| onCheck             | 点击checkbox的回调函数, 传入包含所有点击节点id数组                 | func(data)         |            |                      |
+| onCheck             | 点击checkbox的回调函数, 接受所选中节点的数组与帮助自定义的信息       | func(ids, helpInfo)|            |                      |
 | checkable           | 是否支持checkbox选择																					| bool               | `true`     |                      |                   | 
 | checkedKeys         | 选中节点id数组                                                | array              |            |                      |
 | disabledCheckedKeys | 默认禁选节点id数组                                             | array              |            |                      |

--- a/packages/zent/src/tree/Tree.tsx
+++ b/packages/zent/src/tree/Tree.tsx
@@ -1,31 +1,26 @@
 import * as React from 'react';
-import { PureComponent } from 'react';
+import { Component } from 'react';
 import isEqual from 'lodash-es/isEqual';
-import get from 'lodash-es/get';
-import forEach from 'lodash-es/forEach';
-import uniq from 'lodash-es/uniq';
-import assign from 'lodash-es/assign';
+import _get from 'lodash-es/get';
+
+import _union from 'lodash-es/union';
 import classnames from 'classnames';
 
 import AnimateHeight from '../utils/component/AnimateHeight';
 import Checkbox from '../checkbox';
 import Loading from './components/Loading';
 
-const DEFAULT_REANDER_KEY = {
-  id: 'id',
-  title: 'title',
-  children: 'children',
-  parentId: 'parentId',
-};
-
-export interface ITreeData {
-  id: number | string;
-  title: number | string;
-  children?: ITreeData[];
-  parendId?: string | number;
-  expand?: boolean;
-  isLeaf?: boolean;
-}
+import createStateByProps, {
+  ICreateStateByPropsParams,
+} from './utils/createStateByProps';
+import correctMark from './utils/correctMark';
+import correctExpand from './utils/correctExpand';
+import {
+  ITreeData,
+  RootIdArray,
+  IRootInfoMap,
+  IRenderKey,
+} from './utils/common';
 
 export interface ITreeOperation {
   name: string;
@@ -34,431 +29,121 @@ export interface ITreeOperation {
   shouldRender?: (data: ITreeData) => boolean;
 }
 
-export interface ITreeProps {
-  useNew?: boolean;
-  dataType?: 'tree' | 'plain';
-  data: ITreeData[];
-  renderKey?: {
-    id?: string;
-    title?: string;
-    children?: string;
-    parentId?: string;
-  };
+// onCheck second param to help
+export interface IOncheckHelpInfo {
+  // which root click
+  currentRoot: ITreeData;
+  // all disableNode
+  disabled: ITreeData[];
+  // all checkedNode
+  all: ITreeData[];
+  // only parent or childless checkedNode
+  top: ITreeData[];
+  // only least child checkedNode
+  bottom: ITreeData[];
+}
+
+export interface ITreeProps extends ICreateStateByPropsParams {
   render?: (data: ITreeData, isExpanded?: boolean) => React.ReactNode;
   operations?: ITreeOperation[];
   foldable?: boolean;
-  onCheck?: (data: Array<number | string>) => void;
-  checkable?: boolean;
-  controlled?: boolean;
-  defaultCheckedKeys?: Array<number | string>;
-  disabledCheckedKeys?: Array<number | string>;
+  onCheck?: (selected: RootIdArray, info: IOncheckHelpInfo) => void;
   size?: 'medium' | 'small' | 'large';
   commonStyle?: React.CSSProperties;
-  expandAll?: boolean;
   onExpand?: (data: ITreeData, config: { isExpanded: boolean }) => void;
   autoExpandOnSelect?: boolean;
   onSelect?: (data: ITreeData, target: HTMLSpanElement) => void;
-  isRoot?: (data: ITreeData) => boolean;
-  loadMore?: (data: ITreeData) => Promise<any>;
   prefix?: string;
 }
 
-export class Tree extends PureComponent<ITreeProps, any> {
-  renderKeyMap = DEFAULT_REANDER_KEY;
+export interface ITreeState {
+  preProps: ITreeProps;
+  tree: ITreeData[];
+  rootInfoMap: IRootInfoMap;
+  expandNode: RootIdArray;
+  checkedNode: RootIdArray;
+  disabledNode: RootIdArray;
+  renderKey: IRenderKey;
+  loadingNode: RootIdArray;
+}
 
+export class Tree extends Component<ITreeProps, ITreeState> {
   static defaultProps = {
     autoExpandOnSelect: true,
     dataType: 'tree',
     foldable: true,
     checkable: false,
-    controlled: false,
     size: 'medium',
     prefix: 'zent',
-    renderKey: DEFAULT_REANDER_KEY,
   };
 
-  constructor(props) {
+  constructor(props: ITreeProps) {
     super(props);
-    const {
-      tree,
-      treeMap,
-      checkMap,
-      expandNode,
-      checkedNode,
-      disabledNode,
-      halfCheckNode,
-    } = this.formatDataByProp(props);
-
     this.state = {
-      treeMap,
-      expandNode,
-      tree,
-      checkMap,
-      checkedNode,
-      disabledNode,
-      halfCheckNode,
+      preProps: props,
       loadingNode: [],
+      ...createStateByProps(props),
     };
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (!isEqual(nextProps.data, this.props.data)) {
-      const formatData = this.formatDataByProp(nextProps);
-      let nextExpandNode = formatData.expandNode;
+  static getDerivedStateFromProps(nextProps: ITreeProps, state: ITreeState) {
+    const { preProps } = state;
 
-      // 只有在 loadMore 状态下，我会保持原有打开状态
-      if (this.props.loadMore || nextProps.loadMore) {
-        const { expandNode, tree } = this.state;
-
-        nextExpandNode = this.filterExpandNode(
-          {
-            tree,
-            expandNode,
-          },
-          formatData
-        );
-      }
-
-      this.setState({
-        treeMap: formatData.treeMap,
-        tree: formatData.tree,
-        expandNode: nextExpandNode,
-        checkMap: formatData.checkMap,
-        checkedNode: formatData.checkedNode,
-        disabledNode: formatData.disabledNode,
-        halfCheckNode: formatData.halfCheckNode,
-      });
-      return;
-    }
-
+    // 需要重新计算
     if (
-      nextProps.checkable &&
-      (!isEqual(this.props.defaultCheckedKeys, nextProps.defaultCheckedKeys) ||
-        !isEqual(
-          this.props.disabledCheckedKeys,
-          nextProps.disabledCheckedKeys
-        ) ||
-        this.props.controlled !== nextProps.controlled)
+      !isEqual(nextProps.data, preProps.data) ||
+      !isEqual(nextProps.renderKey, preProps.renderKey) ||
+      nextProps.expandAll !== preProps.expandAll ||
+      nextProps.loadMore !== preProps.loadMore
     ) {
-      const { checkedNode, disabledNode, halfCheckNode } = this.formatCheckInfo(
-        {
-          defaultCheckedKeys: nextProps.defaultCheckedKeys,
-          disabledCheckedKeys: nextProps.disabledCheckedKeys,
-          checkMap: this.state.checkMap,
-          tree: this.state.tree,
-          checkable: nextProps.checkable,
-          controlled: nextProps.controlled,
-        }
-      );
+      const formatData = createStateByProps(nextProps);
+      let { expandNode } = formatData;
 
-      this.setState({
-        checkedNode,
-        disabledNode,
-        halfCheckNode,
-      });
-    }
-  }
+      // // 只有在 loadMore 状态下，我会保持原有打开状态
+      // // if (preProps.loadMore || nextProps.loadMore) {
+      // 任何情况下都做保留
+      expandNode = correctExpand(state, formatData);
+      // // }
 
-  formatDataByProp({
-    data,
-    isRoot,
-    renderKey,
-    dataType,
-    isExpandAll,
-    loadMore,
-    checkable,
-    controlled,
-    disabledCheckedKeys = [],
-    defaultCheckedKeys = [],
-  }) {
-    this.renderKeyMap = assign({}, DEFAULT_REANDER_KEY, renderKey);
-    const { children, parentId, id } = this.renderKeyMap;
-    const treeMap = {};
-    const expandNode = [];
-    const checkMap = {};
-    let roots = [];
-
-    if (dataType === 'plain') {
-      const map = {};
-      const orderRecord = [];
-
-      data.forEach((node, index) => {
-        if (!node.isLeaf) {
-          node[children] = [];
-        }
-
-        map[node[id]] = node;
-        orderRecord[index] = node[id];
-      });
-
-      orderRecord.forEach(key => {
-        const node = map[key];
-        const isRootNode =
-          (isRoot && isRoot(node)) ||
-          node[parentId] === 0 ||
-          node[parentId] === undefined ||
-          node[parentId] === '0';
-
-        if (isRootNode) {
-          roots.push(node);
-        } else if (map[node[parentId]]) {
-          // 防止只删除父节点没有子节点的情况
-          map[node[parentId]][children].push(node);
-        }
-      });
-    } else if (dataType === 'tree') {
-      roots = data;
+      return {
+        preProps: nextProps,
+        ...formatData,
+        expandNode,
+      };
     }
 
-    this.collector({
-      isExpandAll,
-      loadMore,
-      tree: roots,
-      parentPath: [],
-      exPandCb: rootId => {
-        expandNode.push(rootId);
-      },
-      mapCb: (rootId, path) => {
-        treeMap[rootId] = path;
-      },
-      checkCb: (pId, cId) => {
-        if (!checkable) {
-          return;
-        }
-
-        if (checkMap[cId]) {
-          checkMap[cId].unshift(cId);
-        } else {
-          checkMap[cId] = [cId];
-        }
-
-        if (pId !== undefined) {
-          checkMap[pId] = checkMap[pId] || [];
-          checkMap[pId] = checkMap[pId].concat(checkMap[cId]);
-        }
-      },
-    });
-
-    const { checkedNode, disabledNode, halfCheckNode } = this.formatCheckInfo({
-      tree: roots,
-      checkMap,
-      checkable,
-      controlled,
-      disabledCheckedKeys,
-      defaultCheckedKeys,
-    });
-
-    return {
-      treeMap,
-      expandNode,
-      checkMap,
-      tree: roots,
-      checkedNode,
-      disabledNode,
-      halfCheckNode,
-    };
-  }
-
-  formatCheckInfo({
-    defaultCheckedKeys,
-    disabledCheckedKeys,
-    checkMap,
-    tree,
-    checkable,
-    controlled,
-  }) {
-    let checkedNode = [];
-    let disabledNode = [];
-    let halfCheckNode = [];
-
-    if (checkable) {
-      if (!controlled) {
-        const realChecked = uniq(
-          defaultCheckedKeys.reduce((total, rootId) => {
-            return total.concat(checkMap[rootId]);
-          }, [])
+    if (nextProps.checkable) {
+      const newState: Partial<ITreeState> = {};
+      if (
+        !isEqual(preProps.disabledCheckedKeys, nextProps.disabledCheckedKeys)
+      ) {
+        newState.disabledNode = correctMark(
+          nextProps.disabledCheckedKeys,
+          state.rootInfoMap
         );
-        const realDisabled = uniq(
-          disabledCheckedKeys.reduce((total, rootId) => {
-            return total.concat(checkMap[rootId]);
-          }, [])
+      }
+      if (!isEqual(preProps.checkedKeys, nextProps.checkedKeys)) {
+        newState.checkedNode = correctMark(
+          nextProps.checkedKeys,
+          state.rootInfoMap,
+          newState.disabledNode || state.disabledNode
         );
-
-        const correntCheck = this.correctCheckInfo({
-          checkMap,
-          tree,
-          checkedNode: realChecked,
-          disabledNode: realDisabled,
-          isInital: true,
+        newState.checkedNode = newState.checkedNode.filter(id => {
+          // 之前的并没被禁用 or 之前就被选中了,但是是禁用的
+          return (
+            state.disabledNode.indexOf(id) === -1 ||
+            state.checkedNode.indexOf(id) > -1
+          );
         });
-
-        checkedNode = correntCheck.checkedNode;
-        disabledNode = correntCheck.disabledNode;
-        halfCheckNode = correntCheck.halfCheckNode;
-      } else {
-        checkedNode = defaultCheckedKeys;
-        disabledNode = disabledCheckedKeys;
       }
+      return newState;
     }
 
-    return {
-      checkedNode,
-      disabledNode,
-      halfCheckNode,
-    };
+    return null;
   }
 
-  collector({
-    isExpandAll,
-    loadMore,
-    tree,
-    parentPath,
-    exPandCb,
-    mapCb,
-    checkCb,
-    parentId,
-  }: any) {
-    const { children, id } = this.renderKeyMap;
-
-    tree.forEach((item, index) => {
-      const currentPath = parentPath.concat(index);
-      mapCb(item[id], currentPath);
-
-      if (
-        this.isParentNode(item, loadMore) &&
-        (item.expand || (item.expand === undefined && isExpandAll))
-      ) {
-        exPandCb(item[id]);
-      }
-
-      if (item[children]) {
-        this.collector({
-          isExpandAll,
-          tree: item[children],
-          parentPath: currentPath,
-          exPandCb,
-          mapCb,
-          checkCb,
-          parentId: item[id],
-        });
-      }
-
-      checkCb(parentId, item[id]);
-    });
-  }
-
-  filterExpandNode(current, next) {
-    const { id, children } = this.renderKeyMap;
-    const { tree: cTree, expandNode: cExpandNode } = current;
-    const { tree: nTree, treeMap: nTreeMap, expandNode: nExpandNode } = next;
-
-    // use .values will add a polyfill, just for jest
-    // Object.values(nTreeMap).forEach(path => {
-    forEach(nTreeMap, pathKey => {
-      const nPath = pathKey.join(`.${children}.`);
-      const cItem = get(cTree, nPath);
-      const nItem = get(nTree, nPath);
-      const nId = nItem[id];
-
-      // 如果是续费成员 cItem[id] === nId
-      // 当前打开存在，下个打开不存在
-      if (
-        cItem &&
-        cItem[id] === nId &&
-        cExpandNode.indexOf(nId) > -1 &&
-        nExpandNode.indexOf(nId) === -1
-      ) {
-        nExpandNode.push(nId);
-      }
-    });
-    return nExpandNode;
-  }
-
-  isParentNode(root, loadMore) {
-    // loadMore 的 parent children 边界有点模糊
-    const { children } = this.renderKeyMap;
-    return !!(
-      !root.isLeaf &&
-      (loadMore || (root[children] && root[children].length > 0))
-    );
-  }
-
-  correctCheckInfo({ checkedNode, disabledNode, tree, isInital }: any) {
-    const { id, children } = this.renderKeyMap;
-    const tempParentCheckdMap = {};
-    const tempDisabled = disabledNode;
-    const tempHalfCheck = [];
-    let tempChecked = checkedNode;
-
-    tree.forEach(item => {
-      shouldNodeCheck(item);
-    });
-
-    function shouldNodeCheck(root, pId?: any) {
-      const rootId = root[id];
-      const rootChildren = root[children];
-
-      if (
-        (isInital || tempChecked.indexOf(rootId) === -1) &&
-        rootChildren &&
-        rootChildren.length
-      ) {
-        const childLength = rootChildren.length;
-        const rootCount = (tempParentCheckdMap[rootId] = {
-          checkedCount: 0,
-          disabledCount: 0,
-          validCheckedCount: 0,
-        });
-
-        rootChildren.forEach(child => {
-          shouldNodeCheck(child, rootId);
-        });
-
-        const validCheckedLength = childLength - rootCount.disabledCount;
-        const validCheckedCount = rootCount.validCheckedCount;
-
-        if (validCheckedCount) {
-          if (validCheckedCount === validCheckedLength) {
-            tempChecked.push(rootId);
-          } else {
-            tempHalfCheck.push(rootId);
-          }
-        } else {
-          tempChecked = tempChecked.filter(cid => cid !== rootId);
-        }
-
-        if (
-          rootCount.disabledCount === childLength &&
-          tempDisabled.indexOf(rootId) === -1
-        ) {
-          tempDisabled.push(rootId);
-        }
-      }
-
-      if (pId) {
-        if (tempChecked.indexOf(rootId) > -1) {
-          tempParentCheckdMap[pId].checkedCount++;
-
-          if (tempDisabled.indexOf(rootId) === -1) {
-            tempParentCheckdMap[pId].validCheckedCount++;
-          }
-        }
-
-        if (tempDisabled.indexOf(rootId) > -1) {
-          tempParentCheckdMap[pId].disabledCount++;
-        }
-      }
-    }
-
-    return {
-      checkedNode: tempChecked,
-      disabledNode: tempDisabled,
-      halfCheckNode: tempHalfCheck,
-    };
-  }
-
-  handleExpandClick(root, e) {
-    const { id } = this.renderKeyMap;
+  handleExpandClick(root: ITreeData, e: React.MouseEvent) {
+    const { id } = this.state.renderKey;
     const { loadMore, foldable } = this.props;
     if (!foldable) {
       return;
@@ -470,7 +155,7 @@ export class Tree extends PureComponent<ITreeProps, any> {
     if (loadMore) {
       if (!root.children || root.children.length === 0) {
         e.persist();
-        const nextLoadingNode = loadingNode.concat(root[id]);
+        const nextLoadingNode: RootIdArray = loadingNode.concat(root[id]);
         this.setState({ loadingNode: nextLoadingNode });
         loadMore(root)
           .then(() => {
@@ -490,7 +175,7 @@ export class Tree extends PureComponent<ITreeProps, any> {
     this.handleExpand(root, isSwitcher);
   }
 
-  handleExpand(root, isSwitcher) {
+  handleExpand(root: ITreeData, isSwitcher: boolean) {
     const { onExpand, autoExpandOnSelect } = this.props;
     const { expandNode } = this.state;
 
@@ -498,7 +183,7 @@ export class Tree extends PureComponent<ITreeProps, any> {
       return;
     }
 
-    const { id } = this.renderKeyMap;
+    const { id } = this.state.renderKey;
     const activeId = root[id];
     let newExpandNode = expandNode.slice();
     let isClose = true;
@@ -521,68 +206,97 @@ export class Tree extends PureComponent<ITreeProps, any> {
     }
   }
 
-  handleCheckboxClick(root) {
-    const { onCheck, controlled } = this.props;
-    const rootId = root[this.renderKeyMap.id];
-    let { checkedNode, disabledNode, tree, checkMap } = this.state;
+  handleCheckboxClick(root: ITreeData) {
+    const { onCheck } = this.props;
+    let { checkedNode, disabledNode, rootInfoMap, renderKey } = this.state;
+    const rootId = root[renderKey.id];
 
-    // 受控模式
-    if (controlled) {
-      if (checkedNode.indexOf(rootId) > -1) {
-        checkedNode = checkedNode.filter(id => id !== rootId);
-      } else {
-        checkedNode = checkedNode.concat(rootId);
-      }
-      onCheck && onCheck(checkedNode.slice());
+    if (checkedNode.indexOf(rootId) > -1) {
+      checkedNode = checkedNode.filter(id => {
+        // 自己
+        if (id === rootId) {
+          return false;
+        }
 
-      // zent 模式
-    } else {
-      if (checkedNode.indexOf(rootId) > -1) {
-        checkedNode = checkedNode.filter(id => {
-          return (
-            disabledNode.indexOf(id) > -1 ||
-            (checkMap[id].indexOf(rootId) === -1 &&
-              checkMap[rootId].indexOf(id) === -1)
-          );
-        });
-      } else {
-        checkedNode = uniq(
-          checkedNode.concat(
-            checkMap[rootId].filter(id => disabledNode.indexOf(id) === -1)
-          )
-        );
-      }
+        // 如果被禁用
+        if (disabledNode.indexOf(id) > -1) {
+          return true;
+        }
 
-      const checkInfo = this.correctCheckInfo({
-        checkedNode,
-        disabledNode,
-        tree,
-        checkMap,
+        // 父类包含了该节点
+        if (rootInfoMap[id].includes.indexOf(rootId) > -1) {
+          return false;
+        }
+
+        // 他的子类
+        if (rootInfoMap[rootId].includes.indexOf(id) > -1) {
+          return false;
+        }
+
+        return true;
       });
-
-      this.setState(checkInfo);
-
-      onCheck && onCheck(checkInfo.checkedNode.slice());
-    }
-  }
-
-  renderSwitcher(root, isParent) {
-    if (isParent) {
-      return (
-        <i
-          className="switcher"
-          onClick={e => {
-            this.handleExpandClick(root, e);
-          }}
-        />
+    } else {
+      checkedNode = correctMark(
+        [rootId, ...checkedNode],
+        rootInfoMap,
+        disabledNode
       );
     }
 
-    return null;
+    /**
+     * all 所有选中节点
+     * disabled 所有
+     */
+    const helperInfo: IOncheckHelpInfo = {
+      currentRoot: root,
+      disabled: disabledNode.map(id => rootInfoMap[id].root),
+      all: [],
+      top: [],
+      bottom: [],
+    };
+    checkedNode.forEach(id => {
+      helperInfo.all.push(rootInfoMap[id].root);
+
+      // top
+      if (
+        !rootInfoMap[id].parentId ||
+        checkedNode.indexOf(
+          rootInfoMap[rootInfoMap[id].parentId as string].id
+        ) === -1
+      ) {
+        helperInfo.top.push(rootInfoMap[id].root);
+      }
+
+      // bottom
+      if (
+        rootInfoMap[id].includes.length === 1 ||
+        rootInfoMap[id].includes.every(
+          child => checkedNode.indexOf(child) === -1
+        )
+      ) {
+        helperInfo.bottom.push(rootInfoMap[id].root);
+      }
+    });
+
+    onCheck && onCheck(checkedNode, helperInfo);
   }
 
-  renderContent(root, isParent, isExpanded) {
-    const { title } = this.renderKeyMap;
+  renderSwitcher(root: ITreeData) {
+    return (
+      <i
+        className="switcher"
+        onClick={e => {
+          this.handleExpandClick(root, e);
+        }}
+      />
+    );
+  }
+
+  renderContent(root: ITreeData, isExpanded: boolean) {
+    const {
+      rootInfoMap,
+      renderKey: { id, title },
+    } = this.state;
     const { render, onSelect } = this.props;
     return (
       <span
@@ -590,7 +304,7 @@ export class Tree extends PureComponent<ITreeProps, any> {
         onClick={e => {
           onSelect && onSelect(root, e.currentTarget);
 
-          if (isParent) {
+          if (rootInfoMap[root[id]].isParent) {
             this.handleExpandClick(root, e);
           }
         }}
@@ -600,28 +314,38 @@ export class Tree extends PureComponent<ITreeProps, any> {
     );
   }
 
-  renderCheckbox(root) {
+  renderCheckbox(root: ITreeData) {
     const { checkable } = this.props;
-    const { checkedNode, disabledNode, halfCheckNode } = this.state;
+    const { checkedNode, disabledNode, rootInfoMap, renderKey } = this.state;
 
     if (!checkable) {
       return null;
     }
 
-    const rootId = root[this.renderKeyMap.id];
+    const rootId = root[renderKey.id];
+    const checked = checkedNode.indexOf(rootId) > -1;
+    const countChild = rootInfoMap[rootId].includes.filter(
+      id => disabledNode.indexOf(id) === -1
+    );
+    const halfChecked = !!(
+      !checked &&
+      countChild.length &&
+      countChild.some(id => checkedNode.indexOf(id) > -1)
+    );
 
     return (
       <Checkbox
         onChange={this.handleCheckboxClick.bind(this, root)}
-        checked={checkedNode.indexOf(rootId) > -1}
+        checked={checked}
         disabled={disabledNode.indexOf(rootId) > -1}
-        indeterminate={halfCheckNode.indexOf(rootId) > -1}
+        indeterminate={halfChecked}
+        width={root[renderKey.title]}
       />
     );
   }
 
-  renderOperations(root, isExpanded) {
-    const { id } = this.renderKeyMap;
+  renderOperations(root: ITreeData, isExpanded: boolean) {
+    const { id } = this.state.renderKey;
     const opts = this.props.operations;
 
     if (opts) {
@@ -650,25 +374,30 @@ export class Tree extends PureComponent<ITreeProps, any> {
     return null;
   }
 
-  renderTreeNodes(roots) {
-    const { id, children } = this.renderKeyMap;
-    const { expandNode, loadingNode } = this.state;
-    const { loadMore, prefix } = this.props;
+  renderTreeNodes(roots: ITreeData[]) {
+    const {
+      expandNode,
+      loadingNode,
+      rootInfoMap,
+      renderKey: { id, children },
+    } = this.state;
+    const { prefix } = this.props;
     if (roots && roots.length > 0) {
       return roots.map(root => {
-        const isShowChildren = expandNode.indexOf(root[id]) > -1;
+        const rootId = root[id];
+        const isShowChildren = expandNode.indexOf(rootId) > -1;
         const barClassName = classnames(`${prefix}-tree-bar`, {
           off: !isShowChildren,
         });
-        const isParent = this.isParentNode(root, loadMore);
+
         return (
-          <li key={root[id]}>
+          <li key={rootId}>
             <div className={barClassName}>
-              {this.renderSwitcher(root, isParent)}
+              {rootInfoMap[rootId].isParent ? this.renderSwitcher(root) : null}
               <div className="zent-tree-node">
                 {this.renderCheckbox(root)}
-                {loadingNode.indexOf(root[id]) > -1 ? <Loading /> : null}
-                {this.renderContent(root, isParent, isShowChildren)}
+                {loadingNode.indexOf(rootId) > -1 ? <Loading /> : null}
+                {this.renderContent(root, isShowChildren)}
                 {this.renderOperations(root, isShowChildren)}
               </div>
             </div>
@@ -678,7 +407,7 @@ export class Tree extends PureComponent<ITreeProps, any> {
                 duration={200}
                 height={isShowChildren ? 'auto' : 0}
               >
-                <ul key={`ul-${root[id]}`} className={`${prefix}-tree-child`}>
+                <ul key={`ul-${rootId}`} className={`${prefix}-tree-child`}>
                   {this.renderTreeNodes(root[children])}
                 </ul>
               </AnimateHeight>
@@ -687,6 +416,8 @@ export class Tree extends PureComponent<ITreeProps, any> {
         );
       });
     }
+
+    return null;
   }
 
   render() {

--- a/packages/zent/src/tree/Tree.tsx
+++ b/packages/zent/src/tree/Tree.tsx
@@ -17,9 +17,9 @@ import correctMark from './utils/correctMark';
 import correctExpand from './utils/correctExpand';
 import {
   ITreeData,
-  RootIdArray,
-  IRootInfoMap,
-  IRenderKey,
+  TreeRootIdArray,
+  ITreeRootInfoMap,
+  ITreeRenderKey,
 } from './utils/common';
 
 export interface ITreeOperation {
@@ -30,7 +30,7 @@ export interface ITreeOperation {
 }
 
 // onCheck second param to help
-export interface IOncheckHelpInfo {
+export interface ITreeOncheckHelpInfo {
   // which root click
   currentRoot: ITreeData;
   // all disableNode
@@ -47,7 +47,7 @@ export interface ITreeProps extends ICreateStateByPropsParams {
   render?: (data: ITreeData, isExpanded?: boolean) => React.ReactNode;
   operations?: ITreeOperation[];
   foldable?: boolean;
-  onCheck?: (selected: RootIdArray, info: IOncheckHelpInfo) => void;
+  onCheck?: (selected: TreeRootIdArray, info: ITreeOncheckHelpInfo) => void;
   size?: 'medium' | 'small' | 'large';
   commonStyle?: React.CSSProperties;
   onExpand?: (data: ITreeData, config: { isExpanded: boolean }) => void;
@@ -59,12 +59,12 @@ export interface ITreeProps extends ICreateStateByPropsParams {
 export interface ITreeState {
   preProps: ITreeProps;
   tree: ITreeData[];
-  rootInfoMap: IRootInfoMap;
-  expandNode: RootIdArray;
-  checkedNode: RootIdArray;
-  disabledNode: RootIdArray;
-  renderKey: IRenderKey;
-  loadingNode: RootIdArray;
+  rootInfoMap: ITreeRootInfoMap;
+  expandNode: TreeRootIdArray;
+  checkedNode: TreeRootIdArray;
+  disabledNode: TreeRootIdArray;
+  renderKey: ITreeRenderKey;
+  loadingNode: TreeRootIdArray;
 }
 
 export class Tree extends Component<ITreeProps, ITreeState> {
@@ -155,7 +155,7 @@ export class Tree extends Component<ITreeProps, ITreeState> {
     if (loadMore) {
       if (!root.children || root.children.length === 0) {
         e.persist();
-        const nextLoadingNode: RootIdArray = loadingNode.concat(root[id]);
+        const nextLoadingNode: TreeRootIdArray = loadingNode.concat(root[id]);
         this.setState({ loadingNode: nextLoadingNode });
         loadMore(root)
           .then(() => {
@@ -247,7 +247,7 @@ export class Tree extends Component<ITreeProps, ITreeState> {
      * all 所有选中节点
      * disabled 所有
      */
-    const helperInfo: IOncheckHelpInfo = {
+    const helperInfo: ITreeOncheckHelpInfo = {
       currentRoot: root,
       disabled: disabledNode.map(id => rootInfoMap[id].root),
       all: [],

--- a/packages/zent/src/tree/demos/option.md
+++ b/packages/zent/src/tree/demos/option.md
@@ -4,9 +4,6 @@ zh-CN:
 	title: 可选树
 	index: 首页
 	tree: 树
-	switch: 使用新版
-	radio1: 默认模式
-	radio2: 受控模式
 	title1: 杭州有赞科技有限公司
 	title2: 技术
 	title3: 后端
@@ -22,9 +19,6 @@ en-US:
 	title: Optional Tree
 	index: Index
 	tree: Tree
-	switch: useNew
-	radio1: default
-	radio2: controllable
 	title1: Hangzhou Youzan Technology Co. Ltd
 	title2: Engineer
 	title3: Back End Engineer
@@ -40,9 +34,8 @@ en-US:
 
 
 ```jsx
-import { Tree, Radio, Switch } from 'zent';
+import { Tree } from 'zent';
 
-const RadioGroup = Radio.Group;
 const treeData = [{
 	id: 1,
 	title: '{i18n.title1}',
@@ -80,97 +73,32 @@ const treeData = [{
 
 class TreeExample extends React.Component {
 	state = {
-		useNew: true,
-		radioValue: 'default',
-		controlled: false,
-		defaultCheckedKeys: [3, 5],
-		disabledCheckedKeys: [4, 7, 9]
+		checkedKeys: [3, 5, 22],
+		disabledCheckedKeys: [4, 7, 9, 22]
 	}
 
-	onUseNewChange = (checked) => {
+	onCheck = (checked, helpInfo) => {
+		console.log(checked, helpInfo);
 		this.setState({
-			useNew: checked,
+			checkedKeys: checked
 		});
 	}
 
-	onControllableChange = (e) => {
-		if (e.target.value === 'controllable') {
-			this.setState({
-				controlled: true,
-				radioValue: 'controllable'
-			});
-			return;
-		}
-
-		if (e.target.value === 'default') {
-			this.setState({
-				controlled: false,
-				radioValue: 'default'
-			});
-		}
-	}
-
-	onCheck = (checked) => {
-		console.log(checked);
-
-		if (this.state.controlled) {
-			this.setState({
-				defaultCheckedKeys: checked
-			});
-		}
-	}
-
-	renderNew() {
-		const { controlled, defaultCheckedKeys, disabledCheckedKeys, radioValue } = this.state;
+	render() {
+		const { checkedKeys, disabledCheckedKeys } = this.state;
 
 		return (
 			<div>
-				<RadioGroup onChange={this.onControllableChange} value={radioValue}>
-					<Radio value="default">{i18n.radio1}</Radio>
-					<Radio value="controllable">{i18n.radio2}</Radio>
-				</RadioGroup>
-				<hr/>
 				<Tree
-					useNew
 					checkable
-					controlled={controlled}
 					size="small"
 					data={treeData}
 					onCheck={this.onCheck}
-					defaultCheckedKeys={defaultCheckedKeys}
+					checkedKeys={checkedKeys}
 					disabledCheckedKeys={disabledCheckedKeys}
 				/>
 			</div>
-		)
-	}
-
-	renderOld() {
-		const { defaultCheckedKeys, disabledCheckedKeys } = this.state;
-
-		return (
-			<Tree
-				checkable
-				size="small"
-				data={treeData}
-				onCheck={this.onCheck}
-				defaultCheckedKeys={defaultCheckedKeys}
-				disabledCheckedKeys={disabledCheckedKeys}
-			/>
-		)
-	}
-
-	render() {
-		const { useNew } = this.state;
-
-		return (
-			<div>
-				<div style={{ marginBottom: 15}}>
-					{i18n.switch}  <Switch size="small" checked={useNew} onChange={this.onUseNewChange} />
-				</div>
-				
-				{useNew ? this.renderNew() : this.renderOld()}
-			</div>
-		)
+		);
 	}
 }
 

--- a/packages/zent/src/tree/index.ts
+++ b/packages/zent/src/tree/index.ts
@@ -1,8 +1,4 @@
 import Tree from './Tree';
 export * from './utils/common';
-export * from './utils/correctExpand';
-export * from './utils/correctMark';
-export * from './utils/createStateByProps';
-export * from './utils/getJudgeInfo';
 export * from './Tree';
 export default Tree;

--- a/packages/zent/src/tree/index.ts
+++ b/packages/zent/src/tree/index.ts
@@ -1,3 +1,8 @@
 import Tree from './Tree';
+export * from './utils/common';
+export * from './utils/correctExpand';
+export * from './utils/correctMark';
+export * from './utils/createStateByProps';
+export * from './utils/getJudgeInfo';
 export * from './Tree';
 export default Tree;

--- a/packages/zent/src/tree/utils/common.ts
+++ b/packages/zent/src/tree/utils/common.ts
@@ -1,0 +1,42 @@
+type TArray<T> = T[];
+export type RootIdArray = TArray<string | number>;
+
+// 默认节点渲染key
+export const DEFAULT_REANDER_KEY: IRenderKey = {
+  id: 'id',
+  title: 'title',
+  children: 'children',
+  parentId: 'parentId',
+};
+
+export interface IRenderKey {
+  id: string;
+  title: string;
+  children: string;
+  parentId: string;
+}
+
+export interface ITreeData {
+  // [DEFAULT_REANDER_KEY[id]]?: string | number;
+  // [DEFAULT_REANDER_KEY[parendId]]?: string | number;
+  // [DEFAULT_REANDER_KEY[title]]?: React.ReactNode;
+  // [DEFAULT_REANDER_KEY[children]]?: ITreeData[];
+  expand?: boolean;
+  isLeaf?: boolean;
+  [key: string]: any;
+}
+
+export interface IRootInfoMap {
+  [key: string]: {
+    id: string | number;
+    parentId?: string | number;
+    root: ITreeData;
+    isExpand: boolean;
+    isParent: boolean;
+    son: RootIdArray;
+    includes: RootIdArray;
+    // 节点的选择联动集合 { nodeId: id[] }
+    // id[]: [nodeId, nodeId.children[1]Id, nodeId.children[2]Id, .... nodeId.children[1][...].childrenn[N]Id]
+    // 可以根据当前node的id, 查找它将会影响的子孙节点
+  };
+}

--- a/packages/zent/src/tree/utils/common.ts
+++ b/packages/zent/src/tree/utils/common.ts
@@ -1,15 +1,15 @@
 type TArray<T> = T[];
-export type RootIdArray = TArray<string | number>;
+export type TreeRootIdArray = TArray<string | number>;
 
 // 默认节点渲染key
-export const DEFAULT_REANDER_KEY: IRenderKey = {
+export const DEFAULT_REANDER_KEY: ITreeRenderKey = {
   id: 'id',
   title: 'title',
   children: 'children',
   parentId: 'parentId',
 };
 
-export interface IRenderKey {
+export interface ITreeRenderKey {
   id: string;
   title: string;
   children: string;
@@ -26,15 +26,15 @@ export interface ITreeData {
   [key: string]: any;
 }
 
-export interface IRootInfoMap {
+export interface ITreeRootInfoMap {
   [key: string]: {
     id: string | number;
     parentId?: string | number;
     root: ITreeData;
     isExpand: boolean;
     isParent: boolean;
-    son: RootIdArray;
-    includes: RootIdArray;
+    son: TreeRootIdArray;
+    includes: TreeRootIdArray;
     // 节点的选择联动集合 { nodeId: id[] }
     // id[]: [nodeId, nodeId.children[1]Id, nodeId.children[2]Id, .... nodeId.children[1][...].childrenn[N]Id]
     // 可以根据当前node的id, 查找它将会影响的子孙节点

--- a/packages/zent/src/tree/utils/correctExpand.ts
+++ b/packages/zent/src/tree/utils/correctExpand.ts
@@ -1,0 +1,28 @@
+import { RootIdArray, ITreeData, IRootInfoMap } from './common';
+
+export interface ICurrentParams {
+  tree: ITreeData[];
+  expandNode: RootIdArray;
+}
+
+export interface INextParams {
+  expandNode: RootIdArray;
+  rootInfoMap: IRootInfoMap;
+}
+
+// 纠正 ExpandNode (防止loadMore 之后，之前打开的expand记录丢失)
+export default function filterExpandNode(
+  current: ICurrentParams,
+  next: INextParams
+): RootIdArray {
+  const { expandNode: cExpandNode } = current;
+  const { rootInfoMap, expandNode: nExpandNode } = next;
+
+  cExpandNode.forEach(rootId => {
+    if (nExpandNode.indexOf(rootId) === -1 && rootInfoMap[rootId]) {
+      nExpandNode.push(rootId);
+    }
+  });
+
+  return nExpandNode;
+}

--- a/packages/zent/src/tree/utils/correctExpand.ts
+++ b/packages/zent/src/tree/utils/correctExpand.ts
@@ -1,20 +1,20 @@
-import { RootIdArray, ITreeData, IRootInfoMap } from './common';
+import { TreeRootIdArray, ITreeData, ITreeRootInfoMap } from './common';
 
 export interface ICurrentParams {
   tree: ITreeData[];
-  expandNode: RootIdArray;
+  expandNode: TreeRootIdArray;
 }
 
 export interface INextParams {
-  expandNode: RootIdArray;
-  rootInfoMap: IRootInfoMap;
+  expandNode: TreeRootIdArray;
+  rootInfoMap: ITreeRootInfoMap;
 }
 
 // 纠正 ExpandNode (防止loadMore 之后，之前打开的expand记录丢失)
 export default function filterExpandNode(
   current: ICurrentParams,
   next: INextParams
-): RootIdArray {
+): TreeRootIdArray {
   const { expandNode: cExpandNode } = current;
   const { rootInfoMap, expandNode: nExpandNode } = next;
 

--- a/packages/zent/src/tree/utils/correctMark.ts
+++ b/packages/zent/src/tree/utils/correctMark.ts
@@ -1,17 +1,17 @@
 import _union from 'lodash-es/union';
 
-import { RootIdArray, IRootInfoMap } from './common';
+import { TreeRootIdArray, ITreeRootInfoMap } from './common';
 
 /**
  * 用于向上向下查找关联节点
  */
 export default function correctMark(
-  markList: RootIdArray = [],
-  rootInfoMap: IRootInfoMap,
-  disabled: RootIdArray = [],
+  markList: TreeRootIdArray = [],
+  rootInfoMap: ITreeRootInfoMap,
+  disabled: TreeRootIdArray = [],
   isInit?: boolean
-): RootIdArray {
-  const nextMarkList: RootIdArray = [];
+): TreeRootIdArray {
+  const nextMarkList: TreeRootIdArray = [];
   const markMap: { [key: string]: boolean } = {};
 
   // 向下查询

--- a/packages/zent/src/tree/utils/correctMark.ts
+++ b/packages/zent/src/tree/utils/correctMark.ts
@@ -1,0 +1,73 @@
+import _union from 'lodash-es/union';
+
+import { RootIdArray, IRootInfoMap } from './common';
+
+/**
+ * 用于向上向下查找关联节点
+ */
+export default function correctMark(
+  markList: RootIdArray = [],
+  rootInfoMap: IRootInfoMap,
+  disabled: RootIdArray = [],
+  isInit?: boolean
+): RootIdArray {
+  const nextMarkList: RootIdArray = [];
+  const markMap: { [key: string]: boolean } = {};
+
+  // 向下查询
+  markList.forEach(rootId => {
+    if (!rootInfoMap[rootId]) {
+      return;
+    }
+
+    // 包含所有子孙
+    const rootIncludes = isInit
+      ? rootInfoMap[rootId].includes
+      : rootInfoMap[rootId].includes.filter(id => {
+          return disabled.indexOf(id) === -1;
+        });
+
+    // 搜集所有相关的子孙节点
+    nextMarkList.push(...rootIncludes);
+
+    // 标记当前节点，用于向上查询
+    markMap[rootId] = true;
+  });
+
+  // 向上查询
+  markList.forEach(item => {
+    if (!rootInfoMap[item]) {
+      return;
+    }
+
+    let markParentId = rootInfoMap[item].parentId;
+
+    while (markParentId) {
+      //  父元素登记过, 则无需再向上查询
+      if (markMap[markParentId]) {
+        markParentId = undefined;
+      } else {
+        // 如果儿子被选中或则是禁用
+        if (
+          rootInfoMap[markParentId].son.every(
+            id => markMap[id] || disabled.indexOf(id) > -1
+          )
+        ) {
+          // 标记该节点
+          markMap[markParentId] = true;
+          // 继续探索
+          markParentId = rootInfoMap[markParentId].parentId;
+        } else {
+          // 否则，止
+          markParentId = undefined;
+        }
+      }
+    }
+  });
+
+  // Object.keys.map for number id
+  return _union(
+    Object.keys(markMap).map(id => rootInfoMap[id].id),
+    nextMarkList
+  );
+}

--- a/packages/zent/src/tree/utils/createStateByProps.ts
+++ b/packages/zent/src/tree/utils/createStateByProps.ts
@@ -1,0 +1,121 @@
+import assign from 'lodash-es/assign';
+
+import {
+  ITreeData,
+  IRenderKey,
+  DEFAULT_REANDER_KEY,
+  RootIdArray,
+  IRootInfoMap,
+} from './common';
+import getJudgeInfo from './getJudgeInfo';
+import correctMark from './correctMark';
+
+export interface ICreateStateByPropsParams {
+  data: ITreeData[];
+  dataType?: 'tree' | 'plain'; // 数据类型
+  renderKey?: Partial<IRenderKey>;
+  checkable?: boolean; // 是否为checkbox模式
+  expandAll?: boolean; // 是否展开全部节点
+  checkedKeys?: RootIdArray; // 默认选中节点
+  disabledCheckedKeys?: RootIdArray; // 默认选中节点
+  loadMore?: (data: ITreeData) => Promise<any>;
+  isRoot?: (data: ITreeData) => boolean;
+}
+
+export interface ICreateStateByPropsReturn {
+  tree: ITreeData[];
+  renderKey: IRenderKey;
+  rootInfoMap: IRootInfoMap;
+  expandNode: RootIdArray;
+  checkedNode: RootIdArray;
+  disabledNode: RootIdArray;
+}
+
+/**
+ * 根据props生成初始 state
+ */
+export default function createStateByProps({
+  data,
+  isRoot,
+  renderKey: propsRenderKey,
+  dataType,
+  expandAll,
+  loadMore,
+  checkable,
+  disabledCheckedKeys = [],
+  checkedKeys = [],
+}: ICreateStateByPropsParams): ICreateStateByPropsReturn {
+  const renderKey = assign({}, DEFAULT_REANDER_KEY, propsRenderKey);
+  const { children, parentId, id } = renderKey;
+
+  /**
+   * step 1
+   * 将 dataType === 'plain' 的数据格式化成父子嵌套格式
+   */
+  let roots: ITreeData[] = [];
+  if (dataType === 'plain') {
+    // 记录每个节点map表， { id: node }
+    const map: { [key: string]: ITreeData } = {};
+    const orderRecord: string[] = [];
+
+    data.forEach((node, index) => {
+      if (!node.isLeaf) {
+        node[children] = [];
+      }
+
+      map[node[id]] = node;
+      orderRecord[index] = node[id];
+    });
+
+    orderRecord.forEach(key => {
+      const node = map[key];
+
+      const isRootNode =
+        (isRoot && isRoot(node)) ||
+        node[parentId] === 0 ||
+        node[parentId] === undefined ||
+        node[parentId] === '0';
+
+      if (isRootNode) {
+        roots.push(node);
+      } else if (map[node[parentId]]) {
+        // 防止只删除父节点没有子节点的情况
+        map[node[parentId]][children].push(node);
+      }
+    });
+  } else if (dataType === 'tree') {
+    roots = data;
+  }
+
+  /**
+   * step 2
+   * 收集必要的判断集合
+   */
+  const { rootInfoMap, expandNode } = getJudgeInfo({
+    expandAll,
+    checkable,
+    loadMore,
+    tree: roots,
+    renderKey,
+  });
+
+  /**
+   * step 3
+   * 获取checkbox相关的两个集合 [选中][禁用]
+   */
+  const disabledNode = checkable
+    ? correctMark(disabledCheckedKeys, rootInfoMap)
+    : disabledCheckedKeys;
+  const checkedNode = checkable
+    ? correctMark(checkedKeys, rootInfoMap, disabledNode, true)
+    : checkedKeys;
+
+  return {
+    tree: roots,
+    renderKey,
+    rootInfoMap,
+    expandNode,
+    checkedNode,
+    disabledNode,
+  };
+}

--- a/packages/zent/src/tree/utils/createStateByProps.ts
+++ b/packages/zent/src/tree/utils/createStateByProps.ts
@@ -2,10 +2,10 @@ import assign from 'lodash-es/assign';
 
 import {
   ITreeData,
-  IRenderKey,
+  ITreeRenderKey,
   DEFAULT_REANDER_KEY,
-  RootIdArray,
-  IRootInfoMap,
+  TreeRootIdArray,
+  ITreeRootInfoMap,
 } from './common';
 import getJudgeInfo from './getJudgeInfo';
 import correctMark from './correctMark';
@@ -13,22 +13,22 @@ import correctMark from './correctMark';
 export interface ICreateStateByPropsParams {
   data: ITreeData[];
   dataType?: 'tree' | 'plain'; // 数据类型
-  renderKey?: Partial<IRenderKey>;
+  renderKey?: Partial<ITreeRenderKey>;
   checkable?: boolean; // 是否为checkbox模式
   expandAll?: boolean; // 是否展开全部节点
-  checkedKeys?: RootIdArray; // 默认选中节点
-  disabledCheckedKeys?: RootIdArray; // 默认选中节点
+  checkedKeys?: TreeRootIdArray; // 默认选中节点
+  disabledCheckedKeys?: TreeRootIdArray; // 默认选中节点
   loadMore?: (data: ITreeData) => Promise<any>;
   isRoot?: (data: ITreeData) => boolean;
 }
 
 export interface ICreateStateByPropsReturn {
   tree: ITreeData[];
-  renderKey: IRenderKey;
-  rootInfoMap: IRootInfoMap;
-  expandNode: RootIdArray;
-  checkedNode: RootIdArray;
-  disabledNode: RootIdArray;
+  renderKey: ITreeRenderKey;
+  rootInfoMap: ITreeRootInfoMap;
+  expandNode: TreeRootIdArray;
+  checkedNode: TreeRootIdArray;
+  disabledNode: TreeRootIdArray;
 }
 
 /**

--- a/packages/zent/src/tree/utils/getJudgeInfo.ts
+++ b/packages/zent/src/tree/utils/getJudgeInfo.ts
@@ -1,0 +1,105 @@
+import {
+  DEFAULT_REANDER_KEY,
+  RootIdArray,
+  ITreeData,
+  IRenderKey,
+  IRootInfoMap,
+} from './common';
+
+// getJudgeInfo
+export interface IJudgeInfoParams {
+  expandAll?: boolean;
+  checkable?: boolean;
+  loadMore?: (data: ITreeData) => Promise<any>;
+  tree: ITreeData[];
+  renderKey?: IRenderKey;
+}
+
+export interface IJudgeInfoReturn {
+  expandNode: RootIdArray;
+  rootInfoMap: IRootInfoMap;
+}
+
+/**
+ * 获取必要的判断数据
+ *
+ * @param param
+ * @returns {object}         rootInfoMap
+ * @returns {boolean}        rootInfoMap.isExpand
+ * @returns {boolean}        rootInfoMap.isParent
+ * @returns {number|string}  rootInfoMap.id
+ * @returns {number|string}  rootInfoMap.parentId
+ * @returns {object}         rootInfoMap.root
+ * @returns {array}  JudgeInfo.includes  节点的选择联动集合 { nodeId: id[] }
+ *                   id[]: [nodeId, nodeId.children[1]Id, nodeId.children[2]Id, .... nodeId.children[1][...].childrenn[N]Id]
+ *                   可以根据当前node的id, 查找它将会影响的子孙节点
+ */
+export default function getJudgeInfo({
+  expandAll,
+  loadMore,
+  tree,
+  renderKey = DEFAULT_REANDER_KEY,
+}: IJudgeInfoParams): IJudgeInfoReturn {
+  const expandNode: RootIdArray = [];
+  const rootInfoMap: IRootInfoMap = {};
+  const { children, id } = renderKey;
+
+  function collector({
+    nodeTree,
+    parentId,
+  }: {
+    nodeTree: ITreeData[];
+    parentId?: string | number;
+  }) {
+    nodeTree.forEach(item => {
+      const nodeId = item[id];
+
+      // 初始化
+      rootInfoMap[nodeId] = {
+        id: nodeId,
+        parentId,
+        root: item,
+        isExpand: false,
+        isParent: false,
+        son: (item[children] || []).map((t: ITreeData) => t[id]),
+        includes: [nodeId],
+      };
+
+      // 是否为父节点
+      const isParentNode = !!(
+        !item.isLeaf &&
+        (loadMore || (item[children] && item[children].length > 0))
+      );
+      rootInfoMap[nodeId].isParent = isParentNode;
+
+      // 收集expand节点
+      if (isParentNode && (expandAll || !!item.expand)) {
+        expandNode.push(nodeId);
+      }
+
+      if (item[children]) {
+        collector({
+          nodeTree: item[children],
+          parentId: nodeId,
+        });
+      }
+
+      // 收集当前节点能够影响的所有节点(self + children)
+      if (parentId !== undefined && rootInfoMap[parentId]) {
+        rootInfoMap[parentId].includes = rootInfoMap[parentId].includes.concat(
+          rootInfoMap[nodeId].includes
+        );
+      }
+    });
+  }
+
+  collector({
+    nodeTree: tree,
+    parentId: undefined,
+  });
+
+  return {
+    rootInfoMap: rootInfoMap as IRootInfoMap,
+    expandNode,
+  };
+}

--- a/packages/zent/src/tree/utils/getJudgeInfo.ts
+++ b/packages/zent/src/tree/utils/getJudgeInfo.ts
@@ -1,9 +1,9 @@
 import {
   DEFAULT_REANDER_KEY,
-  RootIdArray,
+  TreeRootIdArray,
   ITreeData,
-  IRenderKey,
-  IRootInfoMap,
+  ITreeRenderKey,
+  ITreeRootInfoMap,
 } from './common';
 
 // getJudgeInfo
@@ -12,12 +12,12 @@ export interface IJudgeInfoParams {
   checkable?: boolean;
   loadMore?: (data: ITreeData) => Promise<any>;
   tree: ITreeData[];
-  renderKey?: IRenderKey;
+  renderKey?: ITreeRenderKey;
 }
 
 export interface IJudgeInfoReturn {
-  expandNode: RootIdArray;
-  rootInfoMap: IRootInfoMap;
+  expandNode: TreeRootIdArray;
+  rootInfoMap: ITreeRootInfoMap;
 }
 
 /**
@@ -40,8 +40,8 @@ export default function getJudgeInfo({
   tree,
   renderKey = DEFAULT_REANDER_KEY,
 }: IJudgeInfoParams): IJudgeInfoReturn {
-  const expandNode: RootIdArray = [];
-  const rootInfoMap: IRootInfoMap = {};
+  const expandNode: TreeRootIdArray = [];
+  const rootInfoMap: ITreeRootInfoMap = {};
   const { children, id } = renderKey;
 
   function collector({
@@ -99,7 +99,7 @@ export default function getJudgeInfo({
   });
 
   return {
-    rootInfoMap: rootInfoMap as IRootInfoMap,
+    rootInfoMap: rootInfoMap as ITreeRootInfoMap,
     expandNode,
   };
 }


### PR DESCRIPTION
[breaking change] Tree：check 模式重新实现并只保留受控模式


#### ChangeLog 说明
* check 模式移除了默认模式，仅保留受控模式
* check 模式的计算方式重新实现

#### 迁移指南
```javascript
onCheck = (checked, helpInfo) => {
    console.log(checked, helpInfo);
    this.setState({
        checkedKeys: checked,
    });
}

<Tree
    checkable
    data={treeData}
    onCheck={this.onCheck}
    // defaultCheckedKeys={this.state.checkedKeys}
    checkedKeys={this.state.checkedKeys}
    disabledCheckedKeys={disabledCheckedKeys}
/>
```
1. 由于只保留受控制模，所以对选中入参名进行变更
**defaultCheckedKeys** => **checkedKeys**

2.  **onCheck**(checked, helpInfo) **onCheck** 将会接受两个参数
**checked**： 当前check操作后，所有被选中节点的id数组，
**helpInfo**： 用来帮助开发者做一些更自定义的选中操作

```javascript
interface IOncheckHelpInfo {
  // 触发onCheck的节点
  currentRoot: Node;
  // 禁用节点集合
  disabled: Node[];
  //  所有选中的节点集合
  all: Node[];
  //  所有选中节点的祖先节点；即全选可能只有顶部节点
  top: Node[];
  //  能够组成这次选中的最底层节点；即全选可能是金字塔底部的节点
  bottom: Node[];
}

```
