### PR TITLE
[bug fix] Upload:: 去除upload popup的getDerivedStateFromProps

### DIFF
--- a/packages/zent/src/upload/components/UploadPopup.tsx
+++ b/packages/zent/src/upload/components/UploadPopup.tsx
@@ -23,16 +23,6 @@ class UploadPopup extends Component<any, any> {
     className: '',
   };
 
-  static getDerivedStateFromProps(nextProps, prevState) {
-    const { categoryId } = nextProps.options;
-    if (prevState.categoryId !== categoryId) {
-      return {
-        categoryId,
-      };
-    }
-    return null;
-  }
-
   networkUrl: string;
   sortable: Sortable;
 


### PR DESCRIPTION
getDerivedStateFromProps每次setState的时候也会触发，由于props的categoryId没改，而state的categoryId改了，导致一直无法设置categoryId。去除getDerivedStateFromProps也无所谓，因为props的categoryId改变时，UploadPopup早已销毁