### PR TITLE
[bug fix] Table: 排序错误，第二次没有取消

### DIFF
--- a/packages/zent/__tests__/table/combine.js
+++ b/packages/zent/__tests__/table/combine.js
@@ -56,6 +56,11 @@ describe('Combine', () => {
     wrapper.find('Head .sort-col--active .caret-down').simulate('click');
     expect(
       wrapper.find('Head .sort-col--active .caret-down').hasClass('sort-active')
+    ).toBe(false);
+
+    wrapper.find('Head .sort-col--active .caret-down').simulate('click');
+    expect(
+      wrapper.find('Head .sort-col--active .caret-down').hasClass('sort-active')
     ).toBe(true);
   });
 

--- a/packages/zent/assets/grid.scss
+++ b/packages/zent/assets/grid.scss
@@ -234,7 +234,7 @@
 
     &:hover,
     &__mouseover {
-      @include theme-color(background-color, stroke, 8);
+      @include theme-color(background-color, primary, 8);
     }
 
     &__expanded {

--- a/packages/zent/src/grid/Grid.tsx
+++ b/packages/zent/src/grid/Grid.tsx
@@ -592,7 +592,7 @@ export class Grid<Data = any> extends PureComponent<
       const headStyle: React.CSSProperties = {};
       const scrollBodyStyle: React.CSSProperties = {
         maxHeight: y,
-        overflowY: 'scroll',
+        overflowY: 'auto',
       };
       if (scrollbarWidth > 0) {
         headStyle.paddingBottom = 0;

--- a/packages/zent/src/table/Table.tsx
+++ b/packages/zent/src/table/Table.tsx
@@ -101,7 +101,6 @@ export class Table extends PureComponent<ITableProps, any> {
     columns: [],
     emptyLabel: '',
     rowKey: 'id',
-    sortType: 'desc',
     loading: false,
     autoScroll: false,
     autoStick: false,


### PR DESCRIPTION
* [bug fix] Table: 修复排序错误，由于有 `props` 有默认值，导致undefined无法设置
* [bug fix] Grid: hover背景色由灰色改为蓝色&y轴滚动条设置为auto，高度不够时不显示滚动条