### PR TITLE
[bug fix] Notify：fix content overflow style;

### DIFF
--- a/packages/zent/assets/notify.scss
+++ b/packages/zent/assets/notify.scss
@@ -29,6 +29,7 @@ $transition-duration: 160ms;
     border-radius: 4px;
     box-sizing: border-box;
     font-weight: $font-weight-medium;
+    word-break: break-all;
 
     &:empty:before {
       content: '\200b';


### PR DESCRIPTION
Changes you made in this pull request:

- add word-break style to notify-content container
