### PR TITLE
Use capture phase for scroll event on window

### DIFF
--- a/packages/zent/src/popover/Content.tsx
+++ b/packages/zent/src/popover/Content.tsx
@@ -207,6 +207,7 @@ export default class PopoverContent extends Component<
           <WindowEventHandler
             eventName="scroll"
             callback={this.onWindowScroll}
+            useCapture
           />
         </div>
       </Portal>


### PR DESCRIPTION
`scroll` events on elements don't bubble, but we can capture it.