### PR TITLE
fix:修改了单选和多选的禁用选项文字颜色

### DIFF
--- a/packages/zent/assets/checkbox.scss
+++ b/packages/zent/assets/checkbox.scss
@@ -128,7 +128,7 @@ $size: 16px;
 
 .zent-checkbox-disabled {
   & > span {
-    @include theme-color(color, stroke, 4);
+    @include theme-color(color, stroke, 3);
   }
 
   & > .zent-checkbox {

--- a/packages/zent/assets/radio.scss
+++ b/packages/zent/assets/radio.scss
@@ -130,7 +130,7 @@ $inner-circle-offset: ($outer-circle-size - $inner-circle-size - 2px) / 2;
     }
 
     & .zent-radio + span {
-      @include theme-color(color, stroke, 4);
+      @include theme-color(color, stroke, 3);
     }
   }
 }


### PR DESCRIPTION
将单选(radio)和多选(checkbox)禁用选项文字色值由C8C9CC($theme-stroke-4)改成969799($theme-stroke-3)