### PR TITLE
[bug fix]Tree: 移除plain模式对数据源的修改 以及 其他组件微小调整

### DIFF
--- a/packages/zent/src/slider/Slider.tsx
+++ b/packages/zent/src/slider/Slider.tsx
@@ -68,6 +68,7 @@ export class Slider extends React.Component<ISliderProps, ISliderState> {
     step: 1,
     withInput: true,
     range: false,
+    value: 0,
   };
 
   static contextType = DisabledContext;

--- a/packages/zent/src/split-button/SplitButton.tsx
+++ b/packages/zent/src/split-button/SplitButton.tsx
@@ -58,7 +58,7 @@ export class SplitButton<Value> extends Component<ISplitButtonProps<Value>> {
     prefix: 'zent',
   };
 
-  contextType = DisabledContext;
+  static contextType = DisabledContext;
   context!: IDisabledContext;
 
   state = {

--- a/packages/zent/src/tree/utils/createStateByProps.ts
+++ b/packages/zent/src/tree/utils/createStateByProps.ts
@@ -56,31 +56,27 @@ export default function createStateByProps({
   if (dataType === 'plain') {
     // 记录每个节点map表， { id: node }
     const map: { [key: string]: ITreeData } = {};
-    const orderRecord: string[] = [];
 
-    data.forEach((node, index) => {
+    data.forEach(node => {
+      map[node[id]] = { ...node };
       if (!node.isLeaf) {
-        node[children] = [];
+        map[node[id]][children] = [];
       }
-
-      map[node[id]] = node;
-      orderRecord[index] = node[id];
     });
 
-    orderRecord.forEach(key => {
-      const node = map[key];
-
+    data.forEach(node => {
       const isRootNode =
         (isRoot && isRoot(node)) ||
         node[parentId] === 0 ||
         node[parentId] === undefined ||
         node[parentId] === '0';
 
+      const markNode = map[node[id]];
       if (isRootNode) {
-        roots.push(node);
-      } else if (map[node[parentId]]) {
+        roots.push(markNode);
+      } else if (map[markNode[parentId]]) {
         // 防止只删除父节点没有子节点的情况
-        map[node[parentId]][children].push(node);
+        map[markNode[parentId]][children].push(markNode);
       }
     });
   } else if (dataType === 'tree') {

--- a/site/package.json
+++ b/site/package.json
@@ -47,6 +47,7 @@
     "@babel/preset-env": "^7.1.6",
     "@babel/preset-react": "^7.0.0",
     "@babel/types": "^7.1.6",
+    "@hot-loader/react-dom": "16.8.x",
     "autoprefixer": "^9.4.6",
     "awesome-typescript-loader": "^5.2.1",
     "babel-loader": "^8.0.5",

--- a/site/webpack/webpack.config.js
+++ b/site/webpack/webpack.config.js
@@ -25,7 +25,6 @@ module.exports = {
     extensions: ['.tsx', '.ts', '.js', '.pcss', '.md'],
     alias: Object.assign(
       {
-        'react-dom': '@hot-loader/react-dom',
         zent$: join(__dirname, '../zent'),
       },
       createAlias(resolve(__dirname, '../../packages/zent/src'))

--- a/site/webpack/webpack.config.js
+++ b/site/webpack/webpack.config.js
@@ -25,6 +25,7 @@ module.exports = {
     extensions: ['.tsx', '.ts', '.js', '.pcss', '.md'],
     alias: Object.assign(
       {
+        'react-dom': '@hot-loader/react-dom',
         zent$: join(__dirname, '../zent'),
       },
       createAlias(resolve(__dirname, '../../packages/zent/src'))

--- a/site/webpack/webpack.dev.config.js
+++ b/site/webpack/webpack.dev.config.js
@@ -14,5 +14,11 @@ module.exports = merge.smart(base, {
 
   devtool: 'inline-cheap-module-source-map',
 
+  resolve: {
+    alias: {
+      'react-dom': '@hot-loader/react-dom',
+    },
+  },
+
   plugins: [new webpack.HotModuleReplacementPlugin()],
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -814,6 +814,16 @@
   resolved "https://registry.yarnpkg.com/@csstools/sass-import-resolve/-/sass-import-resolve-1.0.0.tgz#32c3cdb2f7af3cd8f0dca357b592e7271f3831b5"
   integrity sha512-pH4KCsbtBLLe7eqUrw8brcuFO8IZlN36JjdKlOublibVdAIPHCzEnpBWOVUXK5sCf+DpBi8ZtuWtjF0srybdeA==
 
+"@hot-loader/react-dom@16.8.x":
+  version "16.8.6"
+  resolved "https://registry.npmjs.org/@hot-loader/react-dom/-/react-dom-16.8.6.tgz#7923ba27db1563a7cc48d4e0b2879a140df461ea"
+  integrity sha512-+JHIYh33FVglJYZAUtRjfT5qZoT2mueJGNzU5weS2CVw26BgbxGKSujlJhO85BaRbg8sqNWyW1hYBILgK3ZCgA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.13.6"
+
 "@improved/node@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@improved/node/-/node-1.0.0.tgz#50b1cc6804ffb3d9c86bf91ed1900baa3cd8dd59"


### PR DESCRIPTION
- Tree: 移除plain模式对数据源的修改
- Slider: props.value 默认值设置为0
- SplitButton: contextType 添加 static 
- site/webpack: 增加 alias => 'react-dom': '@hot-loader/react-dom', 移除开发模式warnning