### PR TITLE
[bug fix] Tabs: 添加类型不匹配时的默认展示行为

### DIFF
--- a/packages/zent/__tests__/tabs.js
+++ b/packages/zent/__tests__/tabs.js
@@ -81,7 +81,7 @@ describe('Tabs', () => {
   });
 
   it('different types', () => {
-    const ensure = type => {
+    const ensure = (type, targetType) => {
       const wrapper = mount(
         <Tabs activeId="foobar" type={type}>
           <TabPanel id="foobar" tab="foobar-tab">
@@ -89,15 +89,18 @@ describe('Tabs', () => {
           </TabPanel>
         </Tabs>
       );
-      type = type || 'normal';
       expect(
-        wrapper.find('.zent-tabs-nav').hasClass(`zent-tabs-nav-type__${type}`)
+        wrapper
+          .find('.zent-tabs-nav')
+          .hasClass(`zent-tabs-nav-type__${targetType}`)
       ).toBe(true);
     };
-    ensure();
-    ensure('normal');
-    ensure('card');
-    ensure('button');
+    ensure(undefined, 'normal');
+    ensure('normal', 'normal');
+    ensure('card', 'card');
+    ensure('button', 'button');
+    // zent 6.x tabs type
+    ensure('slider', 'normal');
   });
 
   it('stretch props', () => {

--- a/packages/zent/assets/tabs.scss
+++ b/packages/zent/assets/tabs.scss
@@ -111,7 +111,6 @@
   }
 
   .zent-tabs-tab {
-    min-width: 112px;
     padding: 0 16px;
 
     &-inner {

--- a/packages/zent/src/tabs/Tabs.tsx
+++ b/packages/zent/src/tabs/Tabs.tsx
@@ -87,7 +87,8 @@ export class Tabs<Id extends string | number = string> extends BaseTabs<
     const { type, candel, stretch, navExtraContent, onChange, onDelete } = this
       .props as ITabsInnerProps<Id>;
 
-    const TabsNavComp = TabsNavComponents[type] || TabsNavComponents['normal'];
+    const TabsNavComp = (TabsNavComponents[type] ||
+      TabsNavComponents['normal']) as React.ComponentClass<ITabsNavProps<Id>>;
 
     return (
       <TabsNavComp

--- a/packages/zent/src/tabs/Tabs.tsx
+++ b/packages/zent/src/tabs/Tabs.tsx
@@ -87,13 +87,7 @@ export class Tabs<Id extends string | number = string> extends BaseTabs<
     const { type, candel, stretch, navExtraContent, onChange, onDelete } = this
       .props as ITabsInnerProps<Id>;
 
-    const TabsNavComp = TabsNavComponents[type] as React.ComponentClass<
-      ITabsNavProps<Id>
-    >;
-
-    if (!TabsNavComp) {
-      return null;
-    }
+    const TabsNavComp = TabsNavComponents[type] || TabsNavComponents['normal'];
 
     return (
       <TabsNavComp


### PR DESCRIPTION
- Tabs 组件匹配不到 types 时，展示默认的组件类型
- 删除 normal 类型下的 min-width 宽度限制