### PR TITLE
[bugfix] Tabs: 添加 Panel 的不同渲染行为模式

### DIFF
--- a/packages/zent/src/tabs/README_en-US.md
+++ b/packages/zent/src/tabs/README_en-US.md
@@ -12,17 +12,18 @@ Tabs is used to switch different view in one page.
 
 #### Tabs
 
-| Property        | Description                                                     | Type                          | Default    | Alternative          | Required |
-| --------------- | --------------------------------------------------------------- | ----------------------------- | ---------- | -------------------- | -------- |
-| activeId        | The id of the active tab                                        | string \| number              | `''`       |                      | yes      |
-| onChange        | The callback function that is triggered when the tab is active  | (id: string \| number) => any |            |                      | yes      |
-| tabs            | The config of tabs when not using Panel.                        | Array<ITab\>                  |            |                      | no       |
-| className       | The custom classname                                            | string                        |            |                      | no       |
-| type            | The type of tabs                                                | string                        | `'normal'` | `'card'`, `'button'` | no       |
-| navExtraContent | Nav add extra content                                           | React.ReactNode               |            |                      | no       |
-| stretch         | Is tab stretch to fill content space                            | boolean                       | `false`    |                      | no       |
-| onDelete        | The callback function that is triggered when the tab is closed. | (id: string \| number) => any |            |                      | no       |
-| candel          | Whether the tab can be deleted.                                 | bool                          | `false`    |                      | no       |
+| Property         | Description                                                                                     | Type                          | Default    | Alternative          | Required |
+| ---------------- | ----------------------------------------------------------------------------------------------- | ----------------------------- | ---------- | -------------------- | -------- |
+| activeId         | The id of the active tab                                                                        | string \| number              | `''`       |                      | yes      |
+| onChange         | The callback function that is triggered when the tab is active                                  | (id: string \| number) => any |            |                      | yes      |
+| tabs             | The config of tabs when not using Panel.                                                        | Array<ITab\>                  |            |                      | no       |
+| className        | The custom classname                                                                            | string                        |            |                      | no       |
+| type             | The type of tabs                                                                                | string                        | `'normal'` | `'card'`, `'button'` | no       |
+| navExtraContent  | Nav add extra content                                                                           | React.ReactNode               |            |                      | no       |
+| stretch          | Is tab stretch to fill content space                                                            | boolean                       | `false`    |                      | no       |
+| onDelete         | The callback function that is triggered when the tab is closed.                                 | (id: string \| number) => any |            |                      | no       |
+| candel           | Whether the tab can be deleted.                                                                 | bool                          | `false`    |                      | no       |
+| forceRenderPanel | Force render tabPanel，add `display: none` style instead of return `null` for inactive tabPanel | bool                          | `false`    |                      | no       |
 
 Paramerter type of `tabs`：
 
@@ -36,13 +37,14 @@ interface ITab {
 
 #### VerticalTabs
 
-| Property     | Description                                                    | Type                          | Default | Alternative | Required |
-| ------------ | -------------------------------------------------------------- | ----------------------------- | ------- | ----------- | -------- |
-| activeId     | The id of the active tab                                       | string \| number              | `''`    |             | yes      |
-| onChange     | The callback function that is triggered when the tab is active | (id: string \| number) => any |         |             | yes      |
-| tabs         | The config of tabs when not using Panel.                       | Array<IVerticalTab\>          |         |             | no       |
-| className    | The custom classname                                           | string                        |         |             | no       |
-| scrollHeight | The max height of the scrollable space                         | string \| number              |         |             | no       |
+| Property         | Description                                                                                     | Type                          | Default | Alternative | Required |
+| ---------------- | ----------------------------------------------------------------------------------------------- | ----------------------------- | ------- | ----------- | -------- |
+| activeId         | The id of the active tab                                                                        | string \| number              | `''`    |             | yes      |
+| onChange         | The callback function that is triggered when the tab is active                                  | (id: string \| number) => any |         |             | yes      |
+| tabs             | The config of tabs when not using Panel.                                                        | Array<IVerticalTab\>          |         |             | no       |
+| className        | The custom classname                                                                            | string                        |         |             | no       |
+| scrollHeight     | The max height of the scrollable space                                                          | string \| number              |         |             | no       |
+| forceRenderPanel | Force render tabPanel，add `display: none` style instead of return `null` for inactive tabPanel | bool                          | `false` |             | no       |
 
 Paramerter type of `tabs`：
 

--- a/packages/zent/src/tabs/README_en-US.md
+++ b/packages/zent/src/tabs/README_en-US.md
@@ -12,18 +12,18 @@ Tabs is used to switch different view in one page.
 
 #### Tabs
 
-| Property         | Description                                                                                     | Type                          | Default    | Alternative          | Required |
-| ---------------- | ----------------------------------------------------------------------------------------------- | ----------------------------- | ---------- | -------------------- | -------- |
-| activeId         | The id of the active tab                                                                        | string \| number              | `''`       |                      | yes      |
-| onChange         | The callback function that is triggered when the tab is active                                  | (id: string \| number) => any |            |                      | yes      |
-| tabs             | The config of tabs when not using Panel.                                                        | Array<ITab\>                  |            |                      | no       |
-| className        | The custom classname                                                                            | string                        |            |                      | no       |
-| type             | The type of tabs                                                                                | string                        | `'normal'` | `'card'`, `'button'` | no       |
-| navExtraContent  | Nav add extra content                                                                           | React.ReactNode               |            |                      | no       |
-| stretch          | Is tab stretch to fill content space                                                            | boolean                       | `false`    |                      | no       |
-| onDelete         | The callback function that is triggered when the tab is closed.                                 | (id: string \| number) => any |            |                      | no       |
-| candel           | Whether the tab can be deleted.                                                                 | bool                          | `false`    |                      | no       |
-| forceRenderPanel | Force render tabPanel，add `display: none` style instead of return `null` for inactive tabPanel | bool                          | `false`    |                      | no       |
+| Property           | Description                                                               | Type                          | Default    | Alternative          | Required |
+| ------------------ | ------------------------------------------------------------------------- | ----------------------------- | ---------- | -------------------- | -------- |
+| activeId           | The id of the active tab                                                  | string \| number              | `''`       |                      | yes      |
+| onChange           | The callback function that is triggered when the tab is active            | (id: string \| number) => any |            |                      | yes      |
+| tabs               | The config of tabs when not using Panel.                                  | Array<ITab\>                  |            |                      | no       |
+| className          | The custom classname                                                      | string                        |            |                      | no       |
+| type               | The type of tabs                                                          | string                        | `'normal'` | `'card'`, `'button'` | no       |
+| navExtraContent    | Nav add extra content                                                     | React.ReactNode               |            |                      | no       |
+| stretch            | Is tab stretch to fill content space                                      | boolean                       | `false`    |                      | no       |
+| onDelete           | The callback function that is triggered when the tab is closed.           | (id: string \| number) => any |            |                      | no       |
+| candel             | Whether the tab can be deleted.                                           | bool                          | `false`    |                      | no       |
+| unmountPanelOnHide | unmount TabPanel on inactive instead of using `display: none` style cover | bool                          | `false`    |                      | no       |
 
 Paramerter type of `tabs`：
 
@@ -37,14 +37,14 @@ interface ITab {
 
 #### VerticalTabs
 
-| Property         | Description                                                                                     | Type                          | Default | Alternative | Required |
-| ---------------- | ----------------------------------------------------------------------------------------------- | ----------------------------- | ------- | ----------- | -------- |
-| activeId         | The id of the active tab                                                                        | string \| number              | `''`    |             | yes      |
-| onChange         | The callback function that is triggered when the tab is active                                  | (id: string \| number) => any |         |             | yes      |
-| tabs             | The config of tabs when not using Panel.                                                        | Array<IVerticalTab\>          |         |             | no       |
-| className        | The custom classname                                                                            | string                        |         |             | no       |
-| scrollHeight     | The max height of the scrollable space                                                          | string \| number              |         |             | no       |
-| forceRenderPanel | Force render tabPanel，add `display: none` style instead of return `null` for inactive tabPanel | bool                          | `false` |             | no       |
+| Property           | Description                                                               | Type                          | Default | Alternative | Required |
+| ------------------ | ------------------------------------------------------------------------- | ----------------------------- | ------- | ----------- | -------- |
+| activeId           | The id of the active tab                                                  | string \| number              | `''`    |             | yes      |
+| onChange           | The callback function that is triggered when the tab is active            | (id: string \| number) => any |         |             | yes      |
+| tabs               | The config of tabs when not using Panel.                                  | Array<IVerticalTab\>          |         |             | no       |
+| className          | The custom classname                                                      | string                        |         |             | no       |
+| scrollHeight       | The max height of the scrollable space                                    | string \| number              |         |             | no       |
+| unmountPanelOnHide | unmount TabPanel on inactive instead of using `display: none` style cover | bool                          | `false` |             | no       |
 
 Paramerter type of `tabs`：
 
@@ -54,12 +54,13 @@ type IVerticalTab = ITab | { divide: true };
 
 #### TabPanel
 
-| Property  | Description                                             | Type             | Required |
-| --------- | ------------------------------------------------------- | ---------------- | -------- |
-| tab       | The label of the tab which corresponding to this panel. | ReactNode        | yes      |
-| id        | The id of the tab panel.                                | string \| number | yes      |
-| disabled  | Disable this tab panel.                                 | bool             | no       |
-| className | The extra className of the panel                        | bool             | no       |
+| Property      | Description                                                               | Type             | Required |
+| ------------- | ------------------------------------------------------------------------- | ---------------- | -------- |
+| tab           | The label of the tab which corresponding to this panel.                   | ReactNode        | yes      |
+| id            | The id of the tab panel.                                                  | string \| number | yes      |
+| disabled      | Disable this tab panel.                                                   | bool             | no       |
+| className     | The extra className of the panel                                          | bool             | no       |
+| unmountOnHide | unmount TabPanel on inactive instead of using `display: none` style cover | bool             | 否       |
 
 #### Divide
 

--- a/packages/zent/src/tabs/README_zh-CN.md
+++ b/packages/zent/src/tabs/README_zh-CN.md
@@ -13,18 +13,18 @@ group: 导航
 
 #### Tabs
 
-| 参数             | 说明                                                                               | 类型                          | 默认值     | 备选值               | 是否必须 |
-| ---------------- | ---------------------------------------------------------------------------------- | ----------------------------- | ---------- | -------------------- | -------- |
-| activeId         | 激活的 tab-id                                                                      | string \| number              |            |                      | 是       |
-| onChange         | 选中的 tab 改变时                                                                  | (id: string \| number) => any |            |                      | 是       |
-| tabs             | 不使用 Panel 时的标签列表                                                          | Array<ITab\>                  |            |                      | 否       |
-| className        | 自定义额外类名                                                                     | string                        |            |                      | 否       |
-| type             | tabs 组件类型                                                                      | string                        | `'normal'` | `'card'`, `'button'` | 否       |
-| navExtraContent  | 导航添加额外内容                                                                   | React.ReactNode               |            |                      | 否       |
-| stretch          | tab 是否撑满全部空间                                                               | boolean                       | `false`    |                      | 否       |
-| onDelete         | 关闭 tab 时                                                                        | (id: string \| number) => any |            |                      | 否       |
-| candel           | 是否可删除                                                                         | bool                          | `false`    |                      | 否       |
-| forceRenderPanel | 强制渲染 TabPanel，对非 active 的 Panel 添加 `display: none` 样式而不是返回 `null` | bool                          | `false`    |                      | no       |
+| 参数               | 说明                                                                 | 类型                          | 默认值     | 备选值               | 是否必须 |
+| ------------------ | -------------------------------------------------------------------- | ----------------------------- | ---------- | -------------------- | -------- |
+| activeId           | 激活的 tab-id                                                        | string \| number              |            |                      | 是       |
+| onChange           | 选中的 tab 改变时                                                    | (id: string \| number) => any |            |                      | 是       |
+| tabs               | 不使用 Panel 时的标签列表                                            | Array<ITab\>                  |            |                      | 否       |
+| className          | 自定义额外类名                                                       | string                        |            |                      | 否       |
+| type               | tabs 组件类型                                                        | string                        | `'normal'` | `'card'`, `'button'` | 否       |
+| navExtraContent    | 导航添加额外内容                                                     | React.ReactNode               |            |                      | 否       |
+| stretch            | tab 是否撑满全部空间                                                 | boolean                       | `false`    |                      | 否       |
+| onDelete           | 关闭 tab 时                                                          | (id: string \| number) => any |            |                      | 否       |
+| candel             | 是否可删除                                                           | bool                          | `false`    |                      | 否       |
+| unmountPanelOnHide | panel 非 active 时，不使用 `display: none` 隐藏而是直接 unmount 组件 | bool                          | `false`    |                      | no       |
 
 tabs 参数类型：
 
@@ -38,14 +38,14 @@ interface ITab {
 
 #### VerticalTabs
 
-| 参数             | 说明                                                                               | 类型                          | 默认值  | 备选值 | 是否必须 |
-| ---------------- | ---------------------------------------------------------------------------------- | ----------------------------- | ------- | ------ | -------- |
-| activeId         | 激活的 tab-id                                                                      | string \| number              |         |        | 是       |
-| onChange         | 选中的 tab 改变时                                                                  | (id: string \| number) => any |         |        | 是       |
-| tabs             | 不使用 Panel 时的标签列表                                                          | Array<IVerticalTab\>          |         |        | 否       |
-| className        | 自定义额外类名                                                                     | string                        |         |        | 否       |
-| scrollHeight     | 可滚动区域的最大高度                                                               | string \| number              |         |        | 否       |
-| forceRenderPanel | 强制渲染 TabPanel，对非 active 的 Panel 添加 `display: none` 样式而不是返回 `null` | bool                          | `false` |        | no       |
+| 参数               | 说明                                                                 | 类型                          | 默认值  | 备选值 | 是否必须 |
+| ------------------ | -------------------------------------------------------------------- | ----------------------------- | ------- | ------ | -------- |
+| activeId           | 激活的 tab-id                                                        | string \| number              |         |        | 是       |
+| onChange           | 选中的 tab 改变时                                                    | (id: string \| number) => any |         |        | 是       |
+| tabs               | 不使用 Panel 时的标签列表                                            | Array<IVerticalTab\>          |         |        | 否       |
+| className          | 自定义额外类名                                                       | string                        |         |        | 否       |
+| scrollHeight       | 可滚动区域的最大高度                                                 | string \| number              |         |        | 否       |
+| unmountPanelOnHide | panel 非 active 时，不使用 `display: none` 隐藏而是直接 unmount 组件 | bool                          | `false` |        | no       |
 
 tabs 参数类型：
 
@@ -55,12 +55,13 @@ type IVerticalTab = ITab | { divide: true };
 
 #### TabPanel
 
-| 参数      | 说明                                | 类型             | 是否必须 |
-| --------- | ----------------------------------- | ---------------- | -------- |
-| tab       | 该 TabPanel 所对应的 tab 标签的名字 | ReactNode        | 是       |
-| id        | 该 TabPanel 的 id                   | string \| number | 是       |
-| disabled  | 该 TabPanel 是否被禁用              | bool             | 否       |
-| className | 该 TabPanel 上添加的额外 className  | bool             | 否       |
+| 参数          | 说明                                                           | 类型             | 是否必须 |
+| ------------- | -------------------------------------------------------------- | ---------------- | -------- |
+| tab           | 该 TabPanel 所对应的 tab 标签的名字                            | ReactNode        | 是       |
+| id            | 该 TabPanel 的 id                                              | string \| number | 是       |
+| disabled      | 该 TabPanel 是否被禁用                                         | bool             | 否       |
+| className     | 该 TabPanel 上添加的额外 className                             | bool             | 否       |
+| unmountOnHide | 非 active 时，不使用 `display: none` 隐藏而是直接 unmount 组件 | bool             | 否       |
 
 #### Divide
 

--- a/packages/zent/src/tabs/README_zh-CN.md
+++ b/packages/zent/src/tabs/README_zh-CN.md
@@ -13,17 +13,18 @@ group: 导航
 
 #### Tabs
 
-| 参数            | 说明                      | 类型                          | 默认值     | 备选值               | 是否必须 |
-| --------------- | ------------------------- | ----------------------------- | ---------- | -------------------- | -------- |
-| activeId        | 激活的 tab-id             | string \| number              |            |                      | 是       |
-| onChange        | 选中的 tab 改变时         | (id: string \| number) => any |            |                      | 是       |
-| tabs            | 不使用 Panel 时的标签列表 | Array<ITab\>                  |            |                      | 否       |
-| className       | 自定义额外类名            | string                        |            |                      | 否       |
-| type            | tabs 组件类型             | string                        | `'normal'` | `'card'`, `'button'` | 否       |
-| navExtraContent | 导航添加额外内容          | React.ReactNode               |            |                      | 否       |
-| stretch         | tab 是否撑满全部空间      | boolean                       | `false`    |                      | 否       |
-| onDelete        | 关闭 tab 时               | (id: string \| number) => any |            |                      | 否       |
-| candel          | 是否可删除                | bool                          | `false`    |                      | 否       |
+| 参数             | 说明                                                                               | 类型                          | 默认值     | 备选值               | 是否必须 |
+| ---------------- | ---------------------------------------------------------------------------------- | ----------------------------- | ---------- | -------------------- | -------- |
+| activeId         | 激活的 tab-id                                                                      | string \| number              |            |                      | 是       |
+| onChange         | 选中的 tab 改变时                                                                  | (id: string \| number) => any |            |                      | 是       |
+| tabs             | 不使用 Panel 时的标签列表                                                          | Array<ITab\>                  |            |                      | 否       |
+| className        | 自定义额外类名                                                                     | string                        |            |                      | 否       |
+| type             | tabs 组件类型                                                                      | string                        | `'normal'` | `'card'`, `'button'` | 否       |
+| navExtraContent  | 导航添加额外内容                                                                   | React.ReactNode               |            |                      | 否       |
+| stretch          | tab 是否撑满全部空间                                                               | boolean                       | `false`    |                      | 否       |
+| onDelete         | 关闭 tab 时                                                                        | (id: string \| number) => any |            |                      | 否       |
+| candel           | 是否可删除                                                                         | bool                          | `false`    |                      | 否       |
+| forceRenderPanel | 强制渲染 TabPanel，对非 active 的 Panel 添加 `display: none` 样式而不是返回 `null` | bool                          | `false`    |                      | no       |
 
 tabs 参数类型：
 
@@ -37,13 +38,14 @@ interface ITab {
 
 #### VerticalTabs
 
-| 参数         | 说明                      | 类型                          | 默认值 | 备选值 | 是否必须 |
-| ------------ | ------------------------- | ----------------------------- | ------ | ------ | -------- |
-| activeId     | 激活的 tab-id             | string \| number              |        |        | 是       |
-| onChange     | 选中的 tab 改变时         | (id: string \| number) => any |        |        | 是       |
-| tabs         | 不使用 Panel 时的标签列表 | Array<IVerticalTab\>          |        |        | 否       |
-| className    | 自定义额外类名            | string                        |        |        | 否       |
-| scrollHeight | 可滚动区域的最大高度      | string \| number              |        |        | 否       |
+| 参数             | 说明                                                                               | 类型                          | 默认值  | 备选值 | 是否必须 |
+| ---------------- | ---------------------------------------------------------------------------------- | ----------------------------- | ------- | ------ | -------- |
+| activeId         | 激活的 tab-id                                                                      | string \| number              |         |        | 是       |
+| onChange         | 选中的 tab 改变时                                                                  | (id: string \| number) => any |         |        | 是       |
+| tabs             | 不使用 Panel 时的标签列表                                                          | Array<IVerticalTab\>          |         |        | 否       |
+| className        | 自定义额外类名                                                                     | string                        |         |        | 否       |
+| scrollHeight     | 可滚动区域的最大高度                                                               | string \| number              |         |        | 否       |
+| forceRenderPanel | 强制渲染 TabPanel，对非 active 的 Panel 添加 `display: none` 样式而不是返回 `null` | bool                          | `false` |        | no       |
 
 tabs 参数类型：
 

--- a/packages/zent/src/tabs/Tabs.tsx
+++ b/packages/zent/src/tabs/Tabs.tsx
@@ -47,7 +47,7 @@ export class Tabs<Id extends string | number = string> extends BaseTabs<
     stretch: false,
     onChange: noop,
     onDelete: noop,
-    forceRenderPanel: false,
+    unmountPanelOnHide: false,
   };
 
   get tabsCls() {
@@ -104,13 +104,13 @@ export class Tabs<Id extends string | number = string> extends BaseTabs<
   }
 
   renderTabPanel(tabItem: IInnerTab<Id>) {
-    const { forceRenderPanel } = this.props;
+    const { unmountPanelOnHide } = this.props;
     return (
       <LazyMount mount={tabItem.actived} key={tabItem.key}>
         <TabPanel
           tab={tabItem.title}
           actived={tabItem.actived}
-          forceRender={forceRenderPanel}
+          unmountOnHide={tabItem.unmountOnHide || unmountPanelOnHide}
           className={tabItem.className}
           id={tabItem.key}
         >

--- a/packages/zent/src/tabs/Tabs.tsx
+++ b/packages/zent/src/tabs/Tabs.tsx
@@ -47,6 +47,7 @@ export class Tabs<Id extends string | number = string> extends BaseTabs<
     stretch: false,
     onChange: noop,
     onDelete: noop,
+    forceRenderPanel: false,
   };
 
   get tabsCls() {
@@ -103,11 +104,13 @@ export class Tabs<Id extends string | number = string> extends BaseTabs<
   }
 
   renderTabPanel(tabItem: IInnerTab<Id>) {
+    const { forceRenderPanel } = this.props;
     return (
       <LazyMount mount={tabItem.actived} key={tabItem.key}>
         <TabPanel
           tab={tabItem.title}
           actived={tabItem.actived}
+          forceRender={forceRenderPanel}
           className={tabItem.className}
           id={tabItem.key}
         >

--- a/packages/zent/src/tabs/VerticalTabs.tsx
+++ b/packages/zent/src/tabs/VerticalTabs.tsx
@@ -30,6 +30,7 @@ export class VerticalTabs<Id extends string | number = string> extends BaseTabs<
   static defaultProps: Partial<IVerticalTabsProps<string>> = {
     activeId: '',
     onChange: noop,
+    forceRenderPanel: false,
   };
 
   get tabsCls() {
@@ -97,11 +98,14 @@ export class VerticalTabs<Id extends string | number = string> extends BaseTabs<
     if ('divide' in tabItem) {
       return null;
     }
+
+    const { forceRenderPanel } = this.props;
     return (
       <LazyMount mount={tabItem.actived} key={tabItem.key}>
         <TabPanel
           tab={tabItem.title}
           actived={tabItem.actived}
+          forceRender={forceRenderPanel}
           className={tabItem.className}
           id={tabItem.key}
         >

--- a/packages/zent/src/tabs/VerticalTabs.tsx
+++ b/packages/zent/src/tabs/VerticalTabs.tsx
@@ -30,7 +30,7 @@ export class VerticalTabs<Id extends string | number = string> extends BaseTabs<
   static defaultProps: Partial<IVerticalTabsProps<string>> = {
     activeId: '',
     onChange: noop,
-    forceRenderPanel: false,
+    unmountPanelOnHide: false,
   };
 
   get tabsCls() {
@@ -99,13 +99,13 @@ export class VerticalTabs<Id extends string | number = string> extends BaseTabs<
       return null;
     }
 
-    const { forceRenderPanel } = this.props;
+    const { unmountPanelOnHide } = this.props;
     return (
       <LazyMount mount={tabItem.actived} key={tabItem.key}>
         <TabPanel
           tab={tabItem.title}
           actived={tabItem.actived}
-          forceRender={forceRenderPanel}
+          unmountOnHide={tabItem.unmountOnHide || unmountPanelOnHide}
           className={tabItem.className}
           id={tabItem.key}
         >

--- a/packages/zent/src/tabs/components/TabPanel.tsx
+++ b/packages/zent/src/tabs/components/TabPanel.tsx
@@ -3,7 +3,13 @@ import cn from 'classnames';
 import { ITabPanelProps } from '../types';
 
 function TabPanel<Id>(props: React.PropsWithChildren<ITabPanelProps<Id>>) {
-  const { actived, className, children } = props;
+  const { actived, className, forceRender, children } = props;
+
+  // 不启用 forceRender 时，非 active 元素不渲染，直接返回 null
+  if (!actived && !forceRender) {
+    return null;
+  }
+
   const displayStyle: React.CSSProperties = actived ? {} : { display: 'none' };
 
   const panelCls = cn('zent-tabs-panel', className);

--- a/packages/zent/src/tabs/components/TabPanel.tsx
+++ b/packages/zent/src/tabs/components/TabPanel.tsx
@@ -3,10 +3,10 @@ import cn from 'classnames';
 import { ITabPanelProps } from '../types';
 
 function TabPanel<Id>(props: React.PropsWithChildren<ITabPanelProps<Id>>) {
-  const { actived, className, forceRender, children } = props;
+  const { actived, className, unmountOnHide, children } = props;
 
-  // 不启用 forceRender 时，非 active 元素不渲染，直接返回 null
-  if (!actived && !forceRender) {
+  // 启用 unmountOnHide 时，非 active 元素不渲染，直接返回 null
+  if (!actived && unmountOnHide) {
     return null;
   }
 

--- a/packages/zent/src/tabs/components/TabPanel.tsx
+++ b/packages/zent/src/tabs/components/TabPanel.tsx
@@ -4,14 +4,11 @@ import { ITabPanelProps } from '../types';
 
 function TabPanel<Id>(props: React.PropsWithChildren<ITabPanelProps<Id>>) {
   const { actived, className, children } = props;
-
-  if (!actived) {
-    return null;
-  }
+  const displayStyle: React.CSSProperties = actived ? {} : { display: 'none' };
 
   const panelCls = cn('zent-tabs-panel', className);
   return (
-    <div role="tabpanel" className={panelCls}>
+    <div role="tabpanel" style={displayStyle} className={panelCls}>
       {children}
     </div>
   );

--- a/packages/zent/src/tabs/components/base/BaseTabs.tsx
+++ b/packages/zent/src/tabs/components/base/BaseTabs.tsx
@@ -38,7 +38,7 @@ abstract class BaseTabs<
       <div className={this.tabsCls}>
         {this.renderNav(tabDataList)}
         <div className="zent-tabs-panel-wrapper">
-          {tabDataList.map(this.renderTabPanel)}
+          {tabDataList.map(this.renderTabPanel.bind(this))}
         </div>
       </div>
     );

--- a/packages/zent/src/tabs/types.ts
+++ b/packages/zent/src/tabs/types.ts
@@ -15,6 +15,7 @@ export type IVerticalTab<Id> = ITab<Id> | IVerticalDivide;
 
 export interface IInnerTab<Id> extends ITab<Id> {
   actived: boolean;
+  unmountOnHide?: boolean;
   panelChildren?: React.ReactNode;
 }
 
@@ -28,7 +29,7 @@ export interface ITabPanelProps<Id> {
   className?: string;
   disabled?: boolean;
   actived?: boolean;
-  forceRender?: boolean;
+  unmountOnHide?: boolean;
 }
 
 export type IVerticalTabPanelProps<Id> = ITabPanelProps<Id> | IVerticalDivide;
@@ -42,7 +43,7 @@ export interface IBaseTabsProps<Id, TabPanelProps> {
   activeId: Id;
   className?: string;
   tabs?: Array<ITab<Id>>;
-  forceRenderPanel?: boolean;
+  unmountPanelOnHide?: boolean;
   children?:
     | ITabPanelElement<TabPanelProps>
     | Array<ITabPanelElement<TabPanelProps>>;

--- a/packages/zent/src/tabs/types.ts
+++ b/packages/zent/src/tabs/types.ts
@@ -28,6 +28,7 @@ export interface ITabPanelProps<Id> {
   className?: string;
   disabled?: boolean;
   actived?: boolean;
+  forceRender?: boolean;
 }
 
 export type IVerticalTabPanelProps<Id> = ITabPanelProps<Id> | IVerticalDivide;
@@ -41,6 +42,7 @@ export interface IBaseTabsProps<Id, TabPanelProps> {
   activeId: Id;
   className?: string;
   tabs?: Array<ITab<Id>>;
+  forceRenderPanel?: boolean;
   children?:
     | ITabPanelElement<TabPanelProps>
     | Array<ITabPanelElement<TabPanelProps>>;

--- a/packages/zent/src/tabs/utils.ts
+++ b/packages/zent/src/tabs/utils.ts
@@ -10,6 +10,7 @@ export function getTabDataFromChild<Id>(
     tab,
     children: panelChildren,
     className: panelClassName,
+    unmountOnHide,
   } = child.props;
   const props: IInnerTab<Id> = {
     title: tab,
@@ -18,6 +19,7 @@ export function getTabDataFromChild<Id>(
     actived: activeId === id,
     panelChildren,
     className: panelClassName,
+    unmountOnHide,
   };
 
   return props;


### PR DESCRIPTION
- 修改 Panel 的默认渲染行为为使用 `display:none` 隐藏，而不是返回 `null`
- 添加 `unmountPanelOnHide` 和 `unmountOnHide` 参数，支持 Panel 的两种不同的渲染行为