### PR TITLE
[new feature] Select: 增加 retainNullOption 配置，允许当 resetOption 启用时，才重置 selectedItem

### DIFF
--- a/packages/zent/src/select/README_en-US.md
+++ b/packages/zent/src/select/README_en-US.md
@@ -51,6 +51,7 @@ Options list pop-up layer, is mainly responsible for display options, data filte
 | className | Optional, custom trigger additional classname | string | `''` | no |
 | popupClassName | Optional, custom popup classname | string | `''`    | no |
 | autoWidth | Whether to automatically set the width of pop-up layer equal with input-box's width | bool | `false` | no |
+| retainNullOption | Strict reset option judgment | bool | `false` | no |
 | resetOption | Whether to add a reset option | bool | `false` | no |
 | resetText | Reset option text | string | `'...'` | no |
 | width |  input-box's width | string or number |  | no |

--- a/packages/zent/src/select/README_zh-CN.md
+++ b/packages/zent/src/select/README_zh-CN.md
@@ -52,6 +52,7 @@ group: 数据
 | className | 可选，自定义trigger额外类名 | string | `''` | 否 |
 | popupClassName | 可选，自定义popup的类名 | string | `''`    | 否 |
 | autoWidth | 是否自动设置弹出层与输入框等宽 | bool | `false` | 否 |
+| retainNullOption | 严格的重置选项判断 | bool | `false` | 否 |
 | resetOption | 是否加入一个重置选项 | bool | `false` | 否 |
 | resetText | 重置选项文本 | string | `'...'` | 否 |
 | width |  输入框宽度 | string or number |  | 否 |

--- a/packages/zent/src/select/Select.tsx
+++ b/packages/zent/src/select/Select.tsx
@@ -342,7 +342,7 @@ export class Select extends React.Component<ISelectProps, any> {
         selectedItems.push(selectedItem);
       }
     } else if (
-      selectedItem.value === null ||
+      (!retainNullOption && selectedItem.value === null) ||
       (retainNullOption && resetOption && selectedItem.value === null)
     ) {
       // customize reset option

--- a/packages/zent/src/select/Select.tsx
+++ b/packages/zent/src/select/Select.tsx
@@ -321,6 +321,7 @@ export class Select extends React.Component<ISelectProps, any> {
       onEmptySelected,
       optionValue,
       optionText,
+      resetOption,
       tags,
       onChange,
     } = this.props;
@@ -337,7 +338,7 @@ export class Select extends React.Component<ISelectProps, any> {
       if (!selectedItems.some(item => item.cid === selectedItem.cid)) {
         selectedItems.push(selectedItem);
       }
-    } else if (selectedItem.value === null) {
+    } else if (resetOption && selectedItem.value === null) {
       // customize reset option
       selectedItem = {};
     }

--- a/packages/zent/src/select/Select.tsx
+++ b/packages/zent/src/select/Select.tsx
@@ -54,6 +54,7 @@ export interface ISelectProps {
   className?: string;
   popupClassName?: string;
   autoWidth?: boolean;
+  retainNullOption?: boolean;
   resetOption?: boolean;
   resetText?: string;
   width?: number | string;
@@ -75,6 +76,7 @@ export class Select extends React.Component<ISelectProps, any> {
     autoWidth: false,
 
     // 重置为默认值
+    retainNullOption: false,
     resetOption: false,
     resetText: '...',
 
@@ -321,6 +323,7 @@ export class Select extends React.Component<ISelectProps, any> {
       onEmptySelected,
       optionValue,
       optionText,
+      retainNullOption,
       resetOption,
       tags,
       onChange,
@@ -338,7 +341,10 @@ export class Select extends React.Component<ISelectProps, any> {
       if (!selectedItems.some(item => item.cid === selectedItem.cid)) {
         selectedItems.push(selectedItem);
       }
-    } else if (resetOption && selectedItem.value === null) {
+    } else if (
+      selectedItem.value === null ||
+      (retainNullOption && resetOption && selectedItem.value === null)
+    ) {
       // customize reset option
       selectedItem = {};
     }


### PR DESCRIPTION
当前 Select 仅通过 value===null 判定是否触发重置操作，会出现误判。
通过增加对 resetOption 的判断，试图避免如下情况：
比如产品要求增加一个“全部”选项，并要求选中后展示为“全部”文案，而不是重置效果。
试图在第一项中，插入一个 `{ text: '全部', value: null }` 选项，但仍然触发了重置操作。
