### PR TITLE
Retain imports if not matched

### DIFF
--- a/packages/babel-plugin-zent/src/index.js
+++ b/packages/babel-plugin-zent/src/index.js
@@ -72,18 +72,44 @@ export default function babelPluginZent(babel) {
 
           const { opts: options } = state;
           if (options.noModuleRewrite) {
-            path.insertAfter(replacement);
+            state.data.ops.insert.push({
+              path,
+              replacement,
+            });
+            // path.insertAfter(replacement);
           } else {
-            path.replaceWithMultiple(replacement);
+            // path.replaceWithMultiple(replacement);
+            state.data.ops.replace.push({
+              path,
+              replacement,
+            });
           }
         }
+      },
+
+      Program: {
+        exit(path, state) {
+          const ops = state.data && state.data.ops;
+          if (!ops) {
+            return;
+          }
+
+          ops.insert.forEach(op => {
+            op.path.insertAfter(op.replacement);
+          });
+
+          ops.replace.forEach(op => {
+            const rep = consolidatesImports(t, op.replacement);
+            op.path.replaceWithMultiple(rep);
+          });
+        },
       },
     },
   };
 }
 
 function buildImportReplacement(specifier, types, state, originalPath) {
-  initModuleMappingAsNecessary(state, originalPath);
+  initModuleStateAsNecessary(state, originalPath);
 
   // import {Button as _Button} from 'zent'
   // imported name is Button, but local name is _Button
@@ -133,8 +159,11 @@ function buildImportReplacement(specifier, types, state, originalPath) {
       });
     }
   } else {
-    throw originalPath.buildCodeFrameError(
-      `No export named '${importedName}' found in zent.`
+    replacement.push(
+      types.importDeclaration(
+        buildImportSpecifier(types, false, importedName, localName),
+        types.stringLiteral(libName)
+      )
     );
   }
 
@@ -154,7 +183,7 @@ function buildImportSpecifier(types, isDefaultExport, importedName, localName) {
   ];
 }
 
-function initModuleMappingAsNecessary(state, path) {
+function initModuleStateAsNecessary(state, path) {
   const { opts: options } = state;
 
   if (!state.data) {
@@ -162,6 +191,14 @@ function initModuleMappingAsNecessary(state, path) {
   }
 
   const data = state.data;
+
+  // Store all the paths that needs transform
+  // We only flush these operations at Program.exit
+  data.ops = {
+    insert: [],
+    replace: [],
+  };
+
   if (!data.MODULE_MAPPING) {
     // options.moduleMappingFile is for internal use
     const moduleMappingFile =
@@ -179,6 +216,42 @@ function initModuleMappingAsNecessary(state, path) {
       data.STYLE_IMPORT_MAPPING = {};
     }
   }
+}
+
+function consolidatesImports(types, nodes) {
+  const rv = nodes.reduce(
+    (state, n) => {
+      const mod = n.source.value;
+      const { consolidated, moduleMap } = state;
+      const { specifiers } = n;
+
+      // side-effect import, e.g. import from 'zent/css/button.css';
+      if (specifiers.length === 0) {
+        consolidated.push(n);
+      }
+
+      specifiers.forEach(sp => {
+        // Consolidate import { x } from 'zent'; import { y } from 'zent'; only
+        if (types.isImportSpecifier(sp)) {
+          if (!moduleMap[mod]) {
+            n.specifiers = [];
+            moduleMap[mod] = n;
+            consolidated.push(n);
+          }
+
+          const importNode = moduleMap[mod];
+          importNode.specifiers.push(sp);
+        } else {
+          consolidated.push(n);
+        }
+      });
+
+      return state;
+    },
+    { moduleMap: {}, consolidated: [] }
+  );
+
+  return rv.consolidated;
 }
 
 function getJavaScriptPath(relativePath, libName) {

--- a/packages/babel-plugin-zent/src/index.js
+++ b/packages/babel-plugin-zent/src/index.js
@@ -99,7 +99,7 @@ export default function babelPluginZent(babel) {
           });
 
           ops.replace.forEach(op => {
-            const rep = consolidatesImports(t, op.replacement);
+            const rep = consolidateImports(t, op.replacement);
             op.path.replaceWithMultiple(rep);
           });
         },
@@ -218,7 +218,7 @@ function initModuleStateAsNecessary(state, path) {
   }
 }
 
-function consolidatesImports(types, nodes) {
+function consolidateImports(types, nodes) {
   const rv = nodes.reduce(
     (state, n) => {
       const mod = n.source.value;


### PR DESCRIPTION
Transforms

```js
import { NotFound, NotExists, Button, Icon }  from 'zent'
```

into 

```js
import { NotFound, NotExists } from 'zent';
import Button from 'zent/es/....';
import Icon from 'zent/es/....'; 
```

It throws when processing `NotFound` or `NotExists` before.