### PR TITLE
fix Radio and Checkbox height

### DIFF
--- a/packages/zent/assets/checkbox.scss
+++ b/packages/zent/assets/checkbox.scss
@@ -3,17 +3,14 @@
 $size: 16px;
 
 .zent-checkbox-group {
-  @include font-normal;
-
   display: inline-block;
+  font-size: 0;
 }
 
 .zent-checkbox-wrap {
-  @include font-normal;
-
   display: inline-block;
   cursor: pointer;
-  font-weight: $font-weight-normal;
+  font-size: 0;
   margin: 0;
   padding: 0;
   margin-right: 15px;
@@ -36,6 +33,7 @@ $size: 16px;
   white-space: nowrap;
   outline: none;
   vertical-align: middle;
+  font-size: $font-size-normal;
   line-height: 1;
   margin: 0;
   padding: 0;
@@ -56,6 +54,9 @@ $size: 16px;
   }
 
   &-label {
+    @include font-normal;
+
+    font-weight: $font-weight-normal;
     margin-left: 8px;
     display: inline-block;
     vertical-align: middle;

--- a/packages/zent/assets/radio.scss
+++ b/packages/zent/assets/radio.scss
@@ -7,17 +7,14 @@ $inner-circle-size: 8px;
 $inner-circle-offset: ($outer-circle-size - $inner-circle-size - 2px) / 2;
 
 .zent-radio-group {
-  @include font-normal;
-
   display: inline-block;
+  font-size: 0;
 }
 
 .zent-radio-wrap {
-  @include font-normal;
-
   display: inline-block;
   cursor: pointer;
-  font-weight: $font-weight-normal;
+  font-size: 0;
   margin: 0;
   padding: 0;
   margin-right: 15px;
@@ -52,7 +49,9 @@ $inner-circle-offset: ($outer-circle-size - $inner-circle-size - 2px) / 2;
       cursor: pointer;
     }
 
-    & + span {
+    &-label {
+      @include font-normal;
+      display: inline-block;
       margin-left: 8px;
       vertical-align: middle;
     }
@@ -129,7 +128,7 @@ $inner-circle-offset: ($outer-circle-size - $inner-circle-size - 2px) / 2;
       }
     }
 
-    & .zent-radio + span {
+    & .zent-radio-label {
       @include theme-color(color, stroke, 3);
     }
   }

--- a/packages/zent/src/radio/Radio.tsx
+++ b/packages/zent/src/radio/Radio.tsx
@@ -52,7 +52,9 @@ function Radio<Value>(props: IRadioProps<Value>) {
           onChange={onChange}
         />
       </span>
-      {children !== undefined && <span>{children}</span>}
+      {children !== undefined && (
+        <span className="zent-radio-label">{children}</span>
+      )}
     </label>
   );
 }


### PR DESCRIPTION
Remove extra space introduced by `inline-block`  in `Radio` and `Checkbox`.