### PR TITLE
bugfix: 修复 CopyButton 的类型错误

### DIFF
--- a/packages/zent/src/copy-button/index.tsx
+++ b/packages/zent/src/copy-button/index.tsx
@@ -8,7 +8,7 @@ import { I18nReceiver as Receiver, II18nLocaleCopyButton } from '../i18n';
 import CopyToClipboard from './ReactCopyToClipboard';
 
 export interface ICopyButtonProps {
-  text: () => string | string;
+  text: (() => string) | string;
   onClick?: React.MouseEventHandler;
   onCopySuccess?: () => void | string;
   onCopyError?: () => void | string;


### PR DESCRIPTION
- 修复 `CopyButton` 组件的 `text` prop 类型错误
