### PR TITLE
[bug fix] FormSelectField: 修复 IFormSelectFieldProps['name'] 类型推断

### DIFF
--- a/packages/zent/src/form/form-components/SelectField.tsx
+++ b/packages/zent/src/form/form-components/SelectField.tsx
@@ -22,11 +22,9 @@ import { FormControl } from '../Control';
 import { $MergeParams } from '../utils';
 import { defaultGetValidateOption } from '../Field';
 
-export type IFormSelectFieldProps<T> = Omit<
-  IFormComponentProps<
-    T | T[],
-    Omit<ISelectProps, 'value' | 'tags' | 'onChange'>
-  >,
+export type IFormSelectFieldProps<T> = IFormComponentProps<
+  T | T[],
+  Omit<ISelectProps, 'value' | 'tags' | 'onChange'>,
   'normalize' | 'format'
 > & {
   tags?: boolean;

--- a/packages/zent/src/form/shared.tsx
+++ b/packages/zent/src/form/shared.tsx
@@ -103,10 +103,11 @@ export type IFormFieldProps<Value> = IFormFieldPropsBase<Value> &
     children(props: IFormFieldChildProps<Value>): React.ReactNode;
   };
 
-export type IFormComponentProps<Value, Props> = (Omit<
-  IFormFieldPropsBase<Value>,
-  'touchWhen'
-> & {
+export type IFormComponentProps<
+  Value,
+  Props,
+  OmitKeys extends string = ''
+> = (Omit<IFormFieldPropsBase<Value>, 'touchWhen' | OmitKeys> & {
   props?: Partial<Props>;
 }) &
   (


### PR DESCRIPTION
[bug fix]: 修正IFormSelectFieldProps的类型错误
+ Omit在用于联合类型时会推断成never，因此把Omit放在IFormComponentProps内部，之后需要特别Omit时直接传入OmitKeys泛型参数即可。

