### PR TITLE
fix missing data-zv in zent-grid-tr

### DIFF
--- a/packages/zent/src/grid/Row.tsx
+++ b/packages/zent/src/grid/Row.tsx
@@ -89,6 +89,8 @@ class Row<Data> extends PureComponent<IGridRowProps<Data>> {
         onMouseEnter={() => scroll && scroll.x && onRowMouseEnter(rowIndex)}
         style={{ height }}
         {...rowProps(data, rowIndex)}
+        /* ts-plugin-version-attribute ignores this element, but it may be a tr... */
+        data-zv={__ZENT_VERSION__}
       >
         {cells}
       </BodyRow>


### PR DESCRIPTION
The following code is not transformed by ts-plugin-version-attribute, so `data-zv` is missing.

```js
const Tr = props.something || 'tr';

return <Tr>...</Tr>

```