### PR TITLE
Fix Radio and Checkbox style, add labelStyle prop

### DIFF
--- a/packages/zent/assets/checkbox.scss
+++ b/packages/zent/assets/checkbox.scss
@@ -5,6 +5,10 @@ $size: 16px;
 .zent-checkbox-group {
   display: inline-block;
   font-size: 0;
+
+  > :not(.zent-checkbox-wrap) {
+    @include font-normal;
+  }
 }
 
 .zent-checkbox-wrap {

--- a/packages/zent/assets/radio.scss
+++ b/packages/zent/assets/radio.scss
@@ -55,6 +55,7 @@ $inner-circle-offset: ($outer-circle-size - $inner-circle-size - 2px) / 2;
 
     &-label {
       @include font-normal;
+      display: inline;
       margin-left: 8px;
       vertical-align: middle;
     }

--- a/packages/zent/assets/radio.scss
+++ b/packages/zent/assets/radio.scss
@@ -9,6 +9,10 @@ $inner-circle-offset: ($outer-circle-size - $inner-circle-size - 2px) / 2;
 .zent-radio-group {
   display: inline-block;
   font-size: 0;
+
+  > :not(.zent-radio-wrap) {
+    @include font-normal;
+  }
 }
 
 .zent-radio-wrap {
@@ -51,7 +55,6 @@ $inner-circle-offset: ($outer-circle-size - $inner-circle-size - 2px) / 2;
 
     &-label {
       @include font-normal;
-      display: inline-block;
       margin-left: 8px;
       vertical-align: middle;
     }

--- a/packages/zent/src/checkbox/Checkbox.tsx
+++ b/packages/zent/src/checkbox/Checkbox.tsx
@@ -26,6 +26,7 @@ export interface ICheckboxProps<Value> {
   onChange?: (e: ICheckboxEvent<Value>) => void;
   className?: string;
   style?: React.CSSProperties;
+  labelStyle?: React.CSSProperties;
   width?: number;
   children?: React.ReactNode;
 }
@@ -95,6 +96,7 @@ export function Checkbox<Value>(props: ICheckboxProps<Value>) {
     width,
     // value可以是任意类型，不要写到dom上去
     value,
+    labelStyle,
     ...others
   } = props;
   const readOnly = getReadOnly(groupCtx, props);
@@ -133,7 +135,9 @@ export function Checkbox<Value>(props: ICheckboxProps<Value>) {
       children !== null &&
       children !== true &&
       children !== false ? (
-        <div className="zent-checkbox-label">{children}</div>
+        <div className="zent-checkbox-label" style={labelStyle}>
+          {children}
+        </div>
       ) : null}
     </label>
   );

--- a/packages/zent/src/checkbox/README_en-US.md
+++ b/packages/zent/src/checkbox/README_en-US.md
@@ -16,27 +16,28 @@ group: Data Entry
 
 #### Checkbox API
 
-| Property     |  Description  | Type     | Default  | Alternative |
-| ------------- | --------- | ------------- | -------- |
-| checked       | Whether the checkbox is selected  | bool | `false`  |
-| value         | The value of the components, which is used in `CheckboxGroup` | any |  |
-| disabled      | Disable the checkbox | bool          |          |
-| readOnly      | It specifies the component is read-only | bool          |          |
-| indeterminate | Show style of partially selection | bool | `false`|
-| onChange      | The callback function that is triggered when the checkbox is changed   | func(e:Event) |          |
-| className     | The custom classname   | string        |          |
-| prefix        | The custom prefix     | string        | `'zent'` |
+| Property      | Description                                                          | Type                  | Default  | Alternative |
+| ------------- | -------------------------------------------------------------------- | --------------------- | -------- | ----------- |
+| checked       | Whether the checkbox is selected                                     | `boolean`             | `false`  |
+| value         | The value of the components, which is used in `CheckboxGroup`        | `any`                 |          |
+| disabled      | Disable the checkbox                                                 | `boolean`             |          |
+| readOnly      | It specifies the component is read-only                              | `boolean`             |          |
+| indeterminate | Show style of partially selection                                    | `boolean`             | `false`  |
+| onChange      | The callback function that is triggered when the checkbox is changed | `(e:Event) => void`   |          |
+| labelStyle    | Label inline style                                                   | `React.CSSProperties` |          |
+| className     | The custom classname                                                 | `string`              |          |
+| prefix        | The custom prefix                                                    | `string`              | `'zent'` |
 
 #### Checkbox Group API
 
-| Property     |  Description  | Type     | Default  | Alternative |
-| ------------ | --------------- | ------------------ | --------------- |
-| value        | The value when checkbox is checked, which is required | array<any>  | `[]` |
-| isValueEqual | The funtion to judge whether the value is equal | func(a, b) | `() => a === b` |
-| disabled     | Disable the checkbox group  | bool               |                 |
-| readOnly     | It specifies the component is read-only | bool          |          |
-| onChange     | The callback function that is triggered when the checkbox group is changed | func(checkedValueList) |                 |
-| className    | The custom classname  | string             |                 |
-| prefix       | The custom prefix  | string             | `'zent'`        |
+| Property     | Description                                                                | Type                                | Default         | Alternative |
+| ------------ | -------------------------------------------------------------------------- | ----------------------------------- | --------------- | ----------- |
+| value        | The value when checkbox is checked, which is required                      | `any[]`                             | `[]`            |
+| isValueEqual | The funtion to judge whether the value is equal                            | `(a: any, b: any) => boolean`       | `() => a === b` |
+| disabled     | Disable the checkbox group                                                 | `boolean`                           |                 |
+| readOnly     | It specifies the component is read-only                                    | `boolean`                           |                 |
+| onChange     | The callback function that is triggered when the checkbox group is changed | `(checkedValueList: any[]) => void` |                 |
+| className    | The custom classname                                                       | `string`                            |                 |
+| prefix       | The custom prefix                                                          | `string`                            | `'zent'`        |
 
 [controlled-components]: https://facebook.github.io/react/docs/forms.html#controlled-components

--- a/packages/zent/src/checkbox/README_zh-CN.md
+++ b/packages/zent/src/checkbox/README_zh-CN.md
@@ -9,35 +9,36 @@ group: 数据
 
 ### 使用指南
 
-- Checkbox 表现为一个[受控组件][https://facebook.github.io/react/docs/forms.html#controlled-components], 需要设置 `onChange` 回调在组件外部处理其 `value` 属性的变化.
+- Checkbox 表现为一个[受控组件][https://facebook.github.io/react/docs/forms.html#controlled-components], 需要设置 `onChange` 回调在组件外部处理其 `value` 属性的变化。
 
-- `value` 支持任意类型的值, 包括引用类型.
+- `value` 支持任意类型的值, 包括引用类型。
 
 ### API
 
 #### Checkbox API
 
-| 参数            | 说明        | 类型            | 默认值      |
-| ------------- | --------- | ------------- | -------- |
-| checked       | 指定当前是否选中  | bool          | `false`  |
-| value         | 组件对应的值，在`CheckboxGroup`中使用    | any           |          |
-| disabled      | 使组件不可用    | bool          |          |
-| readOnly      | 使组件只读           | bool               |                 |
-| indeterminate | 展示部分选中的模式 | bool          | `false`  |
-| onChange      | 变化时回调函数   | func(e:Event) |          |
-| className     | 自定义额外类名   | string        |          |
-| prefix        | 自定义前缀     | string        | `'zent'` |
+| 参数          | 说明                                  | 类型                  | 默认值   |
+| ------------- | ------------------------------------- | --------------------- | -------- |
+| checked       | 指定当前是否选中                      | `boolean`             | `false`  |
+| value         | 组件对应的值，在`CheckboxGroup`中使用 | any                   |          |
+| disabled      | 使组件不可用                          | `boolean`             |          |
+| readOnly      | 使组件只读                            | `boolean`             |          |
+| indeterminate | 展示部分选中的模式                    | `boolean`             | `false`  |
+| onChange      | 变化时回调函数                        | `(e:Event) => void`   |          |
+| labelStyle    | label 的内联样式                      | `React.CSSProperties` |          |
+| className     | 自定义额外类名                        | `string`              |          |
+| prefix        | 自定义前缀                            | `string`              | `'zent'` |
 
 #### Checkbox Group API
 
-| 参数           | 说明              | 类型                 | 默认值             |
-| ------------ | --------------- | ------------------ | --------------- |
-| value        | 必填，指定选中的选项      | array<any>         | `[]`            |
-| isValueEqual | 可选，判断value值是否相等 | func(a, b)         | `() => a === b` |
-| disabled     | 使组件不可用          | bool               |                 |
-| readOnly     | 使组件只读           | bool               |                 |
-| onChange     | 变化时回调函数         | func(checkedValueList) |                 |
-| className    | 自定义额外类名         | string             |                 |
-| prefix       | 自定义前缀           | string             | `'zent'`        |
+| 参数         | 说明                        | 类型                                | 默认值          |
+| ------------ | --------------------------- | ----------------------------------- | --------------- |
+| value        | 必填，指定选中的选项        | `any[]`                             | `[]`            |
+| isValueEqual | 可选，判断 value 值是否相等 | `(a: any, b: any) => boolean`       | `() => a === b` |
+| disabled     | 使组件不可用                | `boolean`                           |                 |
+| readOnly     | 使组件只读                  | `boolean`                           |                 |
+| onChange     | 变化时回调函数              | `(checkedValueList: any[]) => void` |                 |
+| className    | 自定义额外类名              | `string`                            |                 |
+| prefix       | 自定义前缀                  | `string`                            | `'zent'`        |
 
 [controlled-components]: https://facebook.github.io/react/docs/forms.html#controlled-components

--- a/packages/zent/src/checkbox/demos/multi-line.md
+++ b/packages/zent/src/checkbox/demos/multi-line.md
@@ -1,0 +1,58 @@
+---
+order: 6
+zh-CN:
+	title: 多行文本
+	text1: 我不能创造的东西，我就不了解。
+	text2: 我很早就明白知道一样事物(Know-how) 和知道一样事物的名字(Know-what)的分别。
+	text3: 事实证明真理总是比你想象得更简单。
+	switch: 切换标签 `display`
+en-US:
+	title: Multi line text
+	text1: What I cannot create, I do not understand.
+	text2: I learned very early the difference between knowing the name of something and knowing something.
+	text3: The truth always turns out to be simpler than you thought.
+	switch: Switch label `display`
+---
+
+```jsx
+import { Checkbox, Button } from 'zent';
+
+class App extends React.Component {
+	state = {
+		style: {},
+		checked: [],
+	};
+
+	onStyleChange = e => {
+		this.setState(state => ({
+			style: state.style.display === 'inline' ? {} : { display: 'inline' },
+		}));
+	};
+
+	handleChange = checked => {
+		this.setState({
+			checked,
+		});
+	};
+
+	render() {
+		const { checked, style } = this.state;
+		return (
+			<div>
+				<Checkbox.Group value={checked} onChange={this.handleChange}>
+					<Checkbox value="Apple" labelStyle={style}>
+						{i18n.text1}
+						<p>{i18n.text2}</p>
+					</Checkbox>
+					<div style={{ color: '#969799', marginTop: 8 }}>{i18n.text3}</div>
+				</Checkbox.Group>
+				<div style={{ marginTop: 16 }}>
+					<Button onClick={this.onStyleChange}>{i18n.switch}</Button>
+				</div>
+			</div>
+		);
+	}
+}
+
+ReactDOM.render(<App />, mountNode);
+```

--- a/packages/zent/src/radio/README_en-US.md
+++ b/packages/zent/src/radio/README_en-US.md
@@ -12,23 +12,24 @@ group: Data Entry
 
 #### RadioGroup
 
-| Props           | Description                | Type             | Default                 |
-| ------------ | ----------------- | -------------- | ------------------- |
-| value        | Used to set the currently selected value        | any            |                     |
-| disabled      | Disable the radio group | bool          |          |
-| readOnly      | It specifies the component is read-only | bool          |          |
-| onChange     | change callback        | func(e: event) |                     |
-| isValueEqual | Optional, a function to determine whether values is equal | func(a, b)     | `(a, b) => a === b` |
-| className    | custom classname           | string         |                     |
-| prefix       | custom prefix  | string         | `'zent'`            |
+| Props        | Description                                               | Type                 | Default             |
+| ------------ | --------------------------------------------------------- | -------------------- | ------------------- |
+| value        | Used to set the currently selected value                  | `any`                |                     |
+| disabled     | Disable the radio group                                   | `boolean`            |                     |
+| readOnly     | It specifies the component is read-only                   | `boolean`            |                     |
+| onChange     | change callback                                           | `(e: Event) => void` |                     |
+| isValueEqual | Optional, a function to determine whether values is equal | `(a, b) => boolean`  | `(a, b) => a === b` |
+| className    | custom classname                                          | `string`             |                     |
+| prefix       | custom prefix                                             | `string`             | `'zent'`            |
 
 #### Radio
 
-| Props        | Description                   | Type     | Default      |
-| --------- | -------------------- | ------ | -------- |
-| value     | Compare according to the, determine if selected | any    |          |
-| disabled      | Disable the radio | bool          |          |
-| readOnly      | It specifies the component is read-only | bool          |          |
-| className | custom classname              | string |          |
-| width    | radio's width           | string or number         |                     |
-| prefix    | custom prefix     | string | `'zent'` |
+| Props      | Description                                     | Type                  | Default  |
+| ---------- | ----------------------------------------------- | --------------------- | -------- |
+| value      | Compare according to the, determine if selected | `any`                 |          |
+| disabled   | Disable the radio                               | `boolean`                |          |
+| readOnly   | It specifies the component is read-only         | `boolean`                |          |
+| labelStyle | Label inline style                              | `React.CSSProperties` |          |
+| className  | custom classname                                | `string`              |          |
+| width      | radio's width                                   | `string` \| `number`  |          |
+| prefix     | custom prefix                                   | `string`              | `'zent'` |

--- a/packages/zent/src/radio/README_zh-CN.md
+++ b/packages/zent/src/radio/README_zh-CN.md
@@ -13,24 +13,24 @@ group: 数据
 
 #### RadioGroup
 
-| 参数           | 说明                | 类型             | 默认值                 |
-| ------------ | ----------------- | -------------- | ------------------- |
-| value        | 用于设置当前选中的值        | any            |                     |
-| disabled     | 使组件不可用    | bool          |          |
-| readOnly     | 使组件只读           | bool               |                 |
-| onChange     | 选项变化时的回调函数        | func(e: event) |                     |
-| isValueEqual | 可选参数，判断value值是否相等 | func(a, b)     | `(a, b) => a === b` |
-| className    | 自定义额外类名           | string         |                     |
-| prefix       | 自定义前缀             | string         | `'zent'`            |
+| 参数         | 说明                            | 类型                          | 默认值              |
+| ------------ | ------------------------------- | ----------------------------- | ------------------- |
+| value        | 用于设置当前选中的值            | `any`                         |                     |
+| disabled     | 使组件不可用                    | `boolean`                     |                     |
+| readOnly     | 使组件只读                      | `boolean`                     |                     |
+| onChange     | 选项变化时的回调函数            | `(e: Event) => void`          |                     |
+| isValueEqual | 可选参数，判断 value 值是否相等 | `(a: any, b: any) => boolean` | `(a, b) => a === b` |
+| className    | 自定义额外类名                  | `string`                      |                     |
+| prefix       | 自定义前缀                      | `string`                      | `'zent'`            |
 
 #### Radio
 
-| 参数        | 说明                   | 类型     | 默认值      |
-| --------- | -------------------- | ------ | -------- |
-| value     | 根据 value 进行比较，判断是否选中 | any    |          |
-| disabled     | 使组件不可用    | bool          |          |
-| readOnly     | 使组件只读           | bool               |                 |
-| className | 自定义额外类名              | string |          |
-| width    | 宽度          | string or number         |                     |
-| prefix    | 自定义前缀                | string | `'zent'` |
-
+| 参数       | 说明                              | 类型                  | 默认值   |
+| ---------- | --------------------------------- | --------------------- | -------- |
+| value      | 根据 value 进行比较，判断是否选中 | `any`                  |          |
+| disabled   | 使组件不可用                      | `boolean`             |          |
+| readOnly   | 使组件只读                        | `boolean`             |          |
+| labelStyle | label 的内联样式                  | `React.CSSProperties` |          |
+| className  | 自定义额外类名                    | `string`              |          |
+| width      | 宽度                              | `string` \| `number`  |          |
+| prefix     | 自定义前缀                        | `string`              | `'zent'` |

--- a/packages/zent/src/radio/Radio.tsx
+++ b/packages/zent/src/radio/Radio.tsx
@@ -8,7 +8,9 @@ import RadioButton from './RadioButton';
 import { DisabledContext } from '../disabled';
 import GroupContext from './GroupContext';
 
-function Radio<Value>(props: IRadioProps<Value>) {
+function Radio<Value>(
+  props: IRadioProps<Value> & { labelStyle?: React.CSSProperties }
+) {
   const {
     className,
     style,
@@ -17,6 +19,9 @@ function Radio<Value>(props: IRadioProps<Value>) {
     // value 不要放到 input 上去
     value,
     width,
+
+    labelStyle,
+
     ...others
   } = props;
   const disabledCtx = React.useContext(DisabledContext);
@@ -53,7 +58,9 @@ function Radio<Value>(props: IRadioProps<Value>) {
         />
       </span>
       {children !== undefined && (
-        <span className="zent-radio-label">{children}</span>
+        <span className="zent-radio-label" style={labelStyle}>
+          {children}
+        </span>
       )}
     </label>
   );

--- a/packages/zent/src/radio/demos/multi-line.md
+++ b/packages/zent/src/radio/demos/multi-line.md
@@ -1,0 +1,56 @@
+---
+order: 5
+zh-CN:
+	title: 多行文本
+	text1: 我不能创造的东西，我就不了解。
+	text2: 我很早就明白知道一样事物(Know-how) 和知道一样事物的名字(Know-what)的分别。
+	text3: 事实证明真理总是比你想象得更简单。
+	switch: 切换标签 `display`
+en-US:
+	title: Multi line text
+	text1: What I cannot create, I do not understand.
+	text2: I learned very early the difference between knowing the name of something and knowing something.
+	text3: The truth always turns out to be simpler than you thought.
+	switch: Switch label `display`
+---
+
+```js
+import { Radio, Button } from 'zent';
+
+const RadioGroup = Radio.Group;
+
+class App extends Component {
+	state = {
+		style: {},
+	};
+
+	onChange = e => {
+		this.setState(state => ({
+			style:
+				state.style.display === 'inline-block'
+					? {}
+					: { display: 'inline-block' },
+		}));
+	};
+
+	render() {
+		return (
+			<>
+				<RadioGroup onChange={this.onChange} value="1">
+					<Radio value="1" labelStyle={this.state.style}>
+						{i18n.text1}
+						<p>{i18n.text2}</p>
+					</Radio>
+					<p style={{ color: '#969799', marginTop: 8 }}>{i18n.text3}</p>
+				</RadioGroup>
+
+				<div style={{ marginTop: 16 }}>
+					<Button onClick={this.onChange}>{i18n.switch}</Button>
+				</div>
+			</>
+		);
+	}
+}
+
+ReactDOM.render(<App />, mountNode);
+```


### PR DESCRIPTION
- Revert `Radio` label display to `inline`
- Fix `font-size` in `RadioGroup` and `CheckboxGroup` children that is not a radio nor checkbox
- Add `labelStyle` to `Radio` and `Checkbox`