### PR TITLE
[bugfix] Upload: 修改文件数量计算规则

### DIFF
--- a/packages/zent/src/upload/ImageUpload.tsx
+++ b/packages/zent/src/upload/ImageUpload.tsx
@@ -131,7 +131,6 @@ export class ImageUpload extends AbstractUpload<
         maxSize={maxSize}
         multiple={multiple}
         disabled={disabled}
-        availableUploadItemsCount={this.availableUploadItemsCount}
         remainAmount={this.remainAmount}
         fileList={fileList}
         onAddFile={this.onTriggerUploadFile}

--- a/packages/zent/src/upload/ImageUpload.tsx
+++ b/packages/zent/src/upload/ImageUpload.tsx
@@ -55,6 +55,8 @@ export class ImageUpload extends AbstractUpload<
     accept: 'image/*',
   };
 
+  static FILE_UPLOAD_STATUS = FILE_UPLOAD_STATUS;
+
   protected getUploadSuccessOverrideProps(
     onUploadSuccessReturn: IImageOnUploadSuccessReturn
   ): Partial<IUploadFileItemInner<IImageUploadFileItem>> {

--- a/packages/zent/src/upload/Upload.tsx
+++ b/packages/zent/src/upload/Upload.tsx
@@ -48,6 +48,8 @@ export class Upload extends AbstractUpload<
     pagination: false,
   };
 
+  static FILE_UPLOAD_STATUS = FILE_UPLOAD_STATUS;
+
   protected createNewUploadFileItem(
     file: File
   ): IUploadFileItemInner<IUploadFileItem> {

--- a/packages/zent/src/upload/Upload.tsx
+++ b/packages/zent/src/upload/Upload.tsx
@@ -102,7 +102,6 @@ export class Upload extends AbstractUpload<
         maxSize={maxSize}
         multiple={multiple}
         disabled={disabled}
-        availableUploadItemsCount={this.availableUploadItemsCount}
         remainAmount={this.remainAmount}
         fileList={fileList}
         onAddFile={this.onTriggerUploadFile}

--- a/packages/zent/src/upload/components/AbstractUpload.tsx
+++ b/packages/zent/src/upload/components/AbstractUpload.tsx
@@ -68,20 +68,11 @@ abstract class AbstractUpload<
   }
 
   /**
-   * 在队列中的可用上传文件
-   */
-  get availableUploadItemsCount() {
-    return this.fileList.filter(
-      item => item.status !== FILE_UPLOAD_STATUS.failed
-    ).length;
-  }
-
-  /**
    * 剩余可上传文件数量
    */
   get remainAmount() {
     const { maxAmount } = this.props;
-    return maxAmount - this.availableUploadItemsCount;
+    return maxAmount - this.fileList.length;
   }
 
   private getUploadItem(id: string): IUploadFileItemInner<UPLOAD_ITEM> {

--- a/packages/zent/src/upload/components/normal/Trigger.tsx
+++ b/packages/zent/src/upload/components/normal/Trigger.tsx
@@ -9,13 +9,13 @@ export default class NormalUploadTrigger extends AbstractTrigger<
   IUploadFileItem
 > {
   renderFileItemCount() {
-    const { availableUploadItemsCount, maxAmount } = this.props;
+    const { fileList, maxAmount } = this.props;
     if (maxAmount === Infinity) {
       return null;
     }
     return (
       <span className="zent-file-upload-trigger-text-count">
-        {availableUploadItemsCount}/{maxAmount}
+        {fileList.length}/{maxAmount}
       </span>
     );
   }

--- a/packages/zent/src/upload/demos/manual.md
+++ b/packages/zent/src/upload/demos/manual.md
@@ -9,7 +9,10 @@ en-US:
 ---
 
 ```jsx
-import { ImageUpload, Button, Notify, FILE_UPLOAD_STATUS } from 'zent';
+import { ImageUpload, Button, Notify } from 'zent';
+
+// ImageUpload 和 Upload 上都有 FILE_UPLOAD_STATUS 这个静态属性
+const FILE_UPLOAD_STATUS = ImageUpload.FILE_UPLOAD_STATUS;
 
 class Simple extends React.Component {
 	state = {

--- a/packages/zent/src/upload/index.ts
+++ b/packages/zent/src/upload/index.ts
@@ -2,5 +2,4 @@ import Upload from './Upload';
 export * from './Upload';
 export * from './ImageUpload';
 export * from './types';
-export { FILE_UPLOAD_STATUS } from './constants';
 export default Upload;

--- a/packages/zent/src/upload/types.ts
+++ b/packages/zent/src/upload/types.ts
@@ -148,7 +148,6 @@ export interface IAbstractUploadTriggerProps<
   fileList: UPLOAD_ITEM[];
   disabled?: boolean;
   accept?: string;
-  availableUploadItemsCount: number;
   remainAmount: number;
   maxSize: number;
   maxAmount: number;


### PR DESCRIPTION
- 修改上传组件的文件数量计算规则，将上传失败的文件也统计到上传文件数量中
- 修改 `FILE_UPLOAD_STATUS` 常量的导出方式，将其设置为组件静态属性而不是顶部变量
- 更新 Demo 示例代码