### PR TITLE
Hotfix/date picker

### DIFF
--- a/packages/zent/__tests__/utils/date.js
+++ b/packages/zent/__tests__/utils/date.js
@@ -25,7 +25,7 @@ describe('getValidDate', () => {
 describe('parseDate', () => {
   it('Date', () => {
     const now = new Date();
-    expect(parseDate(now)).toBe(now);
+    expect(parseDate(now)).toEqual(now);
     expect(parseDate('2019-01-02', 'xxx-f-d-')).toBe(null);
     expect(parseDate(now.getTime()).getTime()).toBe(now.getTime());
     expect(parseDate('2019-01-02', 'YYYY-MM-DD').getTime()).toBe(

--- a/packages/zent/src/datetimepicker/DatePicker.tsx
+++ b/packages/zent/src/datetimepicker/DatePicker.tsx
@@ -155,7 +155,7 @@ export class DatePicker extends PureComponent<IDatePickerProps, any> {
     if (this.isDisabled(val)) return;
 
     // 如果选择的日期和最小日期同一天，则设置时间为最小日期的时间
-    activedTime = setSameDate(activedTime, val);
+    activedTime = setSameDate(val);
     if (min) {
       const minDate = parseDate(min, format);
       if (activedTime < minDate) {

--- a/packages/zent/src/datetimepicker/DatePicker.tsx
+++ b/packages/zent/src/datetimepicker/DatePicker.tsx
@@ -11,7 +11,7 @@ import DatePanel from './date/DatePanel';
 import PanelFooter from './common/PanelFooter';
 import {
   goMonths,
-  setSameDate,
+  cloneFromDate,
   formatDate,
   parseDate,
   dayStart,
@@ -155,7 +155,7 @@ export class DatePicker extends PureComponent<IDatePickerProps, any> {
     if (this.isDisabled(val)) return;
 
     // 如果选择的日期和最小日期同一天，则设置时间为最小日期的时间
-    activedTime = setSameDate(val);
+    activedTime = cloneFromDate(val);
     if (min) {
       const minDate = parseDate(min, format);
       if (activedTime < minDate) {

--- a/packages/zent/src/datetimepicker/utils/index.ts
+++ b/packages/zent/src/datetimepicker/utils/index.ts
@@ -65,11 +65,8 @@ export const goYears = (val, diff) => {
   return new Date(cp.setFullYear(cp.getFullYear() + diff));
 };
 
-export const setSameDate = (val, target) => {
-  val.setFullYear(target.getFullYear());
-  val.setMonth(target.getMonth());
-  val.setDate(target.getDate());
-  return val;
+export const setSameDate = target => {
+  return new Date(target.getFullYear(), target.getMonth(), target.getDate());
 };
 
 /**

--- a/packages/zent/src/datetimepicker/utils/index.ts
+++ b/packages/zent/src/datetimepicker/utils/index.ts
@@ -65,7 +65,7 @@ export const goYears = (val, diff) => {
   return new Date(cp.setFullYear(cp.getFullYear() + diff));
 };
 
-export const setSameDate = target => {
+export const cloneFromDate = target => {
   return new Date(target.getFullYear(), target.getMonth(), target.getDate());
 };
 

--- a/packages/zent/src/utils/date/parseDate.ts
+++ b/packages/zent/src/utils/date/parseDate.ts
@@ -23,7 +23,7 @@ export default function parseDate(
   locale = zhCN
 ): Date {
   if (date instanceof Date) {
-    return date;
+    return new Date(date.getTime());
   }
 
   if (typeof date === 'number') {


### PR DESCRIPTION
Changes you made in this pull request:

- setSameDate method
- parseDate method

补充描述: 
      DatePicker的属性value为Date对象变量时，组件内部直接拿引用赋值，并且在onSelectDate的setSameDate方法中直接改变对象的值，引起外部的value对象改变。
      parseDate功能理解为创建新的Date对象，那么传入Date类型的值，也应该返回一个新的Date对象，而非直接返回传入的实例。（个人理解）