### PR TITLE
fix: check the type of scroll-alert's children

### DIFF
--- a/packages/zent/__tests__/alert.js
+++ b/packages/zent/__tests__/alert.js
@@ -387,4 +387,23 @@ describe('ScrollAlert', () => {
         .containsMatchingElement(<div>foobar1</div>)
     ).toBe(true);
   });
+
+  it(' other node in scroll alert', () => {
+    const wrapper = mount(
+      <ScrollAlert>
+        <AlertItem>
+          <span>foobar1</span>
+        </AlertItem>
+        <div>
+          <span>foobar1</span>
+        </div>
+      </ScrollAlert>
+    );
+    expect(wrapper.find('.zent-alert-item').length).toBe(1);
+  });
+
+  it('scroll alert item is null', () => {
+    const wrapper = mount(<AlertItem />);
+    expect(wrapper.getDOMNode()).toBe(null);
+  });
 });

--- a/packages/zent/src/alert/ScrollAlert.tsx
+++ b/packages/zent/src/alert/ScrollAlert.tsx
@@ -2,8 +2,10 @@ import * as React from 'react';
 import { Children, ReactNode } from 'react';
 import cx from 'classnames';
 import AlertItem from './components/AlertItem';
+import { AlertItem as AlertItemPub } from './AlertItem';
 import { AlertTypes } from './types';
 import { PartialRequired } from '../utils/types';
+import kindOf from '../utils/kindOf';
 import omit from '../utils/omit';
 /**
  * 为满足动画的无缝衔接
@@ -161,7 +163,21 @@ export class ScrollAlert extends React.Component<IScrollAlertProps, IState> {
       ...restItemProps
     } = this.props;
     const { items } = this.state;
-    const extendChildren = cloneChildren(items || children);
+    const childArray = Children.toArray(items || children);
+
+    // children类型校验
+    const alertItem = childArray.reduce<any[]>(
+      (alertItemArray, child: React.ReactElement<any>) => {
+        const type = child.type;
+        if (kindOf(type, AlertItemPub)) {
+          alertItemArray.push(child);
+        }
+        return alertItemArray;
+      },
+      []
+    );
+
+    const extendChildren = cloneChildren(alertItem);
     const length = Children.count(extendChildren);
 
     return length

--- a/packages/zent/src/alert/ScrollAlert.tsx
+++ b/packages/zent/src/alert/ScrollAlert.tsx
@@ -33,7 +33,7 @@ function getRenderChildrenFromProps(children: ReactNode) {
   const childArray = Children.toArray(children);
 
   // children类型校验
-  const alertItem = childArray.reduce<any[]>(
+  const items = childArray.reduce<any[]>(
     (alertItemArray, child: React.ReactElement<any>) => {
       const type = child.type;
       if (kindOf(type, AlertItemPub)) {
@@ -44,8 +44,8 @@ function getRenderChildrenFromProps(children: ReactNode) {
     []
   );
 
-  const renderItems = cloneChildren(alertItem);
-  return { items: alertItem, preChildren: children, renderItems };
+  const renderItems = cloneChildren(items);
+  return { items, preChildren: children, renderItems };
 }
 
 export interface IScrollAlertProps
@@ -210,6 +210,10 @@ export class ScrollAlert extends React.Component<IScrollAlertProps, IState> {
     });
   };
 
+  onFirstChildRef = itemInstance => {
+    this.firstChildHeight = itemInstance?.offsetHeight || 0;
+  };
+
   // 实际dom中需要渲染的子节点
   get renderItem() {
     const {
@@ -234,11 +238,7 @@ export class ScrollAlert extends React.Component<IScrollAlertProps, IState> {
           {...props}
           key={index}
           onAlertItemClose={() => this.onCloseItemHandler(index)}
-          ref={itemInstance => {
-            if (!index) {
-              this.firstChildHeight = itemInstance?.offsetHeight || 0;
-            }
-          }}
+          ref={!index ? this.onFirstChildRef : undefined}
         />
       );
     });

--- a/packages/zent/src/alert/ScrollAlert.tsx
+++ b/packages/zent/src/alert/ScrollAlert.tsx
@@ -236,7 +236,7 @@ export class ScrollAlert extends React.Component<IScrollAlertProps, IState> {
           onAlertItemClose={() => this.onCloseItemHandler(index)}
           ref={itemInstance => {
             if (!index) {
-              this.firstChildHeight = itemInstance?.offsetHeight;
+              this.firstChildHeight = itemInstance?.offsetHeight || 0;
             }
           }}
         />

--- a/packages/zent/src/alert/ScrollAlert.tsx
+++ b/packages/zent/src/alert/ScrollAlert.tsx
@@ -136,16 +136,16 @@ export class ScrollAlert extends React.Component<IScrollAlertProps, IState> {
       // 空节点、一个节点均不产生动画
       if (length <= 1) return;
 
-      // 滚动到最后一个节点时，重置为初始位置
-      if (this.scrollIndex === length - 1) {
-        this.resetChildren();
-      }
-
       // 滚动递增
       ++this.scrollIndex;
       this.setState({
         transitionDuration: 600,
       });
+
+      // 滚动到最后一个节点时，重置为初始位置
+      if (this.scrollIndex === length - 1) {
+        setTimeout(this.resetChildren, 600);
+      }
       this.scrollHandler();
     }, scrollInterval);
   };

--- a/packages/zent/src/alert/ScrollAlert.tsx
+++ b/packages/zent/src/alert/ScrollAlert.tsx
@@ -180,6 +180,10 @@ export class ScrollAlert extends React.Component<IScrollAlertProps, IState> {
     const extendChildren = cloneChildren(alertItem);
     const length = Children.count(extendChildren);
 
+    if (length === 1) {
+      clearInterval(this.intervalId);
+    }
+
     return length
       ? Children.map(extendChildren, (item: React.ReactElement, index) => {
           const props = Object.assign({}, restItemProps, { ...item.props });


### PR DESCRIPTION
Changes you made in this pull request:

- check the type of scroll-alert's children, so that ScrollAlert only render AlertItem.
- add tests about the type of ScrollAlert's children-node.
