### PR TITLE
[bug fix] FormSelectField: 透传children

### DIFF
--- a/packages/zent/src/form/form-components/SelectField.tsx
+++ b/packages/zent/src/form/form-components/SelectField.tsx
@@ -85,7 +85,7 @@ export const FormSelectField: React.FunctionComponent<IFormSelectFieldProps<
   useFormChild(model, anchorRef);
   const onChange = React.useCallback(
     (e: any) => {
-      if (propsRef.current.props.tags) {
+      if (propsRef.current.props?.tags) {
         const value = model.value || [];
         if (!value.includes(e.target.value)) {
           model.value = [...value, e.target.value];
@@ -116,7 +116,9 @@ export const FormSelectField: React.FunctionComponent<IFormSelectFieldProps<
           {...(props.props as Omit<ISelectProps, 'value' | 'onChange'>)}
           onChange={onChange}
           value={model.value}
-        />
+        >
+          {props.children}
+        </Select>
         {after}
       </div>
       {!!notice && <FormNotice>{notice}</FormNotice>}


### PR DESCRIPTION
1. 透传`props.children`给`Select`，与`CheckboxGroup`、`RadioGroup`保持统一
2. 访问`props.props.xxx`时使用`?.`