### PR TITLE
[Table]: 修复 batchComponents 为空数组时页面渲染出一个 0

### DIFF
--- a/packages/zent/src/table/Table.tsx
+++ b/packages/zent/src/table/Table.tsx
@@ -539,7 +539,7 @@ export class Table extends PureComponent<ITableProps, any> {
                 </div>
               )}
             </BlockLoading>
-            {batchComponentsAutoFixed && batchComponents?.length && (
+            {batchComponentsAutoFixed && batchComponents?.length > 0 && (
               <>
                 <WindowResizeHandler onResize={this.setBatchComponents} />
                 <WindowScrollHandler


### PR DESCRIPTION
- 修复 batchComponents 为空数组时页面渲染出一个 0
