### PR TITLE
[bug fix]: ClampLines 非CJK连续字符超长时允许词内折行

### DIFF
--- a/packages/zent/src/clamp-lines/ClampLines.tsx
+++ b/packages/zent/src/clamp-lines/ClampLines.tsx
@@ -186,7 +186,10 @@ export class ClampLines extends Component<IClampLinesProps, IClampLinesState> {
 
     if (this.state.noClamp) {
       return (
-        <div className={className} style={{ overflowWrap: 'break-word' }}>
+        <div
+          className={className}
+          style={{ wordBreak: 'normal', overflowWrap: 'anywhere' }}
+        >
           {text}
           {this.renderResizable()}
         </div>
@@ -198,7 +201,13 @@ export class ClampLines extends Component<IClampLinesProps, IClampLinesState> {
         <Pop
           trigger={trigger}
           content={
-            <div style={{ maxWidth: popWidth, overflowWrap: 'break-word' }}>
+            <div
+              style={{
+                maxWidth: popWidth,
+                wordBreak: 'normal',
+                overflowWrap: 'anywhere',
+              }}
+            >
               {renderPop(text)}
             </div>
           }

--- a/packages/zent/src/clamp-lines/ClampLines.tsx
+++ b/packages/zent/src/clamp-lines/ClampLines.tsx
@@ -154,7 +154,12 @@ export class ClampLines extends Component<IClampLinesProps, IClampLinesState> {
     return (
       <div
         className={classString}
-        style={{ maxHeight: this.maxHeight, overflowY: 'hidden' }}
+        style={{
+          maxHeight: this.maxHeight,
+          overflowY: 'hidden',
+          wordBreak: 'normal',
+          overflowWrap: 'anywhere',
+        }}
       >
         <div ref={this.element}>
           <span ref={this.innerElement}>{this.state.text}</span>
@@ -181,7 +186,7 @@ export class ClampLines extends Component<IClampLinesProps, IClampLinesState> {
 
     if (this.state.noClamp) {
       return (
-        <div className={className}>
+        <div className={className} style={{ overflowWrap: 'break-word' }}>
           {text}
           {this.renderResizable()}
         </div>
@@ -192,7 +197,11 @@ export class ClampLines extends Component<IClampLinesProps, IClampLinesState> {
       return (
         <Pop
           trigger={trigger}
-          content={<div style={{ maxWidth: popWidth }}>{renderPop(text)}</div>}
+          content={
+            <div style={{ maxWidth: popWidth, overflowWrap: 'break-word' }}>
+              {renderPop(text)}
+            </div>
+          }
         >
           {this.renderClampedText()}
         </Pop>

--- a/packages/zent/src/clamp-lines/demos/non-cjk.md
+++ b/packages/zent/src/clamp-lines/demos/non-cjk.md
@@ -14,7 +14,7 @@ ReactDOM.render(
 		<ClampLines
 			lines={3}
 			popWidth={300}
-			text="Firstword 中文字 Secondwordisveryloooooooong thirdword fourthword"
+			text="FirstWord SecondWordIsVeryLoooooooong thirdWord fourthWord"
 		/>
 	</div>
 	, mountNode

--- a/packages/zent/src/clamp-lines/demos/non-cjk.md
+++ b/packages/zent/src/clamp-lines/demos/non-cjk.md
@@ -1,0 +1,22 @@
+---
+order: 7
+zh-CN:
+	title: 如果正常不能分割的一串非CJK文本在一行展示不全，允许单词内折行。
+en-US:
+	title: Word breaking is allowed if a sequence of non-CJK characters is too long to display in one line.
+---
+
+```js
+import { ClampLines } from 'zent';
+
+ReactDOM.render(
+	<div style={{ width: 160, color: '#666', fontSize: 14 }}>
+		<ClampLines
+			lines={3}
+			popWidth={300}
+			text="Firstword 中文字 Secondwordisveryloooooooong thirdword fourthword"
+		/>
+	</div>
+	, mountNode
+);
+```


### PR DESCRIPTION
ClampLines 内容中非CJK连续单词字符无法一行内展示时，允许词内折行