### PR TITLE
[bug fix] Form: 修复监听字段时首次渲染返回null的问题

### DIFF
--- a/packages/zent/src/form/README_zh-CN.md
+++ b/packages/zent/src/form/README_zh-CN.md
@@ -60,6 +60,7 @@ scatter: true
 - `Model` 模式还支持[以下参数](../../apidoc/interfaces/iformfieldmodeldrivenprops.html)。注意，此模式下校验规则正常是设置在 model 上的，而不是表单项组件上。
 - 在 `View` 模式下使用 `FieldArray` 时，由于该组件的特殊性，虽然此时传给 `Field` 的是 `model`（按上述规则这就是 `Model` 模式），但是校验规则还是需要设置在表单项上。
 
+<!-- demo-slot-17 -->
 <!-- demo-slot-1 -->
 <!-- demo-slot-2 -->
 <!-- demo-slot-3 -->

--- a/packages/zent/src/form/demos/17.test.md
+++ b/packages/zent/src/form/demos/17.test.md
@@ -1,0 +1,61 @@
+---
+order: 17
+zh-CN:
+	title: 基础用法
+en-US:
+	title: Basic usage
+---
+
+```jsx
+import {
+	Form,
+	FormStrategy,
+	FormInputField,
+	FormSwitchField,
+	Button,
+	ErrorBoundary,
+} from 'zent';
+
+function FieldArray({ name, children }) {
+	const model = Form.useFieldArray(name, undefined, [{}]);
+	return <React.Fragment>{children(model)}</React.Fragment>;
+}
+
+function App() {
+	const form = Form.useForm(FormStrategy.View);
+	const [_, __] = React.useState(false);
+	return (
+		<Form form={form}>
+			<FieldArray name="array">
+				{model =>
+					model.children.map((it, index) => {
+						return (
+							<FieldSet model={it} key={it.getModel()?.id || index}>
+								<ErrorBoundary>
+									<FormSwitchField label="手动设置代理：" name="manual" />
+									<Form.FieldValue name="manual">
+										{manual => {
+											return manual ? (
+												<React.Fragment>
+													<FormInputField
+														name="ip"
+														label="IP："
+														destroyOnUnmount
+													/>
+												</React.Fragment>
+											) : null;
+										}}
+									</Form.FieldValue>
+								</ErrorBoundary>
+							</FieldSet>
+						);
+					})
+				}
+			</FieldArray>
+			<Button onClick={() => __(_ => !_)}>re-render</Button>
+		</Form>
+	);
+}
+
+ReactDOM.render(<App />, mountNode);
+```

--- a/packages/zent/src/form/formulr/context.ts
+++ b/packages/zent/src/form/formulr/context.ts
@@ -1,6 +1,6 @@
 import { createContext, useContext } from 'react';
 import { FormStrategy, FormModel, FieldSetModel } from './models';
-import { FormulrError } from './error';
+import { UnexpectedFormContextError } from './error';
 
 export interface IFormContext {
   strategy: FormStrategy;
@@ -17,10 +17,7 @@ export const FormProvider = FormContext.Provider;
 export function useFormContext(): IFormContext {
   const ctx = useContext(FormContext);
   if (ctx === null) {
-    throw new FormulrError('FormContext not found', [
-      'Using form hooks outside the form context',
-      "There's a copy of formulr in your project, run `yarn list formulr` to check",
-    ]);
+    throw UnexpectedFormContextError;
   }
   return ctx;
 }

--- a/packages/zent/src/form/formulr/error.ts
+++ b/packages/zent/src/form/formulr/error.ts
@@ -1,6 +1,6 @@
 import { isArray } from './utils';
 
-export class FormulrError extends Error {
+class FormulrError extends Error {
   constructor(message: string, reason: string | string[]) {
     super(
       `${message}.\n` +
@@ -15,6 +15,14 @@ export class FormulrError extends Error {
     this.name = 'FormulrError';
   }
 }
+
+export const UnexpectedFormContextError = new FormulrError(
+  'FormContext not found',
+  [
+    'Using form hooks outside the form context',
+    "There's a copy of zent in your project, run `yarn list zent` to check",
+  ]
+);
 
 export const UnexpectedFormStrategyError = new FormulrError(
   'Unexpected FormStrategy',

--- a/packages/zent/src/form/formulr/field-array.tsx
+++ b/packages/zent/src/form/formulr/field-array.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useEffect } from 'react';
+import { useMemo } from 'react';
 import {
   FieldArrayModel,
   FormStrategy,
@@ -29,9 +29,8 @@ function useArrayModel<Item, Child extends IModel<Item>>(
   strategy: FormStrategy,
   defaultValue: readonly Item[]
 ) {
-  const { model, effect } = useMemo(() => {
+  const model = useMemo(() => {
     let model: FieldArrayModel<Item, Child>;
-    let effect: (() => void) | undefined;
     if (typeof field === 'string') {
       if (strategy !== FormStrategy.View) {
         throw UnexpectedFormStrategyError;
@@ -47,7 +46,7 @@ function useArrayModel<Item, Child extends IModel<Item>>(
           }
         }
         model = new FieldArrayModel<Item, Child>(null, v);
-        effect = () => parent.registerChild(field, model);
+        parent.registerChild(field, model);
       } else {
         model = m;
       }
@@ -69,18 +68,17 @@ function useArrayModel<Item, Child extends IModel<Item>>(
           }
         }
         model = new FieldArrayModel(null, v);
-        effect = () => field.setModel(model);
+        field.setModel(model);
       } else {
         model = m;
       }
     } else {
       model = field;
     }
-    return { model, effect };
+    return model;
     /** ignore defaultValue */
-  }, [field, parent, strategy]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  useEffect(() => effect?.(), [effect]);
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
+  }, [field, parent, strategy]);
 
   return model;
 }

--- a/packages/zent/src/form/formulr/field-set.tsx
+++ b/packages/zent/src/form/formulr/field-set.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useEffect } from 'react';
+import { useMemo } from 'react';
 import { IFormContext, useFormContext } from './context';
 import {
   $FieldSetValue,
@@ -29,9 +29,8 @@ function useFieldSetModel<T extends Record<string, BasicModel<any>>>(
   parent: FieldSetModel,
   strategy: FormStrategy
 ) {
-  const { model, effect } = useMemo(() => {
+  const model = useMemo(() => {
     let model: FieldSetModel<any>;
-    let effect: (() => void) | undefined;
     if (typeof field === 'string') {
       if (strategy !== FormStrategy.View) {
         throw UnexpectedFormStrategyError;
@@ -48,8 +47,7 @@ function useFieldSetModel<T extends Record<string, BasicModel<any>>>(
           }
         }
         model.patchedValue = v;
-        effect = () =>
-          parent.registerChild(field, model as BasicModel<unknown>);
+        parent.registerChild(field, model as BasicModel<unknown>);
       } else {
         model = m;
       }
@@ -61,17 +59,15 @@ function useFieldSetModel<T extends Record<string, BasicModel<any>>>(
           field.patchedValue,
           () => or(field.initialValue, () => ({}))
         );
-        effect = () => field.setModel(model);
+        field.setModel(model);
       } else {
         model = m;
       }
     } else {
       model = field;
     }
-    return { model, effect };
+    return model;
   }, [field, parent, strategy]);
-
-  useEffect(() => effect?.(), [effect]);
 
   return model;
 }

--- a/packages/zent/src/form/formulr/field.tsx
+++ b/packages/zent/src/form/formulr/field.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useEffect } from 'react';
+import { useMemo } from 'react';
 import {
   FieldModel,
   BasicModel,
@@ -29,9 +29,8 @@ function useModelAndChildProps<Value>(
   defaultValue: Value | (() => Value),
   form: FormModel
 ) {
-  const { model, effect } = useMemo(() => {
+  const model = useMemo(() => {
     let model: FieldModel<Value>;
-    let effect: (() => void) | undefined;
     if (typeof field === 'string') {
       if (strategy !== FormStrategy.View) {
         throw UnexpectedFormStrategyError;
@@ -43,8 +42,7 @@ function useModelAndChildProps<Value>(
           isValueFactory(defaultValue) ? defaultValue : () => defaultValue
         );
         model = new FieldModel<Value>(v);
-        effect = () =>
-          parent.registerChild(field, model as BasicModel<unknown>);
+        parent.registerChild(field, model as BasicModel<unknown>);
       } else {
         model = m;
       }
@@ -58,18 +56,17 @@ function useModelAndChildProps<Value>(
           )
         );
         model = new FieldModel<Value>(v);
-        effect = () => field.setModel(model);
+        field.setModel(model);
       } else {
         model = m;
       }
     } else {
       model = field;
     }
-    return { model, effect };
+    return model;
     /** ignore defaultValue */
-  }, [field, parent, strategy, form]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  useEffect(() => effect?.(), [effect]);
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
+  }, [field, parent, strategy, form]);
 
   return model;
 }


### PR DESCRIPTION
背景：
在之前的迭代中，为了消除react@^16.13.0的warning（在一个组件的render阶段更新其他组件的状态），把“向parent注册child”这个过程从渲染阶段挪到了effect执行阶段。

问题：
在effect阶段注册字段，意味着在首次渲染时，无法从表单上下文中获取到其他字段的model，因此`useFieldValue`在View模式下的首次渲染返回值总是null，当条件渲染的表单组件使用了`destroyOnUnmount`并结合前述行为时会在某些场景下出现预期之外的行为。

代码演示：
```jsx
function FieldArray({ name, children }) {
  const model = useFieldArray(name, undefined, [{}]);

  return <React.Fragment>{children(model)}</React.Fragment>;
}

function App() {
  const form = useForm(FormStrategy.View);
  const [_, __] = React.useState(false);

  return (
    <Form form={form.ctx}>
      <FieldArray name="array">
        {(model: FieldArrayModel<any, any>) => {
          return model.children.map((it, index) => {
            // 组件第一次渲染时id尚未生成，降级到使用index作为key
            return (
              <FieldSet key={it.getModel()?.id || index} model={it}>
                <FormInputField name="input1" />
                <FieldValue name="input1">
                  {input1 => {
                    return input1 !== null ? <FormInputField destroyOnUnmount name="input2" /> : null;
                  }}
                </FieldValue>
              </FieldSet>
            );
          });
        }}
      </FieldArray>
      {/*
         * 点击这个按钮会重新渲染一次App组件，
         * 导致循环渲染中使用的key由index变为
         * Model的id，进而导致表单组件remount，
         * 结果是input2这个输入框中的值丢失了，
         * 原因是useFieldValue在组件首次渲染时
         * 总会返回null，因此使用了
         * destroyOnUnmount的组件会出现闪烁
         */}
      <Button onClick={() => __(_ => !_)}>re-render</Button>
    </Form>
  );
}
```

解决方案：
1. 把“向parent注册child”这个过程从effect执行阶段挪回渲染阶段
2. 为了避免warning重现，需要将数据消费改为异步（rxjs的订阅者是同步消费数据）
3. `useFieldValue`中model需要在首次渲染时就从parent拿一次，否则View模式下总是null