### PR TITLE
[new feature] Form: ModelRef增加id属性

### DIFF
--- a/packages/zent/src/form/demos/8.field-array.md
+++ b/packages/zent/src/form/demos/8.field-array.md
@@ -75,7 +75,7 @@ function Hobbies({ name }) {
 			</Button>
 			<ul>
 				{model.children.map((child, index) => (
-					<li key={index} className="hobby">
+					<li key={child.id} className="hobby">
 						<FormInputField
 							model={child}
 							label={`{i18n.hobby}${index + 1}:`}
@@ -169,7 +169,7 @@ function Members({ name }) {
 			)}
 			<ul>
 				{model.children.map((child, index) => (
-					<FieldSet key={index} model={child}>
+					<FieldSet key={child.id} model={child}>
 						<MemberInfo index={index} remove={remove} />
 					</FieldSet>
 				))}

--- a/packages/zent/src/form/formulr/models/ref.ts
+++ b/packages/zent/src/form/formulr/models/ref.ts
@@ -2,6 +2,7 @@ import { BehaviorSubject } from 'rxjs';
 import { IModel } from './base';
 import { ValidateOption, IMaybeError, IValidators } from '../validate';
 import { Maybe, None } from '../maybe';
+import uniqueId from '../../../utils/uniqueId';
 
 const REF_ID = Symbol('ref');
 
@@ -16,6 +17,8 @@ class ModelRef<Value, Parent extends IModel<any>, Model extends IModel<Value>>
    * @internal
    */
   patchedValue: Maybe<Value> = None();
+
+  id = uniqueId('model-ref-');
 
   model$: BehaviorSubject<Model | null>;
 


### PR DESCRIPTION
增加`ModelRef.prototype.id`，在列表渲染时作为`key`使用，避免使用`index`