### PR TITLE
[bug fix] Form: 修复scrollToError无法滚动至首个错误字段的问题

### DIFF
--- a/packages/zent/src/form/Form.tsx
+++ b/packages/zent/src/form/Form.tsx
@@ -178,8 +178,9 @@ export class Form<T extends {}> extends React.Component<IFormProps<T>> {
   }
 
   scrollToFirstError() {
-    const xPositions: number[] = [];
-    const yPositions: number[] = [];
+    type X = number;
+    type Y = number;
+    const positions: [X, Y][] = [];
     for (let i = 0; i < this.children.length; i += 1) {
       const child = this.children[i];
       const el = child.getDOMNode();
@@ -190,11 +191,21 @@ export class Form<T extends {}> extends React.Component<IFormProps<T>> {
       const { x: pageXOffset, y: pageYOffset } = getScrollPosition();
       const y = elementBound.top + pageYOffset;
       const x = elementBound.left + pageXOffset;
-      xPositions.push(x);
-      yPositions.push(y);
+      positions.push([x, y]);
     }
-    if (xPositions.length) {
-      scroll(document.body, Math.min(...xPositions), Math.min(...yPositions));
+
+    /**
+     * Take the fields with the smallest `y`, then take
+     * the field with the smallest `x` as the scrolling
+     * target within these fields.
+     */
+    positions.sort(([x1, y1], [x2, y2]) => {
+      const diffY = y1 - y2;
+      return diffY ? diffY : x1 - x2;
+    });
+    const target = positions[0];
+    if (target) {
+      scroll(document.body, target[0], target[1]);
     }
   }
 

--- a/packages/zent/src/form/Form.tsx
+++ b/packages/zent/src/form/Form.tsx
@@ -30,6 +30,7 @@ import scroll from '../utils/scroll';
 import { CombineErrors } from './CombineErrors';
 import { ValidateOccasion, TouchWhen } from './shared';
 import { Disabled } from '../disabled';
+import getScrollPosition from '../utils/dom/getScollPosition';
 
 export {
   IRenderError,
@@ -184,8 +185,9 @@ export class Form<T extends {}> extends React.Component<IFormProps<T>> {
         continue;
       }
       const elementBound = el.getBoundingClientRect();
-      const y = elementBound.top + window.pageYOffset;
-      const x = elementBound.left + window.pageXOffset;
+      const { x: pageXOffset, y: pageYOffset } = getScrollPosition();
+      const y = elementBound.top + pageYOffset;
+      const x = elementBound.left + pageXOffset;
       scroll(document.body, x, y);
       break;
     }

--- a/packages/zent/src/form/Form.tsx
+++ b/packages/zent/src/form/Form.tsx
@@ -192,7 +192,8 @@ export class Form<T extends {}> extends React.Component<IFormProps<T>> {
 
       /**
        * Find the position of first field in view
-       * @example
+       *
+       * Example:
        * Field1  Field2
        * Field3
        */

--- a/packages/zent/src/form/Form.tsx
+++ b/packages/zent/src/form/Form.tsx
@@ -177,16 +177,17 @@ export class Form<T extends {}> extends React.Component<IFormProps<T>> {
   }
 
   scrollToFirstError() {
-    for (let i = 0; i < this.children.length; i += 1) {
+    for (let i = this.children.length - 1; i >= 0; i--) {
       const child = this.children[i];
       const el = child.getDOMNode();
-      if (!el) {
+      if (!el || child.valid()) {
         continue;
       }
       const elementBound = el.getBoundingClientRect();
       const y = elementBound.top + window.pageYOffset;
       const x = elementBound.left + window.pageXOffset;
       scroll(document.body, x, y);
+      break;
     }
   }
 

--- a/packages/zent/src/form/Form.tsx
+++ b/packages/zent/src/form/Form.tsx
@@ -178,7 +178,9 @@ export class Form<T extends {}> extends React.Component<IFormProps<T>> {
   }
 
   scrollToFirstError() {
-    for (let i = this.children.length - 1; i >= 0; i--) {
+    const xPositions: number[] = [];
+    const yPositions: number[] = [];
+    for (let i = 0; i < this.children.length; i += 1) {
       const child = this.children[i];
       const el = child.getDOMNode();
       if (!el || child.valid()) {
@@ -188,8 +190,11 @@ export class Form<T extends {}> extends React.Component<IFormProps<T>> {
       const { x: pageXOffset, y: pageYOffset } = getScrollPosition();
       const y = elementBound.top + pageYOffset;
       const x = elementBound.left + pageXOffset;
-      scroll(document.body, x, y);
-      break;
+      xPositions.push(x);
+      yPositions.push(y);
+    }
+    if (xPositions.length) {
+      scroll(document.body, Math.min(...xPositions), Math.min(...yPositions));
     }
   }
 

--- a/packages/zent/src/form/Form.tsx
+++ b/packages/zent/src/form/Form.tsx
@@ -178,9 +178,8 @@ export class Form<T extends {}> extends React.Component<IFormProps<T>> {
   }
 
   scrollToFirstError() {
-    type X = number;
-    type Y = number;
-    const positions: [X, Y][] = [];
+    let scrollX = -1;
+    let scrollY = -1;
     for (let i = 0; i < this.children.length; i += 1) {
       const child = this.children[i];
       const el = child.getDOMNode();
@@ -191,21 +190,21 @@ export class Form<T extends {}> extends React.Component<IFormProps<T>> {
       const { x: pageXOffset, y: pageYOffset } = getScrollPosition();
       const y = elementBound.top + pageYOffset;
       const x = elementBound.left + pageXOffset;
-      positions.push([x, y]);
+
+      /**
+       * Find the position of first field in view
+       * @example
+       * Field1  Field2
+       * Field3
+       */
+      if (y < scrollY || (y === scrollY && x < scrollX)) {
+        scrollX = x;
+        scrollY = y;
+      }
     }
 
-    /**
-     * Take the fields with the smallest `y`, then take
-     * the field with the smallest `x` as the scrolling
-     * target within these fields.
-     */
-    positions.sort(([x1, y1], [x2, y2]) => {
-      const diffY = y1 - y2;
-      return diffY ? diffY : x1 - x2;
-    });
-    const target = positions[0];
-    if (target) {
-      scroll(document.body, target[0], target[1]);
+    if (~scrollX) {
+      scroll(document.body, scrollX, scrollY);
     }
   }
 

--- a/packages/zent/src/form/Form.tsx
+++ b/packages/zent/src/form/Form.tsx
@@ -31,6 +31,7 @@ import { CombineErrors } from './CombineErrors';
 import { ValidateOccasion, TouchWhen } from './shared';
 import { Disabled } from '../disabled';
 import getScrollPosition from '../utils/dom/getScollPosition';
+import { isYesterday } from 'date-fns';
 
 export {
   IRenderError,
@@ -187,9 +188,8 @@ export class Form<T extends {}> extends React.Component<IFormProps<T>> {
         continue;
       }
       const elementBound = el.getBoundingClientRect();
-      const { x: pageXOffset, y: pageYOffset } = getScrollPosition();
-      const y = elementBound.top + pageYOffset;
-      const x = elementBound.left + pageXOffset;
+      const y = elementBound.top;
+      const x = elementBound.left;
 
       /**
        * Find the position of first field in view
@@ -204,7 +204,8 @@ export class Form<T extends {}> extends React.Component<IFormProps<T>> {
     }
 
     if (scrollX > -1) {
-      scroll(document.body, scrollX, scrollY);
+      const { x, y } = getScrollPosition();
+      scroll(document.body, scrollX + x, scrollY + y);
     }
   }
 

--- a/packages/zent/src/form/Form.tsx
+++ b/packages/zent/src/form/Form.tsx
@@ -203,7 +203,7 @@ export class Form<T extends {}> extends React.Component<IFormProps<T>> {
       }
     }
 
-    if (~scrollX) {
+    if (scrollX > -1) {
       scroll(document.body, scrollX, scrollY);
     }
   }

--- a/packages/zent/src/form/Form.tsx
+++ b/packages/zent/src/form/Form.tsx
@@ -31,7 +31,6 @@ import { CombineErrors } from './CombineErrors';
 import { ValidateOccasion, TouchWhen } from './shared';
 import { Disabled } from '../disabled';
 import getScrollPosition from '../utils/dom/getScollPosition';
-import isNil from '../utils/isNil';
 
 export {
   IRenderError,

--- a/packages/zent/src/form/Form.tsx
+++ b/packages/zent/src/form/Form.tsx
@@ -31,7 +31,6 @@ import { CombineErrors } from './CombineErrors';
 import { ValidateOccasion, TouchWhen } from './shared';
 import { Disabled } from '../disabled';
 import getScrollPosition from '../utils/dom/getScollPosition';
-import { isYesterday } from 'date-fns';
 
 export {
   IRenderError,

--- a/packages/zent/src/form/Form.tsx
+++ b/packages/zent/src/form/Form.tsx
@@ -31,6 +31,7 @@ import { CombineErrors } from './CombineErrors';
 import { ValidateOccasion, TouchWhen } from './shared';
 import { Disabled } from '../disabled';
 import getScrollPosition from '../utils/dom/getScollPosition';
+import isNil from '../utils/isNil';
 
 export {
   IRenderError,
@@ -178,8 +179,8 @@ export class Form<T extends {}> extends React.Component<IFormProps<T>> {
   }
 
   scrollToFirstError() {
-    let scrollX = -1;
-    let scrollY = -1;
+    let scrollX: number | undefined;
+    let scrollY: number | undefined;
     for (let i = 0; i < this.children.length; i += 1) {
       const child = this.children[i];
       const el = child.getDOMNode();
@@ -197,13 +198,13 @@ export class Form<T extends {}> extends React.Component<IFormProps<T>> {
        * Field1  Field2
        * Field3
        */
-      if (y < scrollY || (y === scrollY && x < scrollX)) {
+      if (isNil(scrollX) || y < scrollY || (y === scrollY && x < scrollX)) {
         scrollX = x;
         scrollY = y;
       }
     }
 
-    if (scrollX > -1) {
+    if (!isNil(scrollX)) {
       const { x, y } = getScrollPosition();
       scroll(document.body, scrollX + x, scrollY + y);
     }

--- a/packages/zent/src/form/Form.tsx
+++ b/packages/zent/src/form/Form.tsx
@@ -179,8 +179,8 @@ export class Form<T extends {}> extends React.Component<IFormProps<T>> {
   }
 
   scrollToFirstError() {
-    let scrollX: number | undefined;
-    let scrollY: number | undefined;
+    let scrollX = Infinity;
+    let scrollY = Infinity;
     for (let i = 0; i < this.children.length; i += 1) {
       const child = this.children[i];
       const el = child.getDOMNode();
@@ -198,13 +198,13 @@ export class Form<T extends {}> extends React.Component<IFormProps<T>> {
        * Field1  Field2
        * Field3
        */
-      if (isNil(scrollX) || y < scrollY || (y === scrollY && x < scrollX)) {
+      if (y < scrollY || (y === scrollY && x < scrollX)) {
         scrollX = x;
         scrollY = y;
       }
     }
 
-    if (!isNil(scrollX)) {
+    if (scrollX !== Infinity) {
       const { x, y } = getScrollPosition();
       scroll(document.body, scrollX + x, scrollY + y);
     }

--- a/packages/zent/src/utils/dom/getScollPosition.ts
+++ b/packages/zent/src/utils/dom/getScollPosition.ts
@@ -2,16 +2,17 @@
  * Get current scroll position in page
  */
 export default function getScrollPosition() {
+  const { pageXOffset, pageYOffset } = window;
   const x =
-    window.pageXOffset !== undefined
-      ? window.pageXOffset
+    pageXOffset !== undefined
+      ? pageXOffset
       : ((document.documentElement ||
           document.body.parentNode ||
           document.body) as any).scrollLeft;
 
   const y =
-    window.pageYOffset !== undefined
-      ? window.pageYOffset
+    pageYOffset !== undefined
+      ? pageYOffset
       : ((document.documentElement ||
           document.body.parentNode ||
           document.body) as any).scrollTop;


### PR DESCRIPTION
1. `scrollToFirstError`需要滚动至视图内首个校验未通过的表单字段，以位置信息作为判断标准
2. `getScrollPosition`优化