### PR TITLE
[bug fix] ColorPicker支持禁用 && 删除prefix属性

### DIFF
--- a/packages/zent/__tests__/color-picker.js
+++ b/packages/zent/__tests__/color-picker.js
@@ -42,11 +42,6 @@ describe('ColorPicker', () => {
     expect(document.querySelectorAll('.zent-color-picker-popover').length).toBe(
       1
     );
-    expect(document.querySelectorAll('.zent-colorpicker-board').length).toBe(1);
-    expect(document.querySelectorAll('.zent-colorpicker-input').length).toBe(1);
-    expect(document.querySelectorAll('.zent-colorpicker-colors').length).toBe(
-      1
-    );
   });
 
   it('colorPicker props check', () => {

--- a/packages/zent/assets/colorpicker.scss
+++ b/packages/zent/assets/colorpicker.scss
@@ -15,6 +15,10 @@
   height: 30px;
   vertical-align: middle;
 
+  &_disabled {
+    cursor: not-allowed;
+  }
+
   &-wrapper {
     font-size: 0;
   }
@@ -36,20 +40,20 @@
     box-sizing: border-box;
     border-width: 1px;
     border-style: solid;
-    border-radius: 2px;
+    border-radius: 1px;
     display: inline-block;
-    width: 50px;
-    height: 30px;
+    width: 60px;
+    height: 32px;
     outline: none;
-    padding: 5px;
+    padding: 3px;
     transition: border-color 0.25s;
     position: relative;
   }
 
   &__preview {
     box-sizing: border-box;
-    width: 38px;
-    height: 18px;
+    width: 52px;
+    height: 24px;
   }
 }
 

--- a/packages/zent/assets/colorpicker.scss
+++ b/packages/zent/assets/colorpicker.scss
@@ -40,14 +40,14 @@
     box-sizing: border-box;
     border-width: 1px;
     border-style: solid;
-    border-radius: 1px;
-    display: inline-block;
+    border-radius: 2px;
     width: 60px;
     height: 32px;
     outline: none;
-    padding: 3px;
     transition: border-color 0.25s;
-    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   &__preview {
@@ -55,23 +55,25 @@
     width: 52px;
     height: 24px;
   }
-}
 
-.zent-colorpicker-colors-select {
-  @include theme-color(background-color, stroke, 9);
-  width: 190px;
-  box-shadow: $shadow-spec-layer;
-  box-sizing: content-box;
-  line-height: 10px;
-  padding-top: 10px;
-}
+  &-colors-select {
+    @include theme-color(background-color, stroke, 9);
+    width: 190px;
+    box-shadow: $shadow-spec-layer;
+    box-sizing: content-box;
+    line-height: 10px;
+    padding-top: 10px;
+    border-radius: 2px;
+  }
 
-.zent-colorpicker-colors-select__preview {
-  width: 20px;
-  height: 20px;
-  display: inline-block;
-  margin-left: 10px;
-  margin-bottom: 10px;
-  cursor: pointer;
-  box-shadow: inset 0 0 0 1px rgba(black, 0.2); // border
+  &-colors-select__preview {
+    width: 20px;
+    height: 20px;
+    display: inline-block;
+    margin-left: 10px;
+    margin-bottom: 10px;
+    cursor: pointer;
+    box-shadow: inset 0 0 0 1px rgba(black, 0.15); // border
+    border-radius: 2px;
+  }
 }

--- a/packages/zent/src/colorpicker/ColorBoard.tsx
+++ b/packages/zent/src/colorpicker/ColorBoard.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import cx from 'classnames';
 import reactCSS from './helpers/reactcss';
 import { ColorWrap, Saturation, Hue, Alpha, Checkboard } from './common';
 import SketchFields from './SketchFields';
@@ -15,7 +14,6 @@ const Sketch = ({
   showAlpha,
   presetColors,
   renderers,
-  prefix,
   className,
   type,
 }) => {
@@ -101,10 +99,7 @@ const Sketch = ({
   );
 
   return (
-    <div
-      style={styles.picker}
-      className={cx(`${prefix}-colorpicker-board`, className)}
-    >
+    <div style={styles.picker} className={className}>
       <div style={styles.saturation}>
         <Saturation
           style={styles.Saturation}
@@ -140,12 +135,10 @@ const Sketch = ({
         hex={hex}
         onChange={onChange}
         showAlpha={showAlpha}
-        prefix={prefix}
       />
       <SketchPresetColors
         colors={presetColors}
         onClick={onChange}
-        prefix={prefix}
         type={type}
       />
     </div>
@@ -172,7 +165,6 @@ Sketch.defaultProps = {
   ],
   width: 200,
   showAlpha: false,
-  prefix: 'zent',
   className: '',
 };
 

--- a/packages/zent/src/colorpicker/README_en-US.md
+++ b/packages/zent/src/colorpicker/README_en-US.md
@@ -22,6 +22,7 @@ ColorPicker is used for color selection and supports multiple formats.
 | className     | The custom classname   | string  | `''`     |         |
 | wrapperClassName | The  custom classname of trigger's parent node | string | `''` |  |
 | prefix        | The custom prefix  | string              | `'zent'` |         |
+| disabled        | Disable the ColorPicker       | bool                | -       |         |
 
 #### ColorBoard
 

--- a/packages/zent/src/colorpicker/README_en-US.md
+++ b/packages/zent/src/colorpicker/README_en-US.md
@@ -21,7 +21,6 @@ ColorPicker is used for color selection and supports multiple formats.
 | onChange      | The callback function that is triggerd when color is changed | func(color) | `noop`   |  |
 | className     | The custom classname   | string  | `''`     |         |
 | wrapperClassName | The  custom classname of trigger's parent node | string | `''` |  |
-| prefix        | The custom prefix  | string              | `'zent'` |         |
 | disabled        | Disable the ColorPicker       | bool                | -       |         |
 
 #### ColorBoard
@@ -32,4 +31,3 @@ ColorPicker is used for color selection and supports multiple formats.
 | showAlpha     | Whether to show opacity selection    | bool                | `false`  |   `true/false`     |
 | onChange      | The callback function that is triggerd when color is changed    | func(color)         | `noop`   |         |
 | className     | The cutom clasname      | string              | `''`     |         |
-| prefix        | The custom prefix      | string              | `'zent'` |         |

--- a/packages/zent/src/colorpicker/README_zh-CN.md
+++ b/packages/zent/src/colorpicker/README_zh-CN.md
@@ -23,6 +23,7 @@ group: 数据
 | className     | 可选，自定义类名      | string              | `''`     |         |
 | wrapperClassName | 可选，自定义trigger包裹节点的类名 | string | `''`    |         |
 | prefix        | 可选，自定义前缀      | string              | `'zent'` |         |
+| disabled        | 可选，禁用状态      | bool                | -       |         |
 
 #### ColorBoard
 

--- a/packages/zent/src/colorpicker/README_zh-CN.md
+++ b/packages/zent/src/colorpicker/README_zh-CN.md
@@ -22,7 +22,6 @@ group: 数据
 | onChange      | 颜色变化时回调函数    | func(color)         | `noop`   |         |
 | className     | 可选，自定义类名      | string              | `''`     |         |
 | wrapperClassName | 可选，自定义trigger包裹节点的类名 | string | `''`    |         |
-| prefix        | 可选，自定义前缀      | string              | `'zent'` |         |
 | disabled        | 可选，禁用状态      | bool                | -       |         |
 
 #### ColorBoard
@@ -33,4 +32,3 @@ group: 数据
 | showAlpha     | 是否显示透明度选择    | bool                | `false`  |   `true/false`     |
 | onChange      | 颜色变化时回调函数    | func(color)         | `noop`   |         |
 | className     | 可选，自定义类名      | string              | `''`     |         |
-| prefix        | 可选，自定义前缀      | string              | `'zent'` |         |

--- a/packages/zent/src/colorpicker/SketchFields.tsx
+++ b/packages/zent/src/colorpicker/SketchFields.tsx
@@ -129,12 +129,12 @@ export default class SketchFileds extends PureComponent<any> {
   }
 
   render() {
-    const { prefix, rgb } = this.props;
+    const { rgb } = this.props;
     const { hexColor } = this.state;
     const styles = this.styles;
 
     return (
-      <div style={styles.fields} className={`${prefix}-colorpicker-input`}>
+      <div style={styles.fields}>
         <div style={styles.double}>
           <EditableInput
             style={{ input: styles.input, label: styles.label }}

--- a/packages/zent/src/colorpicker/SketchPresetColors.tsx
+++ b/packages/zent/src/colorpicker/SketchPresetColors.tsx
@@ -4,6 +4,7 @@ import { Swatch } from './common';
 import { PresetColors, ColorPickerType } from '.';
 
 export type SketchPresetColorValue = string | { hex: string; source: string };
+const prefixCls = 'zent-color-picker';
 
 export interface ISketchPresetColors {
   colors: PresetColors;
@@ -11,16 +12,10 @@ export interface ISketchPresetColors {
     color: SketchPresetColorValue,
     e?: React.MouseEvent<HTMLElement>
   ): any;
-  prefix: string;
   type: ColorPickerType;
 }
 
-const SketchPresetColors = ({
-  colors,
-  onClick,
-  prefix,
-  type,
-}: ISketchPresetColors) => {
+const SketchPresetColors = ({ colors, onClick, type }: ISketchPresetColors) => {
   const styles: any = reactCSS(
     {
       default: {
@@ -65,11 +60,11 @@ const SketchPresetColors = ({
 
   if (type === 'simple') {
     return (
-      <div className={`${prefix}-colorpicker-colors-select`}>
+      <div className={`${prefixCls}-colors-select`}>
         {colors.map(color => (
           <div
             key={color}
-            className={`${prefix}-colorpicker-colors-select__preview`}
+            className={`${prefixCls}-colors-select__preview`}
             style={{ backgroundColor: color }}
             onClick={() => onClick(color)}
             title={color}
@@ -80,7 +75,7 @@ const SketchPresetColors = ({
   }
 
   return (
-    <div style={styles.colors} className={`${prefix}-colorpicker-colors`}>
+    <div style={styles.colors}>
       {colors.map(colorObjOrString => {
         const c =
           typeof colorObjOrString === 'string'

--- a/packages/zent/src/colorpicker/common/EditableInput.tsx
+++ b/packages/zent/src/colorpicker/common/EditableInput.tsx
@@ -158,7 +158,6 @@ export default class EditableInput extends Component<any, any> {
     return (
       <div style={styles.wrap}>
         <input
-          prefix="colorpicker-rgb"
           style={styles.input}
           ref={this.inputRef}
           value={this.state.value}

--- a/packages/zent/src/colorpicker/demos/disabled.md
+++ b/packages/zent/src/colorpicker/demos/disabled.md
@@ -1,0 +1,52 @@
+---
+order: 6
+zh-CN:
+	title: 禁用
+	disabledProperty: 属性禁用
+	disabledComponent: 兼容Disabled组件
+en-US:
+	title: Disabled
+	disabledProperty: Property 'disabled'
+	disabledComponent: Compatible with Disabled Component
+---
+
+```jsx
+import { ColorPicker, Disabled } from 'zent';
+
+class Simple extends React.Component {
+	state = {
+		color: '#5197FF',
+	};
+
+	handleChange = color => {
+		this.setState({
+			color,
+		});
+	};
+
+	render() {
+		const { color } = this.state;
+		return (
+			<div>
+				<ColorPicker color={color} disabled />
+				<div style={{ color, marginTop: 5 }}>{i18n.disabledProperty}</div>
+				<br />
+				<Disabled>
+					<ColorPicker color={color} />
+					<div className="color-picker-demo" />
+					<ColorPicker color={color} disabled={false} />
+				</Disabled>
+				<div style={{ color, marginTop: 5 }}>{i18n.disabledComponent}</div>
+			</div>
+		);
+	}
+}
+
+ReactDOM.render(<Simple />, mountNode);
+```
+
+<style>
+.color-picker-demo {
+	margin-bottom: 5px;
+}
+</style>

--- a/packages/zent/src/colorpicker/index.tsx
+++ b/packages/zent/src/colorpicker/index.tsx
@@ -16,6 +16,7 @@ import { DisabledContext, IDisabledContext } from '../disabled';
 export type PresetColors = string[];
 export type ColorPickerType = 'default' | 'simple';
 
+const prefixCls = 'zent-color-picker';
 export interface IColorPickerProps {
   color: string;
   showAlpha?: boolean;
@@ -24,7 +25,6 @@ export interface IColorPickerProps {
   onChange?: (color: string) => any;
   className?: string;
   wrapperClassName?: string;
-  prefix?: string;
   disabled?: boolean;
 }
 
@@ -38,7 +38,6 @@ export class ColorPicker extends PureComponent<IColorPickerProps> {
     onChange() {},
     className: '',
     wrapperClassName: '',
-    prefix: 'zent',
     type: 'default',
     presetColors: [
       '#FFFFFF',
@@ -90,20 +89,19 @@ export class ColorPicker extends PureComponent<IColorPickerProps> {
     const {
       color,
       showAlpha,
-      prefix,
       className,
       wrapperClassName,
       type,
       presetColors,
     } = this.props;
     const { popVisible } = this.state;
-    const openClassName = popVisible ? 'zent-color-picker--open' : '';
+    const openClassName = popVisible ? `${prefixCls}--open` : '';
     const backgroundColor = color;
 
     return (
       <Popover
-        className={cx(`${prefix}-color-picker-popover`, className)}
         wrapperClassName="zent-color-picker-wrapper"
+        className={cx(`${prefixCls}-popover`, className)}
         position={Popover.Position.AutoBottomLeft}
         display="inline-block"
         cushion={5}
@@ -112,17 +110,14 @@ export class ColorPicker extends PureComponent<IColorPickerProps> {
       >
         <PopoverClickTrigger>
           <div
-            className={cx(
-              `${prefix}-color-picker`,
-              wrapperClassName,
-              openClassName,
-              { [`${prefix}-color-picker_disabled`]: this.disabled }
-            )}
+            className={cx(prefixCls, wrapperClassName, openClassName, {
+              [`${prefixCls}_disabled`]: this.disabled,
+            })}
             tabIndex={0}
           >
-            <div className={`${prefix}-color-picker__text`}>
+            <div className={`${prefixCls}__text`}>
               <div
-                className={`${prefix}-color-picker__preview`}
+                className={`${prefixCls}__preview`}
                 style={{ backgroundColor }}
               />
             </div>
@@ -133,7 +128,6 @@ export class ColorPicker extends PureComponent<IColorPickerProps> {
             <SketchPresetColors
               colors={presetColors}
               onClick={this.handleChange}
-              prefix={prefix}
               type={type}
             />
           ) : (
@@ -141,7 +135,6 @@ export class ColorPicker extends PureComponent<IColorPickerProps> {
               color={color}
               showAlpha={showAlpha}
               onChange={this.handleChange}
-              prefix={prefix}
               type={type}
             />
           )}

--- a/packages/zent/src/colorpicker/index.tsx
+++ b/packages/zent/src/colorpicker/index.tsx
@@ -11,6 +11,7 @@ import ColorBoard from './ColorBoard';
 import SketchPresetColors from './SketchPresetColors';
 import PopoverClickTrigger from './PopoverClickTrigger';
 import Popover from '../popover';
+import { DisabledContext, IDisabledContext } from '../disabled';
 
 export type PresetColors = string[];
 export type ColorPickerType = 'default' | 'simple';
@@ -24,6 +25,7 @@ export interface IColorPickerProps {
   className?: string;
   wrapperClassName?: string;
   prefix?: string;
+  disabled?: boolean;
 }
 
 export class ColorPicker extends PureComponent<IColorPickerProps> {
@@ -58,6 +60,13 @@ export class ColorPicker extends PureComponent<IColorPickerProps> {
   };
 
   static ColorBoard = ColorBoard;
+  static contextType = DisabledContext;
+  context!: IDisabledContext;
+
+  get disabled() {
+    const { disabled = this.context.value } = this.props;
+    return disabled;
+  }
 
   handleChange = color => {
     const { onChange, showAlpha } = this.props;
@@ -69,6 +78,9 @@ export class ColorPicker extends PureComponent<IColorPickerProps> {
   };
 
   handleVisibleChange = visible => {
+    if (this.disabled) {
+      return;
+    }
     this.setState({
       popVisible: visible,
     });
@@ -103,7 +115,8 @@ export class ColorPicker extends PureComponent<IColorPickerProps> {
             className={cx(
               `${prefix}-color-picker`,
               wrapperClassName,
-              openClassName
+              openClassName,
+              { [`${prefix}-color-picker_disabled`]: this.disabled }
             )}
             tabIndex={0}
           >

--- a/packages/zent/src/disabled/demos/1.basic.md
+++ b/packages/zent/src/disabled/demos/1.basic.md
@@ -23,6 +23,7 @@ import {
 	Slider,
 	Switch,
 	SplitButton,
+	ColorPicker,
 } from 'zent';
 
 ReactDOM.render(
@@ -30,7 +31,9 @@ ReactDOM.render(
 		<Disabled>
 			<AutoComplete />
 			<Button type="primary">Disabled</Button>
-			<Link href="https://www.youzan.com/" target="_blank">www.youzan.com</Link>
+			<Link href="https://www.youzan.com/" target="_blank">
+				www.youzan.com
+			</Link>
 			<Checkbox>Checkbox</Checkbox>
 			<Input />
 			<Input type="textarea" />
@@ -57,6 +60,7 @@ ReactDOM.render(
 					Collapse 3
 				</Collapse.Panel>
 			</Collapse>
+			<ColorPicker color="#5197FF" />
 		</Disabled>
 		<Button type="primary">Not Disabled</Button>
 	</div>,


### PR DESCRIPTION
Fixes #1445 

Changes
- ColorPicker支持禁用，属性disabled，以及Disabled组件
- ColorPicker删除prefix属性
- ColorPicker 组件样式更新
- 删除 `zent-colorpicker-board`, `zent-colorpicker-input` 以及 `zent-colorpicker-colors` CSS class