### PR TITLE
[bug fix] Form: FormModel.prototype.owner改为只读属性而不是getter

### DIFF
--- a/packages/zent/src/form/formulr/models/form.ts
+++ b/packages/zent/src/form/formulr/models/form.ts
@@ -30,10 +30,7 @@ class FormModel<
   private readonly workingValidators = new Set<Observable<unknown>>();
   readonly isValidating$ = new BehaviorSubject(false);
 
-  get owner() {
-    return this;
-  }
-
+  readonly owner = this;
   get form() {
     return (this as unknown) as FormModel;
   }


### PR DESCRIPTION
#1470 改出了问题，修复一下，owner在构造函数中会被赋值，单单一个getter会报错