### PR TITLE
separate UI logic from data structures

### DIFF
--- a/packages/zent/src/cascader/MenuCascader.tsx
+++ b/packages/zent/src/cascader/MenuCascader.tsx
@@ -431,7 +431,10 @@ export class MenuCascader extends React.Component<
       const { onChange } = this.props;
       const { options, selectedPaths: oldSelectedPaths } = this.state;
 
-      const affectedPaths = options.getPaths(node);
+      // filter out paths that contain disabled node
+      const affectedPaths = options.getPaths(node, path =>
+        path.every(node => !node.disabled)
+      );
       let selectedPaths = checked
         ? union(oldSelectedPaths, affectedPaths)
         : difference(oldSelectedPaths, affectedPaths);

--- a/packages/zent/src/cascader/forest.ts
+++ b/packages/zent/src/cascader/forest.ts
@@ -286,15 +286,20 @@ export class Forest {
 
   /**
    * Returns all paths from root to leaf that contains `startNode`
+   *
+   * An optional `predicate` function can be used to filter results,
+   * return `true` to keep it, `false` to drop it.
    */
-  getPaths(startNode: ICascaderItem) {
+  getPaths(
+    startNode: ICascaderItem,
+    predicate?: (path: ICascaderItem[]) => boolean
+  ) {
     const depth = getNodeDepth(startNode);
     const idx = depth - 1;
     const { value } = startNode;
 
     return this.reducePath((acc, path) => {
-      // filter out paths that contain disabled node
-      if (path[idx].value === value && path.every(node => !node.disabled)) {
+      if (path[idx].value === value && (!predicate || predicate(path))) {
         acc.push(path);
       }
 


### PR DESCRIPTION
Decouple `disabled` logic from `getPaths`