### PR TITLE
[bug fix] Form: value-listener中的rxjs异步订阅通知

### DIFF
--- a/packages/zent/src/form/CombineErrors.tsx
+++ b/packages/zent/src/form/CombineErrors.tsx
@@ -152,6 +152,6 @@ export class CombineErrors extends React.Component<
     if (error === null) {
       return null;
     }
-    return <FormError>{error.message}</FormError>;
+    return <FormError>{error?.message}</FormError>;
   }
 }

--- a/packages/zent/src/form/Field.tsx
+++ b/packages/zent/src/form/Field.tsx
@@ -38,7 +38,7 @@ function withDefaultOption(option: ValidateOption | null | undefined) {
  * @param model
  * @param initialValue
  */
-export function useInitialValue<T>(model: FieldModel<T>, initialValue: T) {
+export function useInitialValue<T>(model: FieldModel<T>, initialValue?: T) {
   React.useEffect(() => {
     if (initialValue !== undefined) {
       model.initialize(initialValue);

--- a/packages/zent/src/form/formulr/field-array.tsx
+++ b/packages/zent/src/form/formulr/field-array.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useEffect } from 'react';
+import { useMemo } from 'react';
 import {
   FieldArrayModel,
   FormStrategy,
@@ -29,9 +29,8 @@ function useArrayModel<Item, Child extends IModel<Item>>(
   strategy: FormStrategy,
   defaultValue: readonly Item[]
 ) {
-  const { model, effect } = useMemo(() => {
+  const model = useMemo(() => {
     let model: FieldArrayModel<Item, Child>;
-    let effect: (() => void) | undefined;
     if (typeof field === 'string') {
       if (strategy !== FormStrategy.View) {
         throw UnexpectedFormStrategyError;
@@ -47,7 +46,7 @@ function useArrayModel<Item, Child extends IModel<Item>>(
           }
         }
         model = new FieldArrayModel<Item, Child>(null, v);
-        effect = () => parent.registerChild(field, model);
+        parent.registerChild(field, model);
       } else {
         model = m;
       }
@@ -69,18 +68,15 @@ function useArrayModel<Item, Child extends IModel<Item>>(
           }
         }
         model = new FieldArrayModel(null, v);
-        effect = () => field.setModel(model);
       } else {
         model = m;
       }
     } else {
       model = field;
     }
-    return { model, effect };
+    return model;
     /** ignore defaultValue */
   }, [field, parent, strategy]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  useEffect(() => effect?.(), [effect]);
 
   return model;
 }

--- a/packages/zent/src/form/formulr/field-set.tsx
+++ b/packages/zent/src/form/formulr/field-set.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useEffect } from 'react';
+import { useMemo } from 'react';
 import { IFormContext, useFormContext } from './context';
 import {
   $FieldSetValue,
@@ -29,9 +29,8 @@ function useFieldSetModel<T extends UnknownFieldSetModelChildren>(
   parent: FieldSetModel,
   strategy: FormStrategy
 ) {
-  const { model, effect } = useMemo(() => {
+  const model = useMemo(() => {
     let model: FieldSetModel<T>;
-    let effect: (() => void) | undefined;
     if (typeof field === 'string') {
       if (strategy !== FormStrategy.View) {
         throw UnexpectedFormStrategyError;
@@ -48,8 +47,7 @@ function useFieldSetModel<T extends UnknownFieldSetModelChildren>(
           }
         }
         model.patchedValue = v;
-        effect = () =>
-          parent.registerChild(field, model as BasicModel<unknown>);
+        parent.registerChild(field, model as BasicModel<unknown>);
       } else {
         model = m;
       }
@@ -60,17 +58,15 @@ function useFieldSetModel<T extends UnknownFieldSetModelChildren>(
         model.patchedValue = or(field.patchedValue, () =>
           or(field.initialValue, () => ({}))
         );
-        effect = () => field.setModel(model);
+        field.setModel(model);
       } else {
         model = m;
       }
     } else {
       model = field;
     }
-    return { model, effect };
+    return model;
   }, [field, parent, strategy]);
-
-  useEffect(() => effect?.(), [effect]);
 
   return model;
 }

--- a/packages/zent/src/form/formulr/field.tsx
+++ b/packages/zent/src/form/formulr/field.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useEffect } from 'react';
+import { useMemo } from 'react';
 import {
   FieldModel,
   BasicModel,
@@ -29,9 +29,8 @@ function useModelAndChildProps<Value>(
   defaultValue: Value | (() => Value),
   form: FormModel
 ) {
-  const { model, effect } = useMemo(() => {
+  const model = useMemo(() => {
     let model: FieldModel<Value>;
-    let effect: (() => void) | undefined;
     if (typeof field === 'string') {
       if (strategy !== FormStrategy.View) {
         throw UnexpectedFormStrategyError;
@@ -43,8 +42,7 @@ function useModelAndChildProps<Value>(
           isValueFactory(defaultValue) ? defaultValue : () => defaultValue
         );
         model = new FieldModel<Value>(v);
-        effect = () =>
-          parent.registerChild(field, model as BasicModel<unknown>);
+        parent.registerChild(field, model as BasicModel<unknown>);
       } else {
         model = m;
       }
@@ -58,18 +56,16 @@ function useModelAndChildProps<Value>(
           )
         );
         model = new FieldModel<Value>(v);
-        effect = () => field.setModel(model);
+        field.setModel(model);
       } else {
         model = m;
       }
     } else {
       model = field;
     }
-    return { model, effect };
+    return model;
     /** ignore defaultValue */
   }, [field, parent, strategy, form]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  useEffect(() => effect?.(), [effect]);
 
   return model;
 }

--- a/packages/zent/src/form/formulr/value-listener.tsx
+++ b/packages/zent/src/form/formulr/value-listener.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { merge, of, Observable, NEVER } from 'rxjs';
-import { filter, switchMap } from 'rxjs/operators';
+import { of, Observable, NEVER, asapScheduler, merge } from 'rxjs';
+import { filter, switchMap, observeOn } from 'rxjs/operators';
 import { useFormContext, FormContext, IFormContext } from './context';
 import { useValue$ } from './hooks';
 import {
@@ -46,8 +46,20 @@ function useModelFromContext<Model>(
     }
     const m = parent.get(name);
     check(m) && setModel(m);
+
+    /**
+     * Because `FieldSetModel.prototype.registerChild` will be
+     * called inside `useMemo`, consume at next micro task queue
+     * to avoid react warning below.
+     *
+     * Cannot update a component from inside the function body
+     * of a different component.
+     */
     const $ = merge(parent.childRegister$, parent.childRemove$)
-      .pipe(filter(change => change === name))
+      .pipe(
+        observeOn(asapScheduler),
+        filter(change => change === name)
+      )
       .subscribe(name => {
         const candidate = parent.get(name);
         if (check(candidate)) {
@@ -110,7 +122,10 @@ export function useFieldValue<T>(field: string | FieldModel<T>): T | null {
   >(
     isFieldModel<T>(field) || isModelRef<T, any, FieldModel<T>>(field)
       ? field
-      : null
+      : () => {
+          const m = ctx.parent.get(field);
+          return isFieldModel<T>(m) ? m : null;
+        }
   );
   React.useEffect(() => {
     if (typeof field !== 'string') {
@@ -121,8 +136,20 @@ export function useFieldValue<T>(field: string | FieldModel<T>): T | null {
     if (isFieldModel<T>(m)) {
       setModel(m);
     }
+
+    /**
+     * Because `FieldSetModel.prototype.registerChild` will be
+     * called inside `useMemo`, consume at next micro task queue
+     * to avoid react warning below.
+     *
+     * Cannot update a component from inside the function body
+     * of a different component.
+     */
     const $ = merge(ctx.parent.childRegister$, ctx.parent.childRemove$)
-      .pipe(filter(change => change === field))
+      .pipe(
+        observeOn(asapScheduler),
+        filter(change => change === field)
+      )
       .subscribe(name => {
         const candidate = ctx.parent.get(name);
         if (isFieldModel<T>(candidate)) {
@@ -140,8 +167,9 @@ export function useFieldValue<T>(field: string | FieldModel<T>): T | null {
 
   React.useEffect(() => {
     if (isModelRef<T, IModel<any>, FieldModel<T>>(model)) {
-      const $ = model.model$
+      const $ = merge(model.model$)
         .pipe(
+          observeOn(asapScheduler),
           switchMap<FieldModel<T> | null, Observable<T | null>>(it => {
             if (isFieldModel<T>(it)) {
               return it.value$;

--- a/packages/zent/src/form/formulr/value-listener.tsx
+++ b/packages/zent/src/form/formulr/value-listener.tsx
@@ -167,7 +167,7 @@ export function useFieldValue<T>(field: string | FieldModel<T>): T | null {
 
   React.useEffect(() => {
     if (isModelRef<T, IModel<any>, FieldModel<T>>(model)) {
-      const $ = merge(model.model$)
+      const $ = model.model$
         .pipe(
           observeOn(asapScheduler),
           switchMap<FieldModel<T> | null, Observable<T | null>>(it => {


### PR DESCRIPTION
这是之前在formulr中还没完成的pr，formulr合入zent后遗漏了这个修复，顺便修复了一个类型问题，不影响运行时

解决的问题：
1. 恢复render阶段同步关联model的特性
2. 异步订阅通知，避免react 16.13的update in render的warning（之前的版本是通过异步关联model来避免的）