### PR TITLE
[bug fix] ClampLines: 修复text属性为空串时的渲染问题

### DIFF
--- a/packages/zent/__tests__/clamp-lines.js
+++ b/packages/zent/__tests__/clamp-lines.js
@@ -53,12 +53,12 @@ describe('ClampLines', () => {
       <ClampLines delay={0} lines={2} popWidth={400} resizable text="" />
     );
     const instance = wrapper.find(ClampLines).instance();
-    instance.element.current = {
-      clientHeight: 20,
-    };
-    instance.innerElement.current = {
-      textContent: '',
-    };
+    const element = document.createElement('div');
+    element.style.height = '20px';
+    instance.element.current = element;
+    const innerElement = document.createElement('div');
+    innerElement.textContent = '';
+    instance.innerElement.current = innerElement;
     const spy = jest.spyOn(instance, 'clampLines');
     instance.handleResize();
     jest.runOnlyPendingTimers();

--- a/packages/zent/src/clamp-lines/ClampLines.tsx
+++ b/packages/zent/src/clamp-lines/ClampLines.tsx
@@ -73,14 +73,18 @@ export class ClampLines extends Component<IClampLinesProps, IClampLinesState> {
   }
 
   componentDidUpdate(prevProps: IClampLinesProps) {
-    if (prevProps.text !== this.state.original) {
+    const { original } = this.state;
+    if (original && prevProps.text !== original) {
       this.clampLines();
     }
   }
 
   componentDidMount() {
+    const { text } = this.props;
     this.lineHeight = getLineHeight(this.element.current);
-    this.clampLines();
+    if (text) {
+      this.clampLines();
+    }
   }
 
   handleResize = () => {

--- a/packages/zent/src/clamp-lines/ClampLines.tsx
+++ b/packages/zent/src/clamp-lines/ClampLines.tsx
@@ -71,7 +71,7 @@ export class ClampLines extends Component<IClampLinesProps, IClampLinesState> {
   componentDidUpdate(prevProps: IClampLinesProps) {
     const { original } = this.state;
 
-    if (!this.lineHeight && original) {
+    if (!this.lineHeight) {
       this.lineHeight = getLineHeight(this.element.current);
     }
 

--- a/packages/zent/src/clamp-lines/ClampLines.tsx
+++ b/packages/zent/src/clamp-lines/ClampLines.tsx
@@ -48,7 +48,9 @@ export class ClampLines extends Component<IClampLinesProps, IClampLinesState> {
   constructor(props: IClampLinesProps) {
     super(props);
 
-    this.original = props.text;
+    const { text } = props;
+
+    this.original = text;
 
     this.state = {
       noClamp: false,
@@ -79,10 +81,11 @@ export class ClampLines extends Component<IClampLinesProps, IClampLinesState> {
   }
 
   componentDidMount() {
-    const { text } = this.props;
     this.lineHeight = getLineHeight(this.element.current);
-    if (text) {
+    if (this.props.text) {
       this.clampLines();
+    } else {
+      this.setState({ noClamp: true });
     }
   }
 

--- a/packages/zent/src/clamp-lines/ClampLines.tsx
+++ b/packages/zent/src/clamp-lines/ClampLines.tsx
@@ -43,14 +43,8 @@ export class ClampLines extends Component<IClampLinesProps, IClampLinesState> {
   lineHeight = 0;
   maxHeight = 0;
 
-  original: string;
-
   constructor(props: IClampLinesProps) {
     super(props);
-
-    const { text } = props;
-
-    this.original = text;
 
     this.state = {
       noClamp: false,

--- a/packages/zent/src/clamp-lines/ClampLines.tsx
+++ b/packages/zent/src/clamp-lines/ClampLines.tsx
@@ -75,17 +75,21 @@ export class ClampLines extends Component<IClampLinesProps, IClampLinesState> {
   }
 
   componentDidUpdate(prevProps: IClampLinesProps) {
-    if (prevProps.text !== this.state.original) {
+    const { original } = this.state;
+
+    if (!this.lineHeight && original) {
+      this.lineHeight = getLineHeight(this.element.current);
+    }
+
+    if (prevProps.text !== original) {
       this.clampLines();
     }
   }
 
   componentDidMount() {
-    this.lineHeight = getLineHeight(this.element.current);
     if (this.props.text) {
+      this.lineHeight = getLineHeight(this.element.current);
       this.clampLines();
-    } else {
-      this.setState({ noClamp: true });
     }
   }
 
@@ -180,6 +184,10 @@ export class ClampLines extends Component<IClampLinesProps, IClampLinesState> {
       trigger,
       renderPop,
     } = this.props;
+
+    if (!text) {
+      return null;
+    }
 
     if (this.state.noClamp) {
       return (

--- a/packages/zent/src/clamp-lines/ClampLines.tsx
+++ b/packages/zent/src/clamp-lines/ClampLines.tsx
@@ -4,7 +4,6 @@ import cx from 'classnames';
 import identity from '../utils/identity';
 import Pop from '../pop';
 import { WindowResizeHandler } from '../utils/component/WindowResizeHandler';
-import isBrowser from '../utils/isBrowser';
 import { getLineHeight } from '../utils/dom/getLineHeight';
 
 export interface IClampLinesProps {
@@ -74,18 +73,14 @@ export class ClampLines extends Component<IClampLinesProps, IClampLinesState> {
   }
 
   componentDidUpdate(prevProps: IClampLinesProps) {
-    const { text } = prevProps;
-    if (text && text !== this.state.original) {
+    if (prevProps.text !== this.state.original) {
       this.clampLines();
     }
   }
 
   componentDidMount() {
-    const { text } = this.props;
-    if (text && isBrowser) {
-      this.lineHeight = getLineHeight(this.element.current);
-      this.clampLines();
-    }
+    this.lineHeight = getLineHeight(this.element.current);
+    this.clampLines();
   }
 
   handleResize = () => {
@@ -179,10 +174,6 @@ export class ClampLines extends Component<IClampLinesProps, IClampLinesState> {
       trigger,
       renderPop,
     } = this.props;
-
-    if (!text) {
-      return null;
-    }
 
     if (this.state.noClamp) {
       return (

--- a/packages/zent/src/clamp-lines/ClampLines.tsx
+++ b/packages/zent/src/clamp-lines/ClampLines.tsx
@@ -71,7 +71,7 @@ export class ClampLines extends Component<IClampLinesProps, IClampLinesState> {
   componentDidUpdate(prevProps: IClampLinesProps) {
     const { original } = this.state;
 
-    if (!this.lineHeight) {
+    if (!this.lineHeight && this.element.current) {
       this.lineHeight = getLineHeight(this.element.current);
     }
 
@@ -81,7 +81,7 @@ export class ClampLines extends Component<IClampLinesProps, IClampLinesState> {
   }
 
   componentDidMount() {
-    if (this.props.text) {
+    if (this.element.current) {
       this.lineHeight = getLineHeight(this.element.current);
       this.clampLines();
     }

--- a/packages/zent/src/clamp-lines/ClampLines.tsx
+++ b/packages/zent/src/clamp-lines/ClampLines.tsx
@@ -73,8 +73,7 @@ export class ClampLines extends Component<IClampLinesProps, IClampLinesState> {
   }
 
   componentDidUpdate(prevProps: IClampLinesProps) {
-    const { original } = this.state;
-    if (original && prevProps.text !== original) {
+    if (prevProps.text !== this.state.original) {
       this.clampLines();
     }
   }


### PR DESCRIPTION
1. 首次渲染text属性为空时，后续text变更不会更新视图
```jsx
<Form form={form} layout="horizontal">
  <FormInputField name="text"></FormInputField>
  <Form.FieldValue name="text">
    {text => {
       return <ClampLines text={text || ''}></ClampLines>;
    }}
  </Form.FieldValue>
</Form>
```
2. 首次渲染text非空时，后续text为空会忽略下一次视图更新
```jsx
<Form form={form} layout="horizontal">
    <FormInputField name="text" defaultValue="abc"></FormInputField>
  <Form.FieldValue name="text">
    {text => {
       return <ClampLines text={text || ''}></ClampLines>;
    }}
  </Form.FieldValue>
</Form>
```