### PR TITLE
upgrade sortablejs and fix insertion bug

### DIFF
--- a/packages/zent/package.json
+++ b/packages/zent/package.json
@@ -37,7 +37,7 @@
   ],
   "dependencies": {
     "@types/autosize": "^3.0.7",
-    "@types/sortablejs": "~1.7.2",
+    "@types/sortablejs": "~1.10.6",
     "autosize": "^4.0.0",
     "big.js": "^5.2.2",
     "classnames": "^2.2.6",
@@ -45,7 +45,7 @@
     "react-is": "^16.8.1",
     "react-transition-group": "^2.6.0",
     "rxjs": "^6.6.2",
-    "sortablejs": "~1.9.0",
+    "sortablejs": "~1.12.0",
     "tslib": "^2.0.0",
     "utility-types": "^3.4.1",
     "warning": "^4.0.3",

--- a/packages/zent/src/sortable/Sortable.tsx
+++ b/packages/zent/src/sortable/Sortable.tsx
@@ -1,10 +1,16 @@
 import cx from 'classnames';
 import * as React from 'react';
-import * as sortableJS from 'sortablejs';
+
+// use this only as type, @types/sortablejs and sortablejs cannot be used with `esModuleInterop: false`
+import * as _sortableJS from 'sortablejs';
 
 import reorder from '../utils/reorder';
 
-export interface ISortableProps<T> extends sortableJS.Options {
+// use this as value
+const sortableJS: typeof _sortableJS = (_sortableJS as any).default;
+
+export interface ISortableProps<T>
+  extends Omit<_sortableJS.Options, 'onChange'> {
   // zent wrapper api
   tag?: React.ComponentType | string;
   className?: string;
@@ -18,7 +24,7 @@ export class Sortable<T> extends React.Component<ISortableProps<T>> {
     tag: 'div',
   };
 
-  sortable: sortableJS;
+  sortable: _sortableJS;
   containerRef = React.createRef<HTMLElement>();
 
   initSortable = () => {
@@ -36,7 +42,7 @@ export class Sortable<T> extends React.Component<ISortableProps<T>> {
       return;
     }
 
-    const sortableOptions: sortableJS.Options = {
+    const sortableOptions: _sortableJS.Options = {
       filter: filterClass ? `.${filterClass}` : '',
       ghostClass: `zent-ghost`,
       chosenClass: `zent-chosen`,
@@ -51,7 +57,8 @@ export class Sortable<T> extends React.Component<ISortableProps<T>> {
           return false;
         }
 
-        return 1;
+        // insert point is based on direction
+        return true;
       },
       onEnd: e => {
         const { items } = this.props;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1477,10 +1477,10 @@
   resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.2.tgz#a811b8c18e2babab7d542b3365887ae2e4d9de47"
   integrity sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==
 
-"@types/sortablejs@~1.7.2":
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/@types/sortablejs/-/sortablejs-1.7.3.tgz#844128e9705bec0e44a862176e115364cdabaadd"
-  integrity sha512-tHy0kEMSF7UitXkkr/LoNGryU6XkowzbLbc7ybtYuLqCLZnG6VAZsbIB7aSkiUR8uTH1g5QxSVUg2sUatRhitA==
+"@types/sortablejs@~1.10.6":
+  version "1.10.6"
+  resolved "https://registry.yarnpkg.com/@types/sortablejs/-/sortablejs-1.10.6.tgz#98725ae08f1dfe28b8da0fdf302c417f5ff043c0"
+  integrity sha512-QRz8Z+uw2Y4Gwrtxw8hD782zzuxxugdcq8X/FkPsXUa1kfslhGzy13+4HugO9FXNo+jlWVcE6DYmmegniIQ30A==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -11436,10 +11436,10 @@ sort-keys@^1.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
-sortablejs@~1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.9.0.tgz#2d1e74ae6bac2cb4ad0622908f340848969eb88d"
-  integrity sha512-Ot6bYJ6PoqPmpsqQYXjn1+RKrY2NWQvQt/o4jfd/UYwVWndyO5EPO8YHbnm5HIykf8ENsm4JUrdAvolPT86yYA==
+sortablejs@~1.12.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.12.0.tgz#ee6d7ece3598c2af0feb1559d98595e5ea37cbd6"
+  integrity sha512-bPn57rCjBRlt2sC24RBsu40wZsmLkSo2XeqG8k6DC1zru5eObQUIPPZAQG7W2SJ8FZQYq+BEJmvuw1Zxb3chqg==
 
 source-list-map@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
- Upgrade `sortablejs` to `1.12.0`, `@types/sortablejs` to `1.10.6`
- Fix cannot move item to the first in the list