### PR TITLE
[bug fix] Form: 修复BasicBuilder导致的类型错误

### DIFF
--- a/packages/zent/src/form/ZentForm.tsx
+++ b/packages/zent/src/form/ZentForm.tsx
@@ -61,7 +61,7 @@ export class ZentForm<T extends UnknownFieldSetModelChildren>
   /** @internal */
   submit$ = new Subject<FormEvent | undefined>();
   /** @internal */
-  reset$ = new Subject<FormEvent | undefined>();
+  reset$ = new Subject<FormEvent<HTMLFormElement> | undefined>();
 
   /** @internal */
   constructor(
@@ -143,7 +143,7 @@ export class ZentForm<T extends UnknownFieldSetModelChildren>
     this.inner.model.reset();
   }
 
-  reset(e: FormEvent) {
+  reset(e: FormEvent<HTMLFormElement>) {
     this.reset$.next(e);
   }
 

--- a/packages/zent/src/form/form-components/DateRangeQuickPickerField.tsx
+++ b/packages/zent/src/form/form-components/DateRangeQuickPickerField.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Omit } from 'utility-types';
 import DateRangeQuickPicker, {
+  DateRangeQuickPickerPresetValue,
   IDateRangeQuickPickerProps,
 } from '../../date-range-quick-picker';
 import { DatePickers } from '../../datetimepicker/common/types';
@@ -22,14 +23,17 @@ const DateRangeQuickPickerField: React.FC<{
   childProps: IFormFieldChildProps<DatePickers.RangeValue>;
   props: IFormDateRangeQuickPickerFieldProps;
 }> = ({ childProps, props }) => {
-  const [chosenDays, setChosenDays] = React.useState<number | undefined>(
-    undefined
-  );
+  const [chosenDays, setChosenDays] = React.useState<
+    DateRangeQuickPickerPresetValue | undefined
+  >(undefined);
 
   const onChangeRef = useEventCallbackRef(childProps.onChange);
 
   const onChange = React.useCallback(
-    (value: DatePickers.RangeValue, chosenDays: number) => {
+    (
+      value: DatePickers.RangeValue,
+      chosenDays?: DateRangeQuickPickerPresetValue
+    ) => {
       onChangeRef.current?.(value);
       setChosenDays(chosenDays);
     },

--- a/packages/zent/src/form/form-components/RadioGroupField.tsx
+++ b/packages/zent/src/form/form-components/RadioGroupField.tsx
@@ -43,7 +43,7 @@ export function FormRadioGroupField<T>(
     <FormField
       {...rest}
       className={cx(className, 'zent-form-radio-group-field')}
-      defaultValue={'defaultValue' in props ? props.defaultValue : null}
+      defaultValue={props.defaultValue ?? null}
     >
       {childProps => <RadioGroupField childProps={childProps} props={props} />}
     </FormField>

--- a/packages/zent/src/form/form-components/SwitchField.tsx
+++ b/packages/zent/src/form/form-components/SwitchField.tsx
@@ -4,7 +4,6 @@ import cx from 'classnames';
 import Switch, { ISwitchProps } from '../../switch';
 import { IFormComponentProps, IFormFieldChildProps } from '../shared';
 import { FormField } from '../Field';
-import { $MergeParams } from '../utils';
 
 export type IFormSwitchFieldProps = IFormComponentProps<
   boolean,
@@ -27,10 +26,7 @@ export const FormSwitchField: React.FunctionComponent<IFormSwitchFieldProps> = p
       {...rest}
       className={cx(className, 'zent-form-switch-field')}
       defaultValue={
-        typeof (props as $MergeParams<IFormSwitchFieldProps>).defaultValue ===
-        'boolean'
-          ? (props as $MergeParams<IFormSwitchFieldProps>).defaultValue
-          : false
+        typeof props.defaultValue === 'boolean' ? props.defaultValue : false
       }
     >
       {childProps => renderSwitch(childProps, props)}

--- a/packages/zent/src/form/formulr/builders/basic.ts
+++ b/packages/zent/src/form/formulr/builders/basic.ts
@@ -1,6 +1,5 @@
 import { IModel } from '../models/base';
 import { IValidators } from '../validate';
-import { Maybe } from '../maybe';
 
 export type $GetBuilderValue<T> = T extends BasicBuilder<infer V, infer _>
   ? V
@@ -13,17 +12,7 @@ export type $GetBuilderModel<T> = T extends BasicBuilder<infer _, infer M>
 export abstract class BasicBuilder<Value, Model extends IModel<Value>> {
   protected _validators: IValidators<Value> = [];
 
-  abstract build(
-    defaultValue?: Maybe<
-      /**
-       * To use friendly, don't use `extends` keyword to constraint generic type.
-       * -> `Value extends Record<string, unknown> ? Partial<Value> : Value`
-       *
-       * Note that this will convert `Array<T>` to `Array<T | undefined>` which is unsafe.
-       */
-      any extends Value ? any : Partial<Value>
-    >
-  ): Model;
+  abstract build(defaultValue?: unknown): Model;
 
   /**
    * 设置 builder 上的校验规则

--- a/packages/zent/src/form/formulr/builders/basic.ts
+++ b/packages/zent/src/form/formulr/builders/basic.ts
@@ -21,7 +21,7 @@ export abstract class BasicBuilder<Value, Model extends IModel<Value>> {
        *
        * Note that this will convert `Array<T>` to `Array<T | undefined>` which is unsafe.
        */
-      Partial<Value>
+      any extends Value ? any : Partial<Value>
     >
   ): Model;
 


### PR DESCRIPTION
背景：内部使用BasicBuilder时给了any作为类型参数，导致build方法在类型推断时得出了Partial<any>这样的奇葩类型。
解决方案：BasicBuilder用unknown作为默认值类型，具体类型由子类实现，避免子类实现方法后不报错但又和父类类型不兼容的问题。