### PR TITLE
SSR fix for window event handler

### DIFF
--- a/packages/zent/src/copy-button/CopyToClipboard.ts
+++ b/packages/zent/src/copy-button/CopyToClipboard.ts
@@ -1,12 +1,12 @@
 import toggleSelection from './toggleSelection';
 import createElement from '../utils/dom/createElement';
 
-function copy(text) {
-  let reselectPrevious,
-    range,
-    selection,
-    mark,
-    success = false;
+function copy(text: string) {
+  let reselectPrevious: () => void;
+  let range: Range;
+  let selection: Selection;
+  let mark: HTMLSpanElement;
+  let success = false;
 
   try {
     reselectPrevious = toggleSelection();
@@ -20,14 +20,14 @@ function copy(text) {
     mark.style.all = 'unset';
     // prevents scrolling to the end of the page
     mark.style.position = 'fixed';
-    mark.style.top = 0;
+    mark.style.top = '0';
     mark.style.clip = 'rect(0, 0, 0, 0)';
     // used to preserve spaces and line breaks
     mark.style.whiteSpace = 'pre';
     // do not inherit user-select (it may be `none`)
     mark.style.webkitUserSelect = 'text';
-    mark.style.MozUserSelect = 'text';
-    mark.style.msUserSelect = 'text';
+    (mark.style as any).MozUserSelect = 'text';
+    (mark.style as any).msUserSelect = 'text';
     mark.style.userSelect = 'text';
 
     document.body.appendChild(mark);

--- a/packages/zent/src/copy-button/ReactCopyToClipboard.tsx
+++ b/packages/zent/src/copy-button/ReactCopyToClipboard.tsx
@@ -13,7 +13,7 @@ export interface ICopyToClipboardChildProps {
 }
 
 export class CopyToClipboard extends Component<ICopyToClipboardProps> {
-  onClick = event => {
+  onClick = (event: React.MouseEvent) => {
     const { text, onCopy, children } = this.props;
 
     const elem = React.Children.only<any>(children);

--- a/packages/zent/src/utils/component/WindowEventHandler.tsx
+++ b/packages/zent/src/utils/component/WindowEventHandler.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import isBrowser from '../isBrowser';
 import { useEventHandler, EventHandler } from './event-handler';
 
 export interface IWindowEventHandlerProps<K extends keyof WindowEventMap> {
@@ -12,6 +13,11 @@ export function useWindowEventHandler<K extends keyof WindowEventMap>(
   listener: (ev: WindowEventMap[K]) => void,
   options?: AddEventListenerOptions
 ) {
+  if (!isBrowser) {
+    return;
+  }
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   return useEventHandler(window, eventName, listener, options);
 }
 
@@ -20,6 +26,10 @@ export function WindowEventHandler<K extends keyof WindowEventMap>({
   listener,
   options,
 }: IWindowEventHandlerProps<K>) {
+  if (!isBrowser) {
+    return null;
+  }
+
   return (
     <EventHandler
       target={window}


### PR DESCRIPTION
1. Skip render in SSR mode
2. Add typings for `CopyToClipboard`