### PR TITLE
[bugfix]: Select 选中option后清空搜索内容

### DIFF
--- a/packages/zent/src/select/Select.tsx
+++ b/packages/zent/src/select/Select.tsx
@@ -249,6 +249,7 @@ export class Select<
       return;
     }
 
+    this.setState({ keyword: '' });
     if (this.props.multiple === false) {
       this.onVisibleChange(false);
       const { onChange } = this.props;


### PR DESCRIPTION
Select

- `onSelect` 处理中清除本次搜索内容
