### PR TITLE
[bugfix]: 修复DatePicker `disabled` 失效问题

### DIFF
--- a/packages/zent/src/date-picker/CombinedDateRangePicker.tsx
+++ b/packages/zent/src/date-picker/CombinedDateRangePicker.tsx
@@ -62,7 +62,9 @@ export const CombinedDateRangePicker = <T extends IValueType = 'string'>(
   return (
     <Receiver componentName="TimePicker">
       {(i18n: II18nLocaleTimePicker) => (
-        <PickerContextProvider value={{ i18n, getInputRangeText }}>
+        <PickerContextProvider
+          value={{ i18n, autoComplete: !!showTime, getInputRangeText }}
+        >
           <CombinedPicker
             {...propsRequired}
             width={width ?? (!!showTime ? COMBINED_INPUT_WIDTH : INPUT_WIDTH)}

--- a/packages/zent/src/date-picker/DatePicker.tsx
+++ b/packages/zent/src/date-picker/DatePicker.tsx
@@ -35,6 +35,8 @@ export const DatePicker = <T extends IValueType = 'string'>(
   props: IDatePickerProps<T>
 ) => {
   const disabledContext = React.useContext(DisabledContext);
+  const parentContext = React.useContext(PickerContext);
+
   const propsRequired = {
     ...defaultDatePickerCommonProps,
     ...defaultDatePickerProps,
@@ -65,6 +67,7 @@ export const DatePicker = <T extends IValueType = 'string'>(
       {(i18n: II18nLocaleTimePicker) => (
         <PickerContextProvider
           value={{
+            ...parentContext,
             i18n,
             generateDate,
             getCallbackValue,

--- a/packages/zent/src/date-picker/DateRangePicker.tsx
+++ b/packages/zent/src/date-picker/DateRangePicker.tsx
@@ -66,6 +66,7 @@ export const DateRangePicker = <T extends IValueType = 'string'>(
         <PickerContextProvider
           value={{
             i18n,
+            autoComplete: !!showTime,
             getCallbackRangeValue,
           }}
         >

--- a/packages/zent/src/date-picker/context/PickerContext.ts
+++ b/packages/zent/src/date-picker/context/PickerContext.ts
@@ -19,6 +19,7 @@ export interface IPickerContextProps {
   getInputText?: (val: Date | null) => string | StringTuple;
 
   // range picker
+  autoComplete?: boolean;
   getCallbackRangeValue?: (val: DateNullTuple) => RangeDate | null;
   getInputRangeText?: (val: DateNullTuple) => StringTuple;
 }

--- a/packages/zent/src/date-picker/demos/disabled-time.md
+++ b/packages/zent/src/date-picker/demos/disabled-time.md
@@ -14,7 +14,10 @@ import {
 	CombinedTimeRangePicker,
 	CombinedDateRangePicker,
 } from 'zent';
-
+import { isSameDay } from 'date-fns';
+const initArray = targetNum => {
+	return Array.from({ length: targetNum }, (_, index) => index);
+};
 class Demo extends Component {
 	state = {};
 
@@ -53,13 +56,24 @@ class Demo extends Component {
 		disabledHours: () => [2],
 	});
 
-	disabledTimes2 = date => ({
-		disabledHours: () => {
-			return date && date.getDate() === 15 ? [3, 4, 5] : [2];
-		},
-		disabledMinutes: hour => (hour === 12 ? [10, 20, 30, 40, 50] : []),
-		disabledSeconds: () => [1, 2, 3, 4],
-	});
+	disabledTimes2 = date => {
+		const current = new Date();
+		const hour = current.getHours();
+		const minute = current.getMinutes();
+		const second = current.getSeconds();
+		const isSame = isSameDay(date, current);
+		return isSame
+			? {
+					disabledHours: () => initArray(hour, 24),
+					disabledMinutes: hourValue =>
+						hourValue === hour ? initArray(minute, 59) : [],
+					disabledSeconds: (hourValue, minuteValue) =>
+						hourValue === hour && minuteValue === minute
+							? initArray(second, 59)
+							: [],
+			  }
+			: {};
+	};
 
 	disabledTimes3 = (date, type) => {
 		return type === 'start'
@@ -72,11 +86,7 @@ class Demo extends Component {
 	};
 
 	disabledTimes4 = (date, type) => {
-		return {
-			disabledHours: () => [3, 4, 5],
-			disabledMinutes: () => [],
-			disabledSeconds: () => [],
-		};
+		return type === 'start' ? this.disabledTimes2(date) : {};
 	};
 
 	render() {
@@ -101,6 +111,7 @@ class Demo extends Component {
 					showTime
 					format="YYYY-MM-DD HH:mm:ss"
 					value={dateValue}
+					disabledDate={{ min: new Date() }}
 					onChange={this.onChangeDate}
 					disabledTime={this.disabledTimes2}
 				/>
@@ -126,6 +137,7 @@ class Demo extends Component {
 					value={combinedValue}
 					onChange={this.onChangeCombinedDate}
 					showTime
+					disabledDate={{ min: new Date() }}
 					format="YYYY-MM-DD HH:mm:ss"
 					disabledTime={this.disabledTimes4}
 				/>

--- a/packages/zent/src/date-picker/demos/disabled-time.md
+++ b/packages/zent/src/date-picker/demos/disabled-time.md
@@ -64,7 +64,7 @@ class Demo extends Component {
 		const isSame = isSameDay(date, current);
 		return isSame
 			? {
-					disabledHours: () => initArray(hour, 24),
+					disabledHours: () => initArray(hour, 23),
 					disabledMinutes: hourValue =>
 						hourValue === hour ? initArray(minute, 59) : [],
 					disabledSeconds: (hourValue, minuteValue) =>

--- a/packages/zent/src/date-picker/hooks/useRangeDisabledDate.ts
+++ b/packages/zent/src/date-picker/hooks/useRangeDisabledDate.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { isAfter, isBefore } from 'date-fns';
+import { endOfDay, isAfter, isBefore, startOfDay } from 'date-fns';
 import {
   IGenerateDateConfig,
   RangeType,
@@ -40,7 +40,8 @@ export default function useRangeDisabledDate(
   );
 
   const disabledStartDate = React.useCallback(
-    (date: Date) => {
+    (value: Date) => {
+      const date = endOfDay(value);
       const [start, end] = selected;
       const { isSame, offsetDate } = generateDate;
       if (disabledDateRef.current?.(date, START)) {
@@ -72,7 +73,8 @@ export default function useRangeDisabledDate(
   );
 
   const disabledEndDate = React.useCallback(
-    (date: Date) => {
+    (value: Date) => {
+      const date = startOfDay(value);
       const { circleEndDate, isSame, offsetDate } = generateDate;
       const [start] = selected;
       if (disabledDateRef.current?.(date, END)) {

--- a/packages/zent/src/date-picker/panels/combined-date-range-panel/RangeFooter.tsx
+++ b/packages/zent/src/date-picker/panels/combined-date-range-panel/RangeFooter.tsx
@@ -29,7 +29,7 @@ export const CombinedDateRangeFooter: React.FC<ICombinedDateRangeFooterProps> = 
   onSelected,
   format,
 }) => {
-  const { i18n } = React.useContext(PickerContext);
+  const { i18n, autoComplete } = React.useContext(PickerContext);
   const [start, end] = selected;
 
   const startTimeStatus = useConfirmStatus({
@@ -96,6 +96,7 @@ export const CombinedDateRangeFooter: React.FC<ICombinedDateRangeFooterProps> = 
         onChange={onStartTimeChange}
         selectedDate={start}
         disabledTime={disabledStartTimes}
+        autoComplete={autoComplete}
       />
       <div className={`${prefixCls}-seperator`}>{i18n.to}</div>
       <div className={cx(`${prefixCls}-item`, { [`${prefixCls}-null`]: !end })}>
@@ -111,6 +112,7 @@ export const CombinedDateRangeFooter: React.FC<ICombinedDateRangeFooterProps> = 
         onChange={onEndTimeChange}
         selectedDate={end}
         disabledTime={disabledEndTimes}
+        autoComplete={autoComplete}
       />
       {disabledStatus ? (
         <Pop

--- a/packages/zent/src/date-picker/panels/date-panel/DateFooter.tsx
+++ b/packages/zent/src/date-picker/panels/date-panel/DateFooter.tsx
@@ -27,7 +27,7 @@ const DatePickerFooter: React.FC<IDatePickerFooterProps> = ({
   onSelected,
   disabledPanelDate,
 }) => {
-  const { i18n } = React.useContext(PickerContext);
+  const { i18n, autoComplete } = React.useContext(PickerContext);
   const { format = '' } = showTimeOption || {};
   const confirmStatus = useConfirmStatus({
     selected: formatDate(format, selected),
@@ -119,9 +119,18 @@ const DatePickerFooter: React.FC<IDatePickerFooterProps> = ({
           hiddenIcon={true}
           onChange={onTimeChange}
           disabledTime={disabledTime}
+          autoComplete={autoComplete}
         />
       ) : null,
-    [selected, showTime, showTimeOption, format, disabledTime, onTimeChange]
+    [
+      autoComplete,
+      selected,
+      showTime,
+      showTimeOption,
+      format,
+      disabledTime,
+      onTimeChange,
+    ]
   );
 
   return <PanelFooter leftNode={timeInput} rightNode={renderToday} />;

--- a/packages/zent/src/date-picker/utils/unifiedDisabledDateFromProps.ts
+++ b/packages/zent/src/date-picker/utils/unifiedDisabledDateFromProps.ts
@@ -1,4 +1,4 @@
-import { isAfter, isBefore } from 'date-fns';
+import { endOfDay, isAfter, isBefore, startOfDay } from 'date-fns';
 import { parseBase } from './index';
 import {
   IDisabledDate,
@@ -19,8 +19,8 @@ export default function unifiedDisabledDateFromProps(
   if (typeof disabledDateProps === 'object') {
     const { min, max } = disabledDateProps as IDisabledDateSimple;
     disabledDate = (date: Date) =>
-      (!!min && isBefore(date, parseBase(min, format))) ||
-      (!!max && isAfter(date, parseBase(max, format)));
+      (!!min && isBefore(endOfDay(date), parseBase(min, format))) ||
+      (!!max && isAfter(startOfDay(date), parseBase(max, format)));
   } else {
     disabledDate = disabledDateProps;
   }


### PR DESCRIPTION
DatePicker:

- 🦀️   修复 `disabledDate` 传入 `min`、`max`含时间日期不生效问题
- 🦀️   修复 内部属性未透传导致的 disableTime 校验不及时
