### PR TITLE
feature: 扩展日期组件showTime时的defaultTime类型

### DIFF
--- a/packages/zent/__tests__/date-picker/RangePicker.js
+++ b/packages/zent/__tests__/date-picker/RangePicker.js
@@ -32,7 +32,7 @@ describe('RangePicker', () => {
     Simulate.click(
       pop.querySelectorAll('.zent-datepicker-panel-footer-btn')[0]
     );
-    expect(wrapper.prop('value')[0]).toBe('2020-07-26 12:00');
+    expect(wrapper.prop('value')[0]).toBe('2020-07-26 00:00');
     wrapper.unmount();
   });
 

--- a/packages/zent/__tests__/date-picker/SinglePicker.js
+++ b/packages/zent/__tests__/date-picker/SinglePicker.js
@@ -57,7 +57,7 @@ describe('SinglePicker', () => {
     Simulate.click(
       pop.querySelectorAll('.zent-datepicker-panel-footer-btn')[0]
     );
-    expect(wrapper.prop('value')).toBe('2020-07-26 12:00');
+    expect(wrapper.prop('value')).toBe('2020-07-26 00:00');
     wrapper.unmount();
 
     const onChangeMock2 = jest.fn();

--- a/packages/zent/src/date-picker/CombinedDateRangePicker.tsx
+++ b/packages/zent/src/date-picker/CombinedDateRangePicker.tsx
@@ -10,9 +10,8 @@ import { dateConfig } from './utils/dateUtils';
 import {
   IRangeProps,
   IGenerateDateConfig,
-  IShowTime,
+  IShowTimeRange,
   DateNullTuple,
-  StringTuple,
   IValueType,
   IRangeRelatedType,
 } from './types';
@@ -30,7 +29,7 @@ const PickerContextProvider = PickerContext.Provider;
 export interface ICombinedDateRangePickerProps<T extends IValueType = 'string'>
   extends Omit<IRangeProps, 'valueType' | 'onChange'>,
     IRangeRelatedType<T> {
-  showTime?: IShowTime<StringTuple>;
+  showTime?: IShowTimeRange<string>;
 }
 const DefaultCombinedDateRangeProps = {
   format: DATE_FORMAT,

--- a/packages/zent/src/date-picker/DateRangePicker.tsx
+++ b/packages/zent/src/date-picker/DateRangePicker.tsx
@@ -9,9 +9,8 @@ import { dateConfig } from './utils/dateUtils';
 import {
   IGenerateDateConfig,
   IRangeProps,
-  IShowTime,
+  IShowTimeRange,
   IDisabledTime,
-  StringTuple,
   DateNullTuple,
   IValueType,
   IRangeRelatedType,
@@ -29,7 +28,7 @@ const PickerContextProvider = PickerContext.Provider;
 export interface IDateRangePickerProps<T extends IValueType = 'string'>
   extends Omit<IRangeProps, 'valueType' | 'onChange'>,
     IRangeRelatedType<T> {
-  showTime?: IShowTime<StringTuple>;
+  showTime?: IShowTimeRange<string>;
   disabledTime?: IDisabledTime;
 }
 const DefaultDateRangeProps = {

--- a/packages/zent/src/date-picker/README_en-US.md
+++ b/packages/zent/src/date-picker/README_en-US.md
@@ -52,7 +52,7 @@ interface IDisableDateMap {
 
 **Additional**
 
-- When return value of `showTime` is an object, to provide an additional time selection, there are some properties within this object: `format`、`defaultTime`、`hourStep`、`minuteStep`、`secondStep`
+- When return value of `showTime` is an object, to provide an additional time selection, there are some properties within this object: `format`、`hourStep`、`minuteStep`、`secondStep`, but redefines the type of `defaultTime` to be `string | (date: Date) => string`
 - `disabledTime` only works with `showTime`, see the details in `TimePicker`
 - `format` should be `'YYYY-MM-DD HH:mm:ss'` when `showTime` is `true`
 
@@ -132,7 +132,7 @@ interface IDisabledTimeOption {
 
 **Additional**
 
-- When return value of `showTime` is an object, `defaultTime` should be a range of datetimes. (default: ['00:00:00','23:59:59'])
+- When return value of `showTime` is an object, `defaultTime` should be `[string | (date: Date) => string, string | (date: Date) => string]`. (default: ['00:00:00','23:59:59'])
 - `disabledDate(val, type)` or `disabledTime(val, type)`, the `type` is `'start' | 'end'`
 - Only supports `dateSpan` for `DateRangePicker` and `CombinedDateRangePicker`.
 

--- a/packages/zent/src/date-picker/README_zh-CN.md
+++ b/packages/zent/src/date-picker/README_zh-CN.md
@@ -59,7 +59,7 @@ interface IDisableDateMap {
 
 **注意：**
 
-- `showTime` 为对象时，表示支持时间选择，具体属性可参考 `TimePicker`，包括 `format`、`defaultTime`、`hourStep`、`minuteStep`、`secondStep`
+- `showTime` 为对象时，表示支持时间选择，具体属性可参考 `TimePicker`，包括 `format`、`hourStep`、`minuteStep`、`secondStep`，其中 `defaultTime` 类型定义为 `string | (date: Date) => string`
 - `disabledTime` 在 `showTime` 开启时生效，可参考 `TimePicker` 的 `IDisabledTimeOption`
 - `showTime` 时 `format` 值应为`'YYYY-MM-DD HH:mm:ss'`，使用时注意 `format` 参数
 
@@ -139,7 +139,7 @@ interface IDisabledTimeOption {
 
 **注意：**
 
-- `showTime` 为对象时，`defaultTime` 为数组，表示默认开始时间和默认结束时间（不填为['00:00:00','23:59:59']）
+- `showTime` 为对象时，`defaultTime` 类型为 `[string | (date: Date) => string, string | (date: Date) => string]`，表示默认开始时间和默认结束时间（不填为['00:00:00','23:59:59']）
 - `disabledDate`、`disabledTime` 回调方法的第二个参数均为`type?: 'start' | 'end'`
 - `dateSpan` 仅 `DateRangePicker` 和 `CombinedDateRangePicker` 组件可用
 

--- a/packages/zent/src/date-picker/components/RangePickerBase.tsx
+++ b/packages/zent/src/date-picker/components/RangePickerBase.tsx
@@ -11,12 +11,12 @@ import { useEventCallbackRef } from '../../utils/hooks/useEventCallbackRef';
 import {
   IGenerateDateConfig,
   IShowTime,
+  IShowTimeRange,
   RangeType,
   IDisabledTime,
   IRangePropsWithDefault,
   RangeTypeMap,
   ISingleProps,
-  StringTuple,
   DateNullTuple,
 } from '../types';
 import useRangeDisabledTime from '../hooks/useRangeDisabledTime';
@@ -30,7 +30,7 @@ interface IRangePickerProps extends IRangePropsWithDefault {
       disabledTime?: IDisabledTime;
     }
   >;
-  showTime?: IShowTime<StringTuple>;
+  showTime?: IShowTimeRange<string>;
   seperator: string;
   disabledTime?: IDisabledTime;
 }

--- a/packages/zent/src/date-picker/demos/disabled-time.md
+++ b/packages/zent/src/date-picker/demos/disabled-time.md
@@ -118,7 +118,10 @@ class Demo extends Component {
 				<br />
 				<DateRangePicker
 					className="zent-datepicker-demo"
-					showTime={{ format: 'HH:mm', defaultTime: ['00:00', '23:59'] }}
+					showTime={{ format: 'HH:mm', defaultTime: [
+							date => (isSameDay(date, new Date()) ? '12:30' : '00:00'),
+							'23:59',
+						], }}
 					format="YYYY-MM-DD HH:mm"
 					value={rangeValue}
 					onChange={this.onChangeRange}
@@ -136,7 +139,12 @@ class Demo extends Component {
 					className="zent-datepicker-demo"
 					value={combinedValue}
 					onChange={this.onChangeCombinedDate}
-					showTime
+					showTime={{
+						defaultTime: [
+							date => (isSameDay(date, new Date()) ? '12:30:00' : '00:00:00'),
+							'23:59:59',
+						],
+					}}
 					disabledDate={{ min: new Date() }}
 					format="YYYY-MM-DD HH:mm:ss"
 					disabledTime={this.disabledTimes4}

--- a/packages/zent/src/date-picker/hooks/useShowTimeOption.ts
+++ b/packages/zent/src/date-picker/hooks/useShowTimeOption.ts
@@ -1,7 +1,11 @@
 import { useRef, useMemo } from 'react';
 import { startOfToday, endOfToday } from 'date-fns';
 import { formatBase } from '../utils/index';
-import { IShowTime, StringTuple, IShowTimeOptionWithDefault } from '../types';
+import {
+  IShowTime,
+  IShowTimeRange,
+  IShowTimeOptionWithDefault,
+} from '../types';
 import { TIME_FORMAT } from '../constants';
 
 const formatStartDate = (format: string) => formatBase(startOfToday(), format);
@@ -13,7 +17,7 @@ const DefaultEndTime = formatEndDate(TIME_FORMAT);
  * @param showTime
  */
 export function useShowTimeRangeOption(
-  showTime?: IShowTime<StringTuple>
+  showTime?: IShowTimeRange<string>
 ): Array<IShowTimeOptionWithDefault | undefined> {
   const showTimeRef = useRef(showTime);
   showTimeRef.current = showTime;

--- a/packages/zent/src/date-picker/panels/combined-date-range-panel/index.tsx
+++ b/packages/zent/src/date-picker/panels/combined-date-range-panel/index.tsx
@@ -10,8 +10,7 @@ import useRangeDisabledTime from '../../hooks/useRangeDisabledTime';
 import {
   IRangePanelProps,
   IDisabledTime,
-  IShowTime,
-  StringTuple,
+  IShowTimeRange,
   DateNullTuple,
 } from '../../types';
 
@@ -19,7 +18,7 @@ const prefixCls = 'zent-datepicker-combined-panel';
 
 interface ICombinedDateRangePanelProps extends IRangePanelProps {
   disabledTime?: IDisabledTime;
-  showTime?: IShowTime<StringTuple>;
+  showTime?: IShowTimeRange<string>;
 }
 const CombinedDateRangePanel: React.FC<ICombinedDateRangePanelProps> = ({
   onSelected,
@@ -43,22 +42,32 @@ const CombinedDateRangePanel: React.FC<ICombinedDateRangePanelProps> = ({
   });
   const onChangeStartOrEnd = useCallback(
     (val: Date) => {
+      const { defaultTime: defaultTimeStart, format: formatStart } =
+        startShowTime || {};
+      const { defaultTime: defaultTimeEnd, format: formatEnd } =
+        endShowTime || {};
       let selectedTemp: DateNullTuple;
+      const defaultStartTime = (date: Date) =>
+        typeof defaultTimeStart === 'function'
+          ? defaultTimeStart(date)
+          : defaultTimeStart;
+      const defaultEndTime = (date: Date) =>
+        typeof defaultTimeEnd === 'function'
+          ? defaultTimeEnd(date)
+          : defaultTimeEnd;
       if (start && !end) {
         selectedTemp = [
-          start,
-          endShowTime
-            ? parse(endShowTime.defaultTime, endShowTime.format, val)
-            : val,
+          startShowTime
+            ? parse(defaultStartTime(start), formatStart, start)
+            : start,
+          endShowTime ? parse(defaultEndTime(val), formatEnd, val) : val,
         ];
         onSelected(selectedTemp, !showTime);
       }
       // 选中开始时间是清除上一次的结束时间
       else {
         selectedTemp = [
-          startShowTime
-            ? parse(startShowTime.defaultTime, startShowTime.format, val)
-            : val,
+          startShowTime ? parse(defaultStartTime(val), formatStart, val) : val,
           null,
         ];
         onSelected(selectedTemp);

--- a/packages/zent/src/date-picker/panels/date-panel/DateBody.tsx
+++ b/packages/zent/src/date-picker/panels/date-panel/DateBody.tsx
@@ -76,11 +76,12 @@ const DatePickerBody: FC<IDatePickerBodyProps> = props => {
 
   const setSelectedDate = useCallback(
     (val: Date) => {
+      const { defaultTime, format } = showTimeOption || {};
+      const defaultTimeFn = () =>
+        typeof defaultTime === 'function' ? defaultTime(val) : defaultTime;
       if (!selected) {
         return onSelected(
-          showTimeOption
-            ? parse(showTimeOption.defaultTime, showTimeOption.format, val)
-            : val
+          defaultTime ? parse(defaultTimeFn(), format, val) : val
         );
       }
       let selectedDate = selected;
@@ -88,7 +89,11 @@ const DatePickerBody: FC<IDatePickerBodyProps> = props => {
       selectedDate = setMonth(selectedDate, val.getMonth());
       selectedDate = setDate(selectedDate, val.getDate());
 
-      onSelected(selectedDate);
+      onSelected(
+        defaultTime
+          ? parse(defaultTimeFn(), format, selectedDate)
+          : selectedDate
+      );
     },
     [selected, showTimeOption, onSelected]
   );

--- a/packages/zent/src/date-picker/panels/date-panel/DateFooter.tsx
+++ b/packages/zent/src/date-picker/panels/date-panel/DateFooter.tsx
@@ -108,30 +108,33 @@ const DatePickerFooter: React.FC<IDatePickerFooterProps> = ({
     [selected, format, onSelected]
   );
 
-  const timeInput = useMemo(
-    () =>
-      showTime ? (
-        <TimePicker
-          {...showTimeOption}
-          width={94}
-          selectedDate={selected}
-          value={formatDate(format, selected)}
-          hiddenIcon={true}
-          onChange={onTimeChange}
-          disabledTime={disabledTime}
-          autoComplete={autoComplete}
-        />
-      ) : null,
-    [
-      autoComplete,
-      selected,
-      showTime,
-      showTimeOption,
-      format,
-      disabledTime,
-      onTimeChange,
-    ]
-  );
+  const timeInput = useMemo(() => {
+    const { defaultTime, ...restOption } = showTimeOption || {};
+    const defaultTimeString =
+      typeof defaultTime === 'function' ? defaultTime(selected) : defaultTime;
+
+    return showTime ? (
+      <TimePicker
+        {...restOption}
+        defaultTime={defaultTimeString}
+        width={94}
+        selectedDate={selected}
+        value={formatDate(format, selected)}
+        hiddenIcon={true}
+        onChange={onTimeChange}
+        disabledTime={disabledTime}
+        autoComplete={autoComplete}
+      />
+    ) : null;
+  }, [
+    autoComplete,
+    selected,
+    showTime,
+    showTimeOption,
+    format,
+    disabledTime,
+    onTimeChange,
+  ]);
 
   return <PanelFooter leftNode={timeInput} rightNode={renderToday} />;
 };

--- a/packages/zent/src/date-picker/types.ts
+++ b/packages/zent/src/date-picker/types.ts
@@ -91,10 +91,20 @@ interface ITriggerCommonProps {
   onClearInput: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
 }
 
-export interface IShowTimeOption<T>
-  extends Omit<ITimePickerBase<T>, 'className' | 'selectedDate'> {}
+export interface IShowTimeOptionBase<T>
+  extends Omit<
+    ITimePickerBase<T>,
+    'className' | 'selectedDate' | 'defaultTime'
+  > {}
+export interface IShowTimeOption<T> extends IShowTimeOptionBase<T> {
+  defaultTime?: T | ((date: Date) => T);
+}
+export interface IShowTimeRangeOption<T> extends IShowTimeOptionBase<T> {
+  defaultTime?: [T | ((date: Date) => T), T | ((date: Date) => T)];
+}
 
 export type IShowTime<T = string> = boolean | IShowTimeOption<T>;
+export type IShowTimeRange<T = string> = boolean | IShowTimeRangeOption<T>;
 export type IShowTimeOptionWithDefault = PartialRequired<
   IShowTimeOption<string>,
   'format' | 'defaultTime'


### PR DESCRIPTION
DatePicker:

- 日期组件showTime开启时，参数 `defaultTime` 类型扩展为 `string | (date: Date) => string`，支持根据当前日期自定义默认时间

