### PR TITLE
fix: 修改dialog overflow css问题

### DIFF
--- a/packages/zent/assets/dialog.scss
+++ b/packages/zent/assets/dialog.scss
@@ -124,7 +124,7 @@ $footer-height: 72px;
 
   &-content {
     padding: 0 16px;
-    overflow-y: scroll;
+    overflow-y: auto;
   }
 }
 


### PR DESCRIPTION
- 修复 dialog 组件 overflow 为 auto 导致的滚动条恒显示i问题