### PR TITLE
快捷选择日期今日结束时间统一为当前时间

### DIFF
--- a/packages/zent/src/date-range-quick-picker/DateRangeQuickPicker.tsx
+++ b/packages/zent/src/date-range-quick-picker/DateRangeQuickPicker.tsx
@@ -141,7 +141,6 @@ function calculateTime(
   let endTime: SingleDate;
 
   const today = getToday();
-  const tomorrow = today + ONE_DAY;
 
   if (Array.isArray(chosenItem)) {
     [startTime, endTime] = chosenItem;
@@ -152,9 +151,7 @@ function calculateTime(
       startTime = today - chosenItem * ONE_DAY;
     }
 
-    if (chosenItem === 0) {
-      endTime = tomorrow - 1000;
-    } else if (chosenItem === 1) {
+    if (chosenItem === 1) {
       endTime = today - 1000;
     } else {
       endTime = Date.now();


### PR DESCRIPTION
- 🦀️  `DateRangeQuickPicker` 今天的结束时间统一为当前时间

