### PR TITLE
fix: button bordered:false not work when disabled

### DIFF
--- a/packages/zent/assets/button.scss
+++ b/packages/zent/assets/button.scss
@@ -373,7 +373,8 @@ $btn-warning-active: 1;
     }
   }
 
-  &-border-transparent {
+  &-border-transparent,
+  &#{&}-border-transparent {
     border-color: transparent;
 
     &:hover {

--- a/packages/zent/assets/button.scss
+++ b/packages/zent/assets/button.scss
@@ -373,7 +373,6 @@ $btn-warning-active: 1;
     }
   }
 
-  &-border-transparent,
   &#{&}-border-transparent {
     border-color: transparent;
 


### PR DESCRIPTION
Changes you made in this pull request:
- fix Button `bordered: false` not work when `disabled: true`
  `.zent-btn-disabled[disabled]` is higher than `.zent-btn-border-transparent`
