### PR TITLE
update form-control style(margin-bottom: 24)

### DIFF
--- a/packages/zent/assets/form.scss
+++ b/packages/zent/assets/form.scss
@@ -58,7 +58,7 @@
   &-control {
     display: flex;
     line-height: 30px;
-    margin-bottom: 20px;
+    margin-bottom: 24px;
 
     &-content {
       &-inner {


### PR DESCRIPTION
`.zent-form-control` 样式 `margin-bottom` 由于 `20px` 调整为 `24px`
