### PR TITLE
[bugfix]: Tree expandAll受控逻辑调整

### DIFF
--- a/packages/zent/src/tree/Tree.tsx
+++ b/packages/zent/src/tree/Tree.tsx
@@ -96,11 +96,10 @@ export class Tree extends Component<ITreeProps, ITreeState> {
       const formatData = createStateByProps(nextProps);
       let { expandNode } = formatData;
 
-      // // 只有在 loadMore 状态下，我会保持原有打开状态
-      // // if (prevProps.loadMore || nextProps.loadMore) {
-      // 任何情况下都做保留
-      expandNode = correctExpand(state, formatData);
-      // // }
+      // 任何情况下都做保留, 除非全展/全闭变化了
+      if (nextProps.expandAll === prevProps.expandAll) {
+        expandNode = correctExpand(state, formatData);
+      }
 
       return {
         prevProps: nextProps,


### PR DESCRIPTION
- 在getDerivedStateFromProps时，针对expandAll变动，不在保留历史展开记录

Fixes #1634 
