### PR TITLE
DateRangePicker 属性 `disabled`、`canClear` 类型更新为`boolean | boolean[]`

### DIFF
--- a/packages/zent/__tests__/date-picker/CombinedRangePicker.js
+++ b/packages/zent/__tests__/date-picker/CombinedRangePicker.js
@@ -18,6 +18,15 @@ describe('CombinedRangePicker', () => {
     );
     wrapper.find('.zent-datepicker-trigger').simulate('click');
     const pop = document.querySelector('.zent-datepicker-combined-panel');
+
+    Simulate.click(
+      pop.querySelectorAll('.zent-datepicker-panel-header-arrow')[0]
+    );
+
+    Simulate.click(
+      pop.querySelectorAll('.zent-datepicker-panel-header-arrow')[3]
+    );
+
     const cellsLeft = pop.querySelectorAll(
       '.zent-datepicker-combined-panel-body-item'
     )[0];
@@ -158,7 +167,7 @@ describe('CombinedRangePicker', () => {
     const wrapper = mount(
       <CombinedDateRangePicker
         value={['2020-05-10 20:00:00']}
-        showTime
+        showTime={{ defualtTime: ['00:00:00', '12:00:00'] }}
         format={DateTimeSecFormat}
         onChange={onChange}
       />

--- a/packages/zent/__tests__/date-picker/RangePicker.js
+++ b/packages/zent/__tests__/date-picker/RangePicker.js
@@ -111,4 +111,9 @@ describe('RangePicker', () => {
     wrapper.find('.zent-datepicker-trigger').at(1).simulate('click');
     wrapper.unmount();
   });
+
+  it('DateRangePicker canClear', () => {
+    const wrapper = mount(<DateRangePicker canClear={[true, false]} />);
+    wrapper.unmount();
+  });
 });

--- a/packages/zent/__tests__/date-picker/RangePicker.js
+++ b/packages/zent/__tests__/date-picker/RangePicker.js
@@ -105,4 +105,10 @@ describe('RangePicker', () => {
     wrapper.find('.zent-datepicker-trigger').at(0).simulate('click');
     wrapper.unmount();
   });
+
+  it('DateRangePicker disabled', () => {
+    const wrapper = mount(<DateRangePicker disabled={[true, false]} />);
+    wrapper.find('.zent-datepicker-trigger').at(1).simulate('click');
+    wrapper.unmount();
+  });
 });

--- a/packages/zent/src/date-picker/CombinedDateRangePicker.tsx
+++ b/packages/zent/src/date-picker/CombinedDateRangePicker.tsx
@@ -8,7 +8,7 @@ import { DisabledContext } from '../disabled';
 import PickerContext from './context/PickerContext';
 import { dateConfig } from './utils/dateUtils';
 import {
-  IRangeProps,
+  ICombinedProps,
   IGenerateDateConfig,
   IShowTimeRange,
   DateNullTuple,
@@ -27,7 +27,7 @@ const generateDate: IGenerateDateConfig = dateConfig.date;
 const PickerContextProvider = PickerContext.Provider;
 
 export interface ICombinedDateRangePickerProps<T extends IValueType = 'string'>
-  extends Omit<IRangeProps, 'valueType' | 'onChange'>,
+  extends Omit<ICombinedProps, 'valueType' | 'onChange'>,
     IRangeRelatedType<T> {
   showTime?: IShowTimeRange<string>;
 }

--- a/packages/zent/src/date-picker/README_en-US.md
+++ b/packages/zent/src/date-picker/README_en-US.md
@@ -135,6 +135,7 @@ interface IDisabledTimeOption {
 - When return value of `showTime` is an object, `defaultTime` should be `[string | (date: Date) => string, string | (date: Date) => string]`. (default: ['00:00:00','23:59:59'])
 - `disabledDate(val, type)` or `disabledTime(val, type)`, the `type` is `'start' | 'end'`
 - Only supports `dateSpan` for `DateRangePicker` and `CombinedDateRangePicker`.
+- Definition of `disabled` and `canClear` is `boolean | boolean[]` in `DateRangePicker`.
 
 ### TimeRangePicker / CombinedTimeRangePicker API （Base on TimePicker）
 

--- a/packages/zent/src/date-picker/README_zh-CN.md
+++ b/packages/zent/src/date-picker/README_zh-CN.md
@@ -142,6 +142,7 @@ interface IDisabledTimeOption {
 - `showTime` 为对象时，`defaultTime` 类型为 `[string | (date: Date) => string, string | (date: Date) => string]`，表示默认开始时间和默认结束时间（不填为['00:00:00','23:59:59']）
 - `disabledDate`、`disabledTime` 回调方法的第二个参数均为`type?: 'start' | 'end'`
 - `dateSpan` 仅 `DateRangePicker` 和 `CombinedDateRangePicker` 组件可用
+- `DateRangePicker` 的 `disabled` 、 `canClear` 属性类型为 `boolean | boolean[]`
 
 ### TimeRangePicker / CombinedTimeRangePicker API （基于 TimePicker）
 

--- a/packages/zent/src/date-picker/components/CombinedPickerBase.tsx
+++ b/packages/zent/src/date-picker/components/CombinedPickerBase.tsx
@@ -20,7 +20,7 @@ import {
   IRangePanelProps,
   IGenerateDateConfig,
   DateNullTuple,
-  IRangePropsWithDefault,
+  ICombinedPropsWithDefault,
   DateTuple,
   RangeTypeMap,
 } from '../types';
@@ -28,7 +28,7 @@ import {
 const { START, END } = RangeTypeMap;
 const PanelContextProvider = PanelContext.Provider;
 
-interface ICombinedPickerProps extends IRangePropsWithDefault {
+interface ICombinedPickerProps extends ICombinedPropsWithDefault {
   seperator?: string;
   generateDate: IGenerateDateConfig;
   PanelComponent: React.ComponentType<IRangePanelProps>;

--- a/packages/zent/src/date-picker/components/RangePickerBase.tsx
+++ b/packages/zent/src/date-picker/components/RangePickerBase.tsx
@@ -1,5 +1,5 @@
 import cx from 'classnames';
-import { useCallback, useContext, useRef } from 'react';
+import { useCallback, useContext, useMemo, useRef } from 'react';
 
 import PickerContext from '../context/PickerContext';
 import useRangeMergedProps from '../hooks/useRangeMergedProps';
@@ -52,8 +52,18 @@ const RangePicker: React.FC<IRangePickerProps> = ({
   seperator,
   name,
   dateSpan,
+  disabled,
+  canClear,
   ...restProps
 }) => {
+  const disabledArr = useMemo(
+    () => (Array.isArray(disabled) ? disabled : [disabled, disabled]),
+    [disabled]
+  );
+  const canClearArr = useMemo(
+    () => (Array.isArray(canClear) ? canClear : [canClear, canClear]),
+    [canClear]
+  );
   const restPropsRef = useRef(restProps);
   restPropsRef.current = restProps;
   const { format } = restPropsRef.current;
@@ -97,6 +107,8 @@ const RangePicker: React.FC<IRangePickerProps> = ({
       <div className={cx('zent-datepicker', className)}>
         <PickerComponent
           {...restPropsRef.current}
+          disabled={disabledArr[0]}
+          canClear={canClearArr[0]}
           defaultDate={defaultPanelDate[0]}
           showTime={startShowTime}
           valueType="date"
@@ -112,6 +124,8 @@ const RangePicker: React.FC<IRangePickerProps> = ({
         <span className="zent-datepicker-seperator">{seperator}</span>
         <PickerComponent
           {...restPropsRef.current}
+          disabled={disabledArr[1]}
+          canClear={canClearArr[1]}
           defaultDate={defaultPanelDate[1]}
           showTime={endShowTime}
           valueType="date"

--- a/packages/zent/src/date-picker/demos/basic.md
+++ b/packages/zent/src/date-picker/demos/basic.md
@@ -153,7 +153,8 @@ class DatePickerBasic extends Component {
 					className="zent-datepicker-demo"
 					value={rangeValue}
 					onChange={this.onChangeRange}
-					dateSpan={30}
+                    dateSpan={30}
+                    canClear={[false, true]}
 				/>
 				<br />
 				<CombinedDateRangePicker

--- a/packages/zent/src/date-picker/demos/disabled.md
+++ b/packages/zent/src/date-picker/demos/disabled.md
@@ -18,6 +18,11 @@ ReactDOM.render(
 	<div>
 		<DatePicker className="zent-datepicker-demo" value="2020-01-01" disabled />
 		<br />
+		<DateRangePicker
+			className="zent-datepicker-demo"
+			disabled={[true, false]}
+		/>
+		<br />
 		<TimePicker className="zent-datepicker-demo" value="06:06:06" disabled />
 		<br />
 		<CombinedDateRangePicker className="zent-datepicker-demo" disabled />

--- a/packages/zent/src/date-picker/panels/date-panel/DateFooter.tsx
+++ b/packages/zent/src/date-picker/panels/date-panel/DateFooter.tsx
@@ -43,7 +43,7 @@ const DatePickerFooter: React.FC<IDatePickerFooterProps> = ({
   ]);
   const onClickCurrent = useCallback(() => {
     if (isDisabledToday) return;
-    onSelected(today);
+    onSelected(new Date());
   }, [isDisabledToday, onSelected]);
 
   const confirmHandler = useCallback(() => {

--- a/packages/zent/src/date-picker/types.ts
+++ b/packages/zent/src/date-picker/types.ts
@@ -152,7 +152,10 @@ export interface ISinglePanelProps {
 export type ISingleDateBodyProps = Omit<ISinglePanelProps, 'onChangePanel'>;
 
 /* **************************** CombinedRangePicker / RangePicker **************************** */
-export interface IRangeProps extends ICommonProps<RangeDate> {
+export interface IRangeProps
+  extends Omit<ICommonProps<RangeDate>, 'disabled' | 'canClear'> {
+  disabled?: boolean | boolean[];
+  canClear?: boolean | boolean[];
   placeholder?: [string, string];
   disabledDate?: IRangeDisabledDateFunc | IDisabledDateSimple;
   onOpen?: (type?: RangeType) => void;
@@ -160,8 +163,23 @@ export interface IRangeProps extends ICommonProps<RangeDate> {
   name?: [string, string];
   dateSpan?: number; // 快捷可选日期跨度
 }
+
+export interface ICombinedProps extends ICommonProps<RangeDate> {
+  placeholder?: [string, string];
+  disabledDate?: IRangeDisabledDateFunc | IDisabledDateSimple;
+  onOpen?: (type?: RangeType) => void;
+  onClose?: (type?: RangeType) => void;
+  name?: [string, string];
+  dateSpan?: number; // 快捷可选日期跨度
+}
+
 export type IRangePropsWithDefault = PartialRequired<
   IRangeProps,
+  'format' | 'valueType' | 'placeholder' | 'disabledDate'
+>;
+
+export type ICombinedPropsWithDefault = PartialRequired<
+  ICombinedProps,
   'format' | 'valueType' | 'placeholder' | 'disabledDate'
 >;
 


### PR DESCRIPTION
`DateRangePicker`:

- Update disabled and canClear type definition in DateRangePicker
- Current time update to callback's time
