### PR TITLE
[Bugfix]: fix the tooltip on disabled children

### DIFF
--- a/packages/zent/assets/button.scss
+++ b/packages/zent/assets/button.scss
@@ -318,6 +318,8 @@ $btn-warning-active: 1;
     @include btn-grey(color);
     @include theme-color(background-color, stroke, 8);
     @include btn-light-grey(border-color);
+    // avoid this disabled element to be the target of pointer events, so that events will trigger on the parent element
+    // https://github.com/react-component/tooltip/issues/18
     pointer-events: none;
 
     &:link,

--- a/packages/zent/assets/button.scss
+++ b/packages/zent/assets/button.scss
@@ -309,12 +309,16 @@ $btn-warning-active: 1;
     );
   }
 
+  &-disabled-wrapper {
+    cursor: not-allowed;
+  }
+
   &-disabled,
   &-disabled[disabled] {
     @include btn-grey(color);
     @include theme-color(background-color, stroke, 8);
     @include btn-light-grey(border-color);
-    cursor: not-allowed;
+    pointer-events: none;
 
     &:link,
     &:visited,

--- a/packages/zent/assets/button.scss
+++ b/packages/zent/assets/button.scss
@@ -1,5 +1,6 @@
 @import './theme/default';
 @import './theme/font';
+@import './mixins/pointer-events';
 
 $btn-height-small: 24px;
 $btn-height-normal: 32px;
@@ -318,9 +319,7 @@ $btn-warning-active: 1;
     @include btn-grey(color);
     @include theme-color(background-color, stroke, 8);
     @include btn-light-grey(border-color);
-    // avoid this disabled element to be the target of pointer events, so that events will trigger on the parent element
-    // https://github.com/react-component/tooltip/issues/18
-    pointer-events: none;
+    @include prevent-pointer-events;
 
     &:link,
     &:visited,

--- a/packages/zent/assets/checkbox.scss
+++ b/packages/zent/assets/checkbox.scss
@@ -143,7 +143,7 @@ $size: 16px;
     }
 
     & > input[type='checkbox'] {
-      cursor: not-allowed;
+      pointer-events: none;
     }
   }
 

--- a/packages/zent/assets/checkbox.scss
+++ b/packages/zent/assets/checkbox.scss
@@ -1,5 +1,6 @@
 @import './theme/default';
 @import './theme/font';
+@import './mixins/pointer-events';
 $size: 16px;
 
 .zent-checkbox-group {
@@ -143,9 +144,7 @@ $size: 16px;
     }
 
     & > input[type='checkbox'] {
-      // avoid this disabled element to be the target of pointer events, so that events will trigger on the parent element
-      // https://github.com/react-component/tooltip/issues/18
-      pointer-events: none;
+      @include prevent-pointer-events;
     }
   }
 

--- a/packages/zent/assets/checkbox.scss
+++ b/packages/zent/assets/checkbox.scss
@@ -143,6 +143,8 @@ $size: 16px;
     }
 
     & > input[type='checkbox'] {
+      // avoid this disabled element to be the target of pointer events, so that events will trigger on the parent element
+      // https://github.com/react-component/tooltip/issues/18
       pointer-events: none;
     }
   }

--- a/packages/zent/assets/input.scss
+++ b/packages/zent/assets/input.scss
@@ -79,6 +79,10 @@ $large-size: 40px;
   .zent-input-close {
     @include theme-color(color, stroke, 4);
   }
+
+  &-disabled {
+    cursor: not-allowed;
+  }
 }
 
 .zent-textarea-wrapper.zent-input-wrapper {
@@ -122,7 +126,7 @@ $large-size: 40px;
 .zent-input[readonly] {
   @include theme-color(background-color, stroke, 8);
   @include theme-color(color, stroke, 4);
-  cursor: not-allowed;
+  pointer-events: none;
 }
 
 .zent-input-addon-before,

--- a/packages/zent/assets/input.scss
+++ b/packages/zent/assets/input.scss
@@ -1,5 +1,6 @@
 @import './theme/default';
 @import './theme/font';
+@import './mixins/pointer-events';
 
 $border-radius: 2px;
 $border-transition: border 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
@@ -126,9 +127,7 @@ $large-size: 40px;
 .zent-input[readonly] {
   @include theme-color(background-color, stroke, 8);
   @include theme-color(color, stroke, 4);
-  // avoid this disabled element to be the target of pointer events, so that events will trigger on the parent element
-  // https://github.com/react-component/tooltip/issues/18
-  pointer-events: none;
+  @include prevent-pointer-events;
 }
 
 .zent-input-addon-before,

--- a/packages/zent/assets/input.scss
+++ b/packages/zent/assets/input.scss
@@ -126,6 +126,8 @@ $large-size: 40px;
 .zent-input[readonly] {
   @include theme-color(background-color, stroke, 8);
   @include theme-color(color, stroke, 4);
+  // avoid this disabled element to be the target of pointer events, so that events will trigger on the parent element
+  // https://github.com/react-component/tooltip/issues/18
   pointer-events: none;
 }
 

--- a/packages/zent/assets/mixins/_index.scss
+++ b/packages/zent/assets/mixins/_index.scss
@@ -1,3 +1,4 @@
 @import './popup';
 @import './popup-menu-item';
 @import './clearfix';
+@import './pointer-events';

--- a/packages/zent/assets/mixins/_pointer-events.scss
+++ b/packages/zent/assets/mixins/_pointer-events.scss
@@ -1,5 +1,5 @@
 @mixin prevent-pointer-events {
   // avoid this disabled element to be the target of pointer events, so that events will trigger on the parent element
-  // https://github.com/react-component/tooltip/issues/18
+  // https://github.com/youzan/zent/issues/142
   pointer-events: none;
 }

--- a/packages/zent/assets/mixins/_pointer-events.scss
+++ b/packages/zent/assets/mixins/_pointer-events.scss
@@ -1,0 +1,5 @@
+@mixin prevent-pointer-events {
+  // avoid this disabled element to be the target of pointer events, so that events will trigger on the parent element
+  // https://github.com/react-component/tooltip/issues/18
+  pointer-events: none;
+}

--- a/packages/zent/assets/radio.scss
+++ b/packages/zent/assets/radio.scss
@@ -118,6 +118,8 @@ $inner-circle-offset: ($outer-circle-size - $inner-circle-size - 2px) / 2;
       }
 
       & > input[type='radio'] {
+        // avoid this disabled element to be the target of pointer events, so that events will trigger on the parent element
+        // https://github.com/react-component/tooltip/issues/18
         pointer-events: none;
       }
     }
@@ -197,6 +199,8 @@ $inner-circle-offset: ($outer-circle-size - $inner-circle-size - 2px) / 2;
     cursor: not-allowed;
 
     > input[type='radio'] {
+      // avoid this disabled element to be the target of pointer events, so that events will trigger on the parent element
+      // https://github.com/react-component/tooltip/issues/18
       pointer-events: none;
     }
 

--- a/packages/zent/assets/radio.scss
+++ b/packages/zent/assets/radio.scss
@@ -118,7 +118,7 @@ $inner-circle-offset: ($outer-circle-size - $inner-circle-size - 2px) / 2;
       }
 
       & > input[type='radio'] {
-        cursor: not-allowed;
+        pointer-events: none;
       }
     }
 
@@ -194,9 +194,10 @@ $inner-circle-offset: ($outer-circle-size - $inner-circle-size - 2px) / 2;
   &--disabled {
     @include theme-color(color, stroke, 4);
     @include theme-color(background-color, stroke, 8);
+    cursor: not-allowed;
 
     > input[type='radio'] {
-      cursor: not-allowed;
+      pointer-events: none;
     }
 
     &.zent-radio-button--checked {

--- a/packages/zent/assets/radio.scss
+++ b/packages/zent/assets/radio.scss
@@ -1,6 +1,7 @@
 @import './theme/default';
 @import './theme/font';
 @import './theme/timing-functions';
+@import './mixins/pointer-events';
 
 $outer-circle-size: 16px;
 $inner-circle-size: 8px;
@@ -118,9 +119,7 @@ $inner-circle-offset: ($outer-circle-size - $inner-circle-size - 2px) / 2;
       }
 
       & > input[type='radio'] {
-        // avoid this disabled element to be the target of pointer events, so that events will trigger on the parent element
-        // https://github.com/react-component/tooltip/issues/18
-        pointer-events: none;
+        @include prevent-pointer-events;
       }
     }
 
@@ -199,9 +198,7 @@ $inner-circle-offset: ($outer-circle-size - $inner-circle-size - 2px) / 2;
     cursor: not-allowed;
 
     > input[type='radio'] {
-      // avoid this disabled element to be the target of pointer events, so that events will trigger on the parent element
-      // https://github.com/react-component/tooltip/issues/18
-      pointer-events: none;
+      @include prevent-pointer-events;
     }
 
     &.zent-radio-button--checked {

--- a/packages/zent/src/button/Button.tsx
+++ b/packages/zent/src/button/Button.tsx
@@ -3,6 +3,10 @@ import { Component } from 'react';
 import { Omit } from 'utility-types';
 import Group from './Group';
 import { IButtonDirectiveProps, ButtonDirective } from './Directive';
+import {
+  IPopoverHoverTriggerContext,
+  PopoverHoverTriggerContext,
+} from '../popover';
 
 export interface IButtonProps
   extends Omit<
@@ -28,6 +32,31 @@ export class Button extends Component<IButtonProps> {
 
   static Group = Group;
   static Directive = ButtonDirective;
+  static contextType = PopoverHoverTriggerContext;
+  context!: IPopoverHoverTriggerContext;
+
+  /**
+   * Why fixTooltipOnDisabledChildren?
+   * Mouse events don't trigger on disabled button
+   * https://github.com/react-component/tooltip/issues/18
+   *
+   * Workaround
+   * 1. Wrap the disabled button/input in another element.
+   * 2. Add {pointer-events: none} style to the disabled button/input.
+   */
+  renderCompatibleChildren(children: React.ReactNode) {
+    return this.context.fixTooltipOnDisabledChildren ? (
+      <span
+        className="zent-btn-disabled-wrapper"
+        onMouseEnter={(this.props as any).onMouseEnter}
+        onMouseLeave={(this.props as any).onMouseLeave}
+      >
+        {children}
+      </span>
+    ) : (
+      children
+    );
+  }
 
   render() {
     const {
@@ -48,26 +77,35 @@ export class Button extends Component<IButtonProps> {
     } = this.props;
 
     return (
-      <ButtonDirective
-        type={type}
-        size={size}
-        block={block}
-        disabled={disabled}
-        loading={loading}
-        outline={outline}
-        bordered={bordered}
-        icon={icon}
-      >
-        {href || target ? (
-          <a href={href || ''} target={target} download={download} {...props}>
-            {children}
-          </a>
-        ) : (
-          <button type={htmlType} {...props}>
-            {children}
-          </button>
+      <>
+        {this.renderCompatibleChildren(
+          <ButtonDirective
+            type={type}
+            size={size}
+            block={block}
+            disabled={disabled}
+            loading={loading}
+            outline={outline}
+            bordered={bordered}
+            icon={icon}
+          >
+            {href || target ? (
+              <a
+                href={href || ''}
+                target={target}
+                download={download}
+                {...props}
+              >
+                {children}
+              </a>
+            ) : (
+              <button type={htmlType} {...props}>
+                {children}
+              </button>
+            )}
+          </ButtonDirective>
         )}
-      </ButtonDirective>
+      </>
     );
   }
 }

--- a/packages/zent/src/button/Button.tsx
+++ b/packages/zent/src/button/Button.tsx
@@ -48,8 +48,8 @@ export class Button extends Component<IButtonProps> {
     return this.context.fixTooltipOnDisabledChildren ? (
       <span
         className="zent-btn-disabled-wrapper"
-        onMouseEnter={(this.props as any).onMouseEnter}
-        onMouseLeave={(this.props as any).onMouseLeave}
+        onMouseEnter={this.props.onMouseEnter}
+        onMouseLeave={this.props.onMouseLeave}
       >
         {children}
       </span>
@@ -76,36 +76,27 @@ export class Button extends Component<IButtonProps> {
       ...props
     } = this.props;
 
-    return (
-      <>
-        {this.renderCompatibleChildren(
-          <ButtonDirective
-            type={type}
-            size={size}
-            block={block}
-            disabled={disabled}
-            loading={loading}
-            outline={outline}
-            bordered={bordered}
-            icon={icon}
-          >
-            {href || target ? (
-              <a
-                href={href || ''}
-                target={target}
-                download={download}
-                {...props}
-              >
-                {children}
-              </a>
-            ) : (
-              <button type={htmlType} {...props}>
-                {children}
-              </button>
-            )}
-          </ButtonDirective>
+    return this.renderCompatibleChildren(
+      <ButtonDirective
+        type={type}
+        size={size}
+        block={block}
+        disabled={disabled}
+        loading={loading}
+        outline={outline}
+        bordered={bordered}
+        icon={icon}
+      >
+        {href || target ? (
+          <a href={href || ''} target={target} download={download} {...props}>
+            {children}
+          </a>
+        ) : (
+          <button type={htmlType} {...props}>
+            {children}
+          </button>
         )}
-      </>
+      </ButtonDirective>
     );
   }
 }

--- a/packages/zent/src/button/Button.tsx
+++ b/packages/zent/src/button/Button.tsx
@@ -7,6 +7,7 @@ import {
   IPopoverHoverTriggerContext,
   PopoverHoverTriggerContext,
 } from '../popover';
+import { renderCompatibleChildren } from './utils';
 
 export interface IButtonProps
   extends Omit<
@@ -35,29 +36,6 @@ export class Button extends Component<IButtonProps> {
   static contextType = PopoverHoverTriggerContext;
   context!: IPopoverHoverTriggerContext;
 
-  /**
-   * Why fixTooltipOnDisabledChildren?
-   * Mouse events don't trigger on disabled button
-   * https://github.com/react-component/tooltip/issues/18
-   *
-   * Workaround
-   * 1. Wrap the disabled button/input in another element.
-   * 2. Add {pointer-events: none} style to the disabled button/input.
-   */
-  renderCompatibleChildren(children: React.ReactNode) {
-    return this.context.fixTooltipOnDisabledChildren ? (
-      <span
-        className="zent-btn-disabled-wrapper"
-        onMouseEnter={this.props.onMouseEnter}
-        onMouseLeave={this.props.onMouseLeave}
-      >
-        {children}
-      </span>
-    ) : (
-      children
-    );
-  }
-
   render() {
     const {
       href,
@@ -76,7 +54,7 @@ export class Button extends Component<IButtonProps> {
       ...props
     } = this.props;
 
-    return this.renderCompatibleChildren(
+    const commonChildren = (
       <ButtonDirective
         type={type}
         size={size}
@@ -98,6 +76,12 @@ export class Button extends Component<IButtonProps> {
         )}
       </ButtonDirective>
     );
+
+    return renderCompatibleChildren(commonChildren, {
+      disabled: this.context.fixTooltipOnDisabledChildren,
+      onMouseEnter: this.props.onMouseEnter,
+      onMouseLeave: this.props.onMouseLeave,
+    });
   }
 }
 

--- a/packages/zent/src/button/Directive.tsx
+++ b/packages/zent/src/button/Directive.tsx
@@ -6,6 +6,7 @@ import { Children, cloneElement, useCallback, useContext, useRef } from 'react';
 import Icon, { IconType } from '../icon';
 import { DisabledContext } from '../disabled';
 import { PopoverHoverTriggerContext } from '../popover';
+import { renderCompatibleChildren } from './utils';
 
 export interface IButtonDirectiveChildProps {
   className?: string;
@@ -41,10 +42,12 @@ export interface IButtonDirectiveProps<
   icon?: IconType;
   block?: boolean;
   children: React.ReactElement<ChildProps>;
+  onMouseEnter?: React.MouseEventHandler<HTMLElement>;
+  onMouseLeave?: React.MouseEventHandler<HTMLElement>;
 }
 
 export function ButtonDirective<ChildProps extends IButtonDirectiveChildProps>(
-  props: IButtonDirectiveProps<ChildProps> & React.HTMLAttributes<HTMLElement>
+  props: IButtonDirectiveProps<ChildProps>
 ) {
   const disabledContext = useContext(DisabledContext);
   const popoverHoverTriggerContext = useContext(PopoverHoverTriggerContext);
@@ -58,6 +61,8 @@ export function ButtonDirective<ChildProps extends IButtonDirectiveChildProps>(
     bordered = true,
     icon,
     children,
+    onMouseEnter,
+    onMouseLeave,
   } = props;
   if (!isElement(children)) {
     throw new Error(
@@ -108,23 +113,9 @@ export function ButtonDirective<ChildProps extends IButtonDirectiveChildProps>(
     ) || [])
   );
 
-  /**
-   * Mouse events don't trigger on disabled button
-   * https://github.com/react-component/tooltip/issues/18
-   *
-   * Workaround
-   * 1. Wrap the disabled button/input in another element.
-   * 2. Add {pointer-events: none} style to the disabled button/input.
-   */
-  return popoverHoverTriggerContext.fixTooltipOnDisabledChildren ? (
-    <span
-      className="zent-btn-disabled-wrapper"
-      onMouseEnter={props.onMouseEnter}
-      onMouseLeave={props.onMouseLeave}
-    >
-      {commonChildren}
-    </span>
-  ) : (
-    commonChildren
-  );
+  return renderCompatibleChildren(commonChildren, {
+    disabled: popoverHoverTriggerContext.fixTooltipOnDisabledChildren,
+    onMouseEnter,
+    onMouseLeave,
+  });
 }

--- a/packages/zent/src/button/utils.tsx
+++ b/packages/zent/src/button/utils.tsx
@@ -1,0 +1,30 @@
+interface IOptopns {
+  disabled: boolean;
+  onMouseEnter: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
+  onMouseLeave: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
+}
+/**
+ * Why fixTooltipOnDisabledChildren?
+ * Mouse events don't trigger on disabled button
+ * https://github.com/react-component/tooltip/issues/18
+ *
+ * Workaround
+ * 1. Wrap the disabled button/input in another element.
+ * 2. Add {pointer-events: none} style to the disabled button/input.
+ */
+export const renderCompatibleChildren = (
+  children: React.ReactElement,
+  { disabled, onMouseEnter, onMouseLeave }: IOptopns
+) => {
+  return disabled ? (
+    <span
+      className="zent-btn-disabled-wrapper"
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
+      {children}
+    </span>
+  ) : (
+    children
+  );
+};

--- a/packages/zent/src/button/utils.tsx
+++ b/packages/zent/src/button/utils.tsx
@@ -6,7 +6,7 @@ interface IOptopns {
 /**
  * Why fixTooltipOnDisabledChildren?
  * Mouse events don't trigger on disabled button
- * https://github.com/react-component/tooltip/issues/18
+ * https://github.com/youzan/zent/issues/142
  *
  * Workaround
  * 1. Wrap the disabled button/input in another element.

--- a/packages/zent/src/checkbox/Checkbox.tsx
+++ b/packages/zent/src/checkbox/Checkbox.tsx
@@ -5,7 +5,6 @@ import getWidth from '../utils/getWidth';
 import GroupContext, { ICheckboxContext } from './GroupContext';
 import { DisabledContext, IDisabledContext } from '../disabled';
 import CheckboxGroup from './Group';
-import omit from '../utils/omit';
 
 export interface ICheckboxEventTarget<Value> extends ICheckboxProps<Value> {
   type: 'checkbox';
@@ -98,6 +97,8 @@ export function Checkbox<Value>(props: ICheckboxProps<Value>) {
     // value可以是任意类型，不要写到dom上去
     value,
     labelStyle,
+    onMouseEnter,
+    onMouseLeave,
     ...others
   } = props;
   const readOnly = getReadOnly(groupCtx, props);
@@ -120,13 +121,13 @@ export function Checkbox<Value>(props: ICheckboxProps<Value>) {
       style={{
         ...getWidth(width),
       }}
-      onMouseEnter={props.onMouseEnter}
-      onMouseLeave={props.onMouseLeave}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
     >
       <span className="zent-checkbox">
         <span className="zent-checkbox-inner" />
         <input
-          {...omit(others, ['onMouseEnter', 'onMouseLeave'])}
+          {...others}
           type="checkbox"
           checked={checked && !indeterminate}
           disabled={disabled}

--- a/packages/zent/src/checkbox/Checkbox.tsx
+++ b/packages/zent/src/checkbox/Checkbox.tsx
@@ -5,6 +5,7 @@ import getWidth from '../utils/getWidth';
 import GroupContext, { ICheckboxContext } from './GroupContext';
 import { DisabledContext, IDisabledContext } from '../disabled';
 import CheckboxGroup from './Group';
+import omit from '../utils/omit';
 
 export interface ICheckboxEventTarget<Value> extends ICheckboxProps<Value> {
   type: 'checkbox';
@@ -117,11 +118,13 @@ export function Checkbox<Value>(props: ICheckboxProps<Value>) {
       style={{
         ...getWidth(width),
       }}
+      onMouseEnter={(props as any).onMouseEnter}
+      onMouseLeave={(props as any).onMouseLeave}
     >
       <span className="zent-checkbox">
         <span className="zent-checkbox-inner" />
         <input
-          {...others}
+          {...omit<any, any>(others, ['onMouseEnter', 'onMouseLeave'])}
           type="checkbox"
           checked={checked && !indeterminate}
           disabled={disabled}

--- a/packages/zent/src/checkbox/Checkbox.tsx
+++ b/packages/zent/src/checkbox/Checkbox.tsx
@@ -30,6 +30,8 @@ export interface ICheckboxProps<Value> {
   labelStyle?: React.CSSProperties;
   width?: number;
   children?: React.ReactNode;
+  onMouseEnter?: React.MouseEventHandler<HTMLElement>;
+  onMouseLeave?: React.MouseEventHandler<HTMLElement>;
 }
 
 function getDisabled<Value>(
@@ -118,13 +120,13 @@ export function Checkbox<Value>(props: ICheckboxProps<Value>) {
       style={{
         ...getWidth(width),
       }}
-      onMouseEnter={(props as any).onMouseEnter}
-      onMouseLeave={(props as any).onMouseLeave}
+      onMouseEnter={props.onMouseEnter}
+      onMouseLeave={props.onMouseLeave}
     >
       <span className="zent-checkbox">
         <span className="zent-checkbox-inner" />
         <input
-          {...omit<any, any>(others, ['onMouseEnter', 'onMouseLeave'])}
+          {...omit(others, ['onMouseEnter', 'onMouseLeave'])}
           type="checkbox"
           checked={checked && !indeterminate}
           disabled={disabled}

--- a/packages/zent/src/grid/SelectionCheckbox.tsx
+++ b/packages/zent/src/grid/SelectionCheckbox.tsx
@@ -71,9 +71,7 @@ class SelectionCheckbox extends PureComponent<
     const { checked } = this.state;
     return reason && disabled ? (
       <Pop content={reason} trigger="hover" position="top-left" centerArrow>
-        <span>
-          <Checkbox onChange={onChange} checked={checked} disabled={disabled} />
-        </span>
+        <Checkbox onChange={onChange} checked={checked} disabled={disabled} />
       </Pop>
     ) : (
       <Checkbox onChange={onChange} checked={checked} disabled={disabled} />

--- a/packages/zent/src/grid/SelectionRadio.tsx
+++ b/packages/zent/src/grid/SelectionRadio.tsx
@@ -79,9 +79,7 @@ class SelectionCheckbox extends PureComponent<
     const { checked } = this.state;
     return reason && disabled ? (
       <Pop content={reason} trigger="hover" position="top-left" centerArrow>
-        <span>
-          <Radio onChange={onChange} checked={checked} disabled={disabled} />
-        </span>
+        <Radio onChange={onChange} checked={checked} disabled={disabled} />
       </Pop>
     ) : (
       <Radio onChange={onChange} checked={checked} disabled={disabled} />

--- a/packages/zent/src/input/Input.tsx
+++ b/packages/zent/src/input/Input.tsx
@@ -192,8 +192,12 @@ export class Input extends Component<IInputProps, IInputState> {
       <div
         className={wrapClass}
         style={wrapperStyle}
-        onMouseEnter={(props as any).onMouseEnter}
-        onMouseLeave={(props as any).onMouseLeave}
+        onMouseEnter={
+          props.onMouseEnter as React.MouseEventHandler<HTMLElement>
+        }
+        onMouseLeave={
+          props.onMouseLeave as React.MouseEventHandler<HTMLElement>
+        }
       >
         {renderInner ? renderInner(children) : children}
       </div>

--- a/packages/zent/src/input/Input.tsx
+++ b/packages/zent/src/input/Input.tsx
@@ -183,12 +183,18 @@ export class Input extends Component<IInputProps, IInputState> {
             (props as IInputCoreProps).addonBefore),
         'zent-input--has-focus': hasFocus,
         'zent-input-wrapper-inline': props.inline,
+        'zent-input-wrapper-disabled': disabled,
       },
       className
     );
 
     return (
-      <div className={wrapClass} style={wrapperStyle}>
+      <div
+        className={wrapClass}
+        style={wrapperStyle}
+        onMouseEnter={(props as any).onMouseEnter}
+        onMouseLeave={(props as any).onMouseLeave}
+      >
         {renderInner ? renderInner(children) : children}
       </div>
     );

--- a/packages/zent/src/pop/Pop.tsx
+++ b/packages/zent/src/pop/Pop.tsx
@@ -41,6 +41,7 @@ export interface IPopHoverTriggerProps<
   trigger: 'hover';
   mouseEnterDelay?: number;
   mouseLeaveDelay?: number;
+  fixTooltipOnDisabledChildren?: boolean;
 }
 
 export interface IPopFocusTriggerProps<
@@ -169,6 +170,7 @@ export class Pop extends Component<IPopProps, IPopState> {
             showDelay={props.mouseEnterDelay}
             hideDelay={props.mouseLeaveDelay}
             anchorOnly={props.anchorOnly}
+            fixTooltipOnDisabledChildren={props.fixTooltipOnDisabledChildren}
           >
             {props.children}
           </Trigger.Hover>

--- a/packages/zent/src/pop/README_en-US.md
+++ b/packages/zent/src/pop/README_en-US.md
@@ -64,7 +64,7 @@ A floating card opened by clicking, hovering or focusing.
 
 Why
 
-- [Mouse events don't trigger on disabled button](https://github.com/react-component/tooltip/issues/18)
+- [Mouse events don't trigger on disabled button](https://github.com/youzan/zent/issues/142)
 
 Workaround
 

--- a/packages/zent/src/pop/README_en-US.md
+++ b/packages/zent/src/pop/README_en-US.md
@@ -58,6 +58,11 @@ A floating card opened by clicking, hovering or focusing.
 | mouseEnterDelay | Hover open delay(in ms) | number | No | `200` |
 | mouseLeaveDelay | Hover close delay(in ms) | number | No | `200` |
 | anchorOnly | Only use trigger as hot area | boolean | No | `false` |
+| fixTooltipOnDisabledChildren | Fix the tooltip on disabled children | boolean | No | `false` |
+
+**PS**
+
+- `fixTooltipOnDisabledChildren` is only effective on Zent Components.
 
 #### None
 

--- a/packages/zent/src/pop/README_en-US.md
+++ b/packages/zent/src/pop/README_en-US.md
@@ -60,9 +60,17 @@ A floating card opened by clicking, hovering or focusing.
 | anchorOnly | Only use trigger as hot area | boolean | No | `false` |
 | fixTooltipOnDisabledChildren | Fix the tooltip on disabled children | boolean | No | `false` |
 
-**PS**
+**PS:**`fixTooltipOnDisabledChildren` is only effective on Zent Components.
 
-- `fixTooltipOnDisabledChildren` is only effective on Zent Components.
+Why
+
+- [Mouse events don't trigger on disabled button](https://github.com/react-component/tooltip/issues/18)
+
+Workaround
+
+- Wrap the disabled button/input in another element.
+- Then add {pointer-events: none} style to the disabled button/input.
+
 
 #### None
 

--- a/packages/zent/src/pop/README_zh-CN.md
+++ b/packages/zent/src/pop/README_zh-CN.md
@@ -65,7 +65,7 @@ group: 反馈
 
 背景
 
-- [原生 `input` 和 `button` 在 disabled 状态下触发鼠标事件失效](https://github.com/react-component/tooltip/issues/18)
+- [原生 `input` 和 `button` 在 disabled 状态下触发鼠标事件失效](https://github.com/youzan/zent/issues/142)
 
 解决方案
 

--- a/packages/zent/src/pop/README_zh-CN.md
+++ b/packages/zent/src/pop/README_zh-CN.md
@@ -61,9 +61,16 @@ group: 反馈
 | anchorOnly | 仅考虑 Trigger 作为触发区域 | boolean | 否 | `false` |
 | fixTooltipOnDisabledChildren | 被禁用的子节点展示 Tooltip | boolean | 否 | `false` |
 
-**注意**
+**注意：**`fixTooltipOnDisabledChildren` 仅对 Zent 组件有效。
 
-- `fixTooltipOnDisabledChildren` 仅对 Zent 组件有效。
+背景
+
+- [原生 `input` 和 `button` 在 disabled 状态下触发鼠标事件失效](https://github.com/react-component/tooltip/issues/18)
+
+解决方案
+
+- 先将元素 `input` 或 `button` 包裹在另一元素内部
+- 再给元素 `input` 或 `button` 加样式 `{pointer-events: none}`
 
 #### None
 

--- a/packages/zent/src/pop/README_zh-CN.md
+++ b/packages/zent/src/pop/README_zh-CN.md
@@ -59,6 +59,11 @@ group: 反馈
 | mouseEnterDelay | hover打开的延迟（单位：毫秒） | number | 否 | `200` |
 | mouseLeaveDelay | 关闭的的延迟（单位：毫秒） | number | 否 | `200` |
 | anchorOnly | 仅考虑 Trigger 作为触发区域 | boolean | 否 | `false` |
+| fixTooltipOnDisabledChildren | 被禁用的子节点展示 Tooltip | boolean | 否 | `false` |
+
+**注意**
+
+- `fixTooltipOnDisabledChildren` 仅对 Zent 组件有效。
 
 #### None
 

--- a/packages/zent/src/pop/demos/disabled.md
+++ b/packages/zent/src/pop/demos/disabled.md
@@ -35,7 +35,7 @@ ReactDOM.render(
 			position="top-left"
 			content="{i18n.content}"
 		>
-			<Input disabled style={{ marginRight: '12px' }} />
+			<Input disabled className="zent-pop-disabled-mr" />
 		</Pop>
 		<Pop
 			centerArrow
@@ -44,11 +44,28 @@ ReactDOM.render(
 			content="{i18n.content}"
 			fixTooltipOnDisabledChildren
 		>
-			<Button type="primary" disabled>
+			<Button type="primary" disabled className="zent-pop-disabled-mr">
 				Button
 			</Button>
+		</Pop>
+		<Pop
+			centerArrow
+			trigger="hover"
+			position="top-left"
+			content="{i18n.content}"
+			fixTooltipOnDisabledChildren
+		>
+			<Button.Directive type="primary" disabled>
+				<a href=""> ButtonDirective </a>
+			</Button.Directive>
 		</Pop>
 	</div>,
 	mountNode
 );
 ```
+
+<style type="text/css">
+	.zent-pop-disabled-mr {
+		margin-right:12px;
+	}
+</style>

--- a/packages/zent/src/pop/demos/disabled.md
+++ b/packages/zent/src/pop/demos/disabled.md
@@ -1,0 +1,43 @@
+---
+order: 9
+zh-CN:
+	title: 禁用表单元素
+	content: 内容
+en-US:
+	title: Disabled form inputs
+	content: content
+---
+
+```jsx
+import { Pop, Radio, Checkbox, Input } from 'zent';
+
+ReactDOM.render(
+	<div className="zent-doc-pop-container">
+		<Pop
+			centerArrow
+			trigger="hover"
+			position="top-left"
+			content="{i18n.content}"
+		>
+			<Radio disabled></Radio>
+		</Pop>
+		<Pop
+			centerArrow
+			trigger="hover"
+			position="top-left"
+			content="{i18n.content}"
+		>
+			<Checkbox disabled></Checkbox>
+		</Pop>
+		<Pop
+			centerArrow
+			trigger="hover"
+			position="top-left"
+			content="{i18n.content}"
+		>
+			<Input disabled />
+		</Pop>
+	</div>,
+	mountNode
+);
+```

--- a/packages/zent/src/pop/demos/disabled.md
+++ b/packages/zent/src/pop/demos/disabled.md
@@ -9,7 +9,7 @@ en-US:
 ---
 
 ```jsx
-import { Pop, Radio, Checkbox, Input } from 'zent';
+import { Button, Pop, Radio, Checkbox, Input } from 'zent';
 
 ReactDOM.render(
 	<div className="zent-doc-pop-container">
@@ -35,7 +35,18 @@ ReactDOM.render(
 			position="top-left"
 			content="{i18n.content}"
 		>
-			<Input disabled />
+			<Input disabled style={{ marginRight: '12px' }} />
+		</Pop>
+		<Pop
+			centerArrow
+			trigger="hover"
+			position="top-left"
+			content="{i18n.content}"
+			fixTooltipOnDisabledChildren
+		>
+			<Button type="primary" disabled>
+				Button
+			</Button>
 		</Pop>
 	</div>,
 	mountNode

--- a/packages/zent/src/popover/trigger/HoverTrigger.tsx
+++ b/packages/zent/src/popover/trigger/HoverTrigger.tsx
@@ -19,9 +19,10 @@ interface IHoverTriggerCompatibleProps {
 
 export interface IPopoverHoverTriggerContext
   extends IHoverTriggerCompatibleProps {}
-export const PopoverHoverTriggerContext = createContext<IPopoverHoverTriggerContext>(
-  {}
-);
+
+export const PopoverHoverTriggerContext = createContext<
+  Required<IPopoverHoverTriggerContext>
+>({ fixTooltipOnDisabledChildren: false });
 export interface IPopoverHoverTriggerChildProps {
   onMouseEnter?: (...args: any[]) => void;
   onMouseLeave?: (...args: any[]) => void;

--- a/packages/zent/src/popover/trigger/HoverTrigger.tsx
+++ b/packages/zent/src/popover/trigger/HoverTrigger.tsx
@@ -1,4 +1,11 @@
-import { cloneElement, useContext, useEffect, useMemo, useRef } from 'react';
+import {
+  cloneElement,
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react';
 import { Subject, Observable } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import Context from '../Context';
@@ -6,6 +13,15 @@ import Anchor, { PopoverAnchorGetElementFn } from '../Anchor';
 import { addEventListener } from '../../utils/component/event-handler';
 import { isElement } from 'react-is';
 
+interface IHoverTriggerCompatibleProps {
+  fixTooltipOnDisabledChildren?: boolean;
+}
+
+export interface IPopoverHoverTriggerContext
+  extends IHoverTriggerCompatibleProps {}
+export const PopoverHoverTriggerContext = createContext<IPopoverHoverTriggerContext>(
+  {}
+);
 export interface IPopoverHoverTriggerChildProps {
   onMouseEnter?: (...args: any[]) => void;
   onMouseLeave?: (...args: any[]) => void;
@@ -13,7 +29,7 @@ export interface IPopoverHoverTriggerChildProps {
 
 export interface IPopoverHoverTriggerProps<
   ChildProps extends IPopoverHoverTriggerChildProps
-> {
+> extends IHoverTriggerCompatibleProps {
   hideDelay?: number;
   showDelay?: number;
   anchorOnly?: boolean;
@@ -66,7 +82,7 @@ export function PopoverHoverTrigger<
     return () => $.unsubscribe();
   }, [ctx.popover, visible$]);
 
-  const { children } = props;
+  const { children, fixTooltipOnDisabledChildren } = props;
   const { portalRef, didMount } = ctx;
 
   didMount(() => {
@@ -129,7 +145,13 @@ export function PopoverHoverTrigger<
       </span>
     );
   }
-  return <Anchor getElement={props.getElement}>{child}</Anchor>;
+  return (
+    <PopoverHoverTriggerContext.Provider
+      value={{ fixTooltipOnDisabledChildren }}
+    >
+      <Anchor getElement={props.getElement}>{child}</Anchor>
+    </PopoverHoverTriggerContext.Provider>
+  );
 }
 
 export default PopoverHoverTrigger;

--- a/packages/zent/src/popover/trigger/HoverTrigger.tsx
+++ b/packages/zent/src/popover/trigger/HoverTrigger.tsx
@@ -18,11 +18,11 @@ interface IHoverTriggerCompatibleProps {
 }
 
 export interface IPopoverHoverTriggerContext
-  extends IHoverTriggerCompatibleProps {}
+  extends Required<IHoverTriggerCompatibleProps> {}
 
-export const PopoverHoverTriggerContext = createContext<
-  Required<IPopoverHoverTriggerContext>
->({ fixTooltipOnDisabledChildren: false });
+export const PopoverHoverTriggerContext = createContext<IPopoverHoverTriggerContext>(
+  { fixTooltipOnDisabledChildren: false }
+);
 export interface IPopoverHoverTriggerChildProps {
   onMouseEnter?: (...args: any[]) => void;
   onMouseLeave?: (...args: any[]) => void;

--- a/packages/zent/src/radio/AbstractRadio.tsx
+++ b/packages/zent/src/radio/AbstractRadio.tsx
@@ -22,6 +22,8 @@ export interface IRadioProps<Value> {
   onChange?: (e: IRadioEvent<Value>) => void;
   style?: React.CSSProperties;
   children?: ReactNode;
+  onMouseEnter?: React.MouseEventHandler<HTMLElement>;
+  onMouseLeave?: React.MouseEventHandler<HTMLElement>;
 }
 
 function makeEvent<Value>(

--- a/packages/zent/src/radio/Radio.tsx
+++ b/packages/zent/src/radio/Radio.tsx
@@ -49,13 +49,13 @@ function Radio<Value>(
     <label
       className={classString}
       style={wrapStyle}
-      onMouseEnter={(props as any).onMouseEnter}
-      onMouseLeave={(props as any).onMouseLeave}
+      onMouseEnter={props.onMouseEnter}
+      onMouseLeave={props.onMouseLeave}
     >
       <span className="zent-radio">
         <span className="zent-radio-inner" />
         <input
-          {...omit<any, any>(others, ['onMouseEnter', 'onMouseLeave'])}
+          {...omit(others, ['onMouseEnter', 'onMouseLeave'])}
           type="radio"
           checked={!!checked}
           disabled={disabled}

--- a/packages/zent/src/radio/Radio.tsx
+++ b/packages/zent/src/radio/Radio.tsx
@@ -7,7 +7,6 @@ import RadioButton from './RadioButton';
 import { DisabledContext } from '../disabled';
 import GroupContext from './GroupContext';
 import { useContext } from 'react';
-import omit from '../utils/omit';
 
 function Radio<Value>(
   props: IRadioProps<Value> & { labelStyle?: React.CSSProperties }
@@ -22,7 +21,8 @@ function Radio<Value>(
     width,
 
     labelStyle,
-
+    onMouseEnter,
+    onMouseLeave,
     ...others
   } = props;
   const disabledCtx = useContext(DisabledContext);
@@ -55,7 +55,7 @@ function Radio<Value>(
       <span className="zent-radio">
         <span className="zent-radio-inner" />
         <input
-          {...omit(others, ['onMouseEnter', 'onMouseLeave'])}
+          {...others}
           type="radio"
           checked={!!checked}
           disabled={disabled}

--- a/packages/zent/src/radio/Radio.tsx
+++ b/packages/zent/src/radio/Radio.tsx
@@ -7,6 +7,7 @@ import RadioButton from './RadioButton';
 import { DisabledContext } from '../disabled';
 import GroupContext from './GroupContext';
 import { useContext } from 'react';
+import omit from '../utils/omit';
 
 function Radio<Value>(
   props: IRadioProps<Value> & { labelStyle?: React.CSSProperties }
@@ -45,11 +46,16 @@ function Radio<Value>(
   };
 
   return (
-    <label className={classString} style={wrapStyle}>
+    <label
+      className={classString}
+      style={wrapStyle}
+      onMouseEnter={(props as any).onMouseEnter}
+      onMouseLeave={(props as any).onMouseLeave}
+    >
       <span className="zent-radio">
         <span className="zent-radio-inner" />
         <input
-          {...others}
+          {...omit<any, any>(others, ['onMouseEnter', 'onMouseLeave'])}
           type="radio"
           checked={!!checked}
           disabled={disabled}

--- a/packages/zent/src/radio/RadioButton.tsx
+++ b/packages/zent/src/radio/RadioButton.tsx
@@ -6,6 +6,7 @@ import getWidth from '../utils/getWidth';
 import { getRadioState, useRadioHandler, IRadioProps } from './AbstractRadio';
 import { DisabledContext } from '../disabled';
 import GroupContext from './GroupContext';
+import omit from '../utils/omit';
 
 export function RadioButton<Value>(props: IRadioProps<Value>) {
   const {
@@ -42,9 +43,14 @@ export function RadioButton<Value>(props: IRadioProps<Value>) {
   };
 
   return (
-    <label className={classString} style={wrapStyle}>
+    <label
+      className={classString}
+      style={wrapStyle}
+      onMouseEnter={(props as any).onMouseEnter}
+      onMouseLeave={(props as any).onMouseLeave}
+    >
       <input
-        {...others}
+        {...omit<any, any>(others, ['onMouseEnter', 'onMouseLeave'])}
         type="radio"
         checked={!!checked}
         disabled={disabled}

--- a/packages/zent/src/radio/RadioButton.tsx
+++ b/packages/zent/src/radio/RadioButton.tsx
@@ -6,7 +6,6 @@ import getWidth from '../utils/getWidth';
 import { getRadioState, useRadioHandler, IRadioProps } from './AbstractRadio';
 import { DisabledContext } from '../disabled';
 import GroupContext from './GroupContext';
-import omit from '../utils/omit';
 
 export function RadioButton<Value>(props: IRadioProps<Value>) {
   const {
@@ -17,6 +16,8 @@ export function RadioButton<Value>(props: IRadioProps<Value>) {
     // value 不要放到 input 上去
     value,
     width,
+    onMouseEnter,
+    onMouseLeave,
     ...others
   } = props;
   const disabledCtx = useContext(DisabledContext);
@@ -46,11 +47,11 @@ export function RadioButton<Value>(props: IRadioProps<Value>) {
     <label
       className={classString}
       style={wrapStyle}
-      onMouseEnter={props.onMouseEnter}
-      onMouseLeave={props.onMouseLeave}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
     >
       <input
-        {...omit(others, ['onMouseEnter', 'onMouseLeave'])}
+        {...others}
         type="radio"
         checked={!!checked}
         disabled={disabled}

--- a/packages/zent/src/radio/RadioButton.tsx
+++ b/packages/zent/src/radio/RadioButton.tsx
@@ -46,11 +46,11 @@ export function RadioButton<Value>(props: IRadioProps<Value>) {
     <label
       className={classString}
       style={wrapStyle}
-      onMouseEnter={(props as any).onMouseEnter}
-      onMouseLeave={(props as any).onMouseLeave}
+      onMouseEnter={props.onMouseEnter}
+      onMouseLeave={props.onMouseLeave}
     >
       <input
-        {...omit<any, any>(others, ['onMouseEnter', 'onMouseLeave'])}
+        {...omit(others, ['onMouseEnter', 'onMouseLeave'])}
         type="radio"
         checked={!!checked}
         disabled={disabled}

--- a/packages/zent/src/tooltip/README_en-US.md
+++ b/packages/zent/src/tooltip/README_en-US.md
@@ -43,6 +43,11 @@ group: FIXME group name here
 | mouseLeaveDelay | Hover close delay(in ms) | number | No | `200` |
 | isOutside | Callback to determine if mouse is outside of Tooltip | func | No | |
 | quirk | Switch to quirk mode, you don't have to move from inside to outside to trigger a close in quirk mode | bool | No | `true` |
+| fixTooltipOnDisabledChildren | Fix the tooltip on disabled children | boolean | No | `false` |
+
+**PS**
+
+- `fixTooltipOnDisabledChildren` is only effective on Zent Components.
 
 #### None
 

--- a/packages/zent/src/tooltip/README_en-US.md
+++ b/packages/zent/src/tooltip/README_en-US.md
@@ -49,7 +49,7 @@ group: FIXME group name here
 
 Why
 
-- [Mouse events don't trigger on disabled button](https://github.com/react-component/tooltip/issues/18)
+- [Mouse events don't trigger on disabled button](https://github.com/youzan/zent/issues/142)
 
 Workaround
 

--- a/packages/zent/src/tooltip/README_en-US.md
+++ b/packages/zent/src/tooltip/README_en-US.md
@@ -45,9 +45,16 @@ group: FIXME group name here
 | quirk | Switch to quirk mode, you don't have to move from inside to outside to trigger a close in quirk mode | bool | No | `true` |
 | fixTooltipOnDisabledChildren | Fix the tooltip on disabled children | boolean | No | `false` |
 
-**PS**
+**PS:**`fixTooltipOnDisabledChildren` is only effective on Zent Components.
 
-- `fixTooltipOnDisabledChildren` is only effective on Zent Components.
+Why
+
+- [Mouse events don't trigger on disabled button](https://github.com/react-component/tooltip/issues/18)
+
+Workaround
+
+- Wrap the disabled button/input in another element.
+- Then add {pointer-events: none} style to the disabled button/input.
 
 #### None
 

--- a/packages/zent/src/tooltip/README_zh-CN.md
+++ b/packages/zent/src/tooltip/README_zh-CN.md
@@ -40,6 +40,11 @@ group: 展示
 |------|------|------|--------|-------|
 | mouseEnterDelay | hover打开的延迟（单位：毫秒） | number | 否 | `160` |
 | mouseLeaveDelay | 关闭的的延迟（单位：毫秒） | number | 否 | `160` |
+| fixTooltipOnDisabledChildren | 被禁用的子节点展示 Tooltip | boolean | 否 | `false` |
+
+**注意**
+
+- `fixTooltipOnDisabledChildren` 仅对 Zent 组件有效。
 
 #### None
 

--- a/packages/zent/src/tooltip/README_zh-CN.md
+++ b/packages/zent/src/tooltip/README_zh-CN.md
@@ -46,7 +46,7 @@ group: 展示
 
 背景
 
-- [原生 `input` 和 `button` 在 disabled 状态下触发鼠标事件失效](https://github.com/react-component/tooltip/issues/18)
+- [原生 `input` 和 `button` 在 disabled 状态下触发鼠标事件失效](https://github.com/youzan/zent/issues/142)
 
 解决方案
 

--- a/packages/zent/src/tooltip/README_zh-CN.md
+++ b/packages/zent/src/tooltip/README_zh-CN.md
@@ -42,9 +42,16 @@ group: 展示
 | mouseLeaveDelay | 关闭的的延迟（单位：毫秒） | number | 否 | `160` |
 | fixTooltipOnDisabledChildren | 被禁用的子节点展示 Tooltip | boolean | 否 | `false` |
 
-**注意**
+**注意：**`fixTooltipOnDisabledChildren` 仅对 Zent 组件有效。
 
-- `fixTooltipOnDisabledChildren` 仅对 Zent 组件有效。
+背景
+
+- [原生 `input` 和 `button` 在 disabled 状态下触发鼠标事件失效](https://github.com/react-component/tooltip/issues/18)
+
+解决方案
+
+- 先将元素 `input` 或 `button` 包裹在另一元素内部
+- 再给元素 `input` 或 `button` 加样式 `{pointer-events: none}`
 
 #### None
 

--- a/packages/zent/src/tooltip/Tooltip.tsx
+++ b/packages/zent/src/tooltip/Tooltip.tsx
@@ -21,6 +21,7 @@ export interface ITooltipBaseProps {
   visible?: boolean;
   onVisibleChange?: (visible: boolean) => void;
   children: ReactElement | string | number;
+  fixTooltipOnDisabledChildren?: boolean;
 }
 
 interface ITooltipTriggerProps extends ITooltipBaseProps {
@@ -85,12 +86,14 @@ export class Tooltip extends Component<ITooltipProps> {
         mouseLeaveDelay = 200,
         mouseEnterDelay = 200,
         anchorOnly,
+        fixTooltipOnDisabledChildren,
       } = this.props;
       return (
         <Trigger.Hover
           showDelay={mouseEnterDelay}
           hideDelay={mouseLeaveDelay}
           anchorOnly={anchorOnly}
+          fixTooltipOnDisabledChildren={fixTooltipOnDisabledChildren}
         >
           {children}
         </Trigger.Hover>

--- a/packages/zent/src/tooltip/demos/disabled.md
+++ b/packages/zent/src/tooltip/demos/disabled.md
@@ -1,0 +1,35 @@
+---
+order: 5
+zh-CN:
+	title: 禁用元素
+	content: 内容
+
+en-US:
+	title: Disabled elements
+	content: Content
+---
+
+```jsx
+import { Button, Input, Radio, Tooltip } from 'zent';
+
+ReactDOM.render(
+	<div className="zent-doc-tooltip-container">
+		<Tooltip
+			trigger="hover"
+			title="{i18n.content}"
+			fixTooltipOnDisabledChildren
+		>
+			<Button type="primary" disabled>
+				Button
+			</Button>
+		</Tooltip>
+		<Tooltip trigger="hover" title="{i18n.content}">
+			<Input disabled />
+		</Tooltip>
+		<Tooltip trigger="hover" title="{i18n.content}">
+			<Radio disabled style={{ marginLeft: '12px' }} />
+		</Tooltip>
+	</div>,
+	mountNode
+);
+```

--- a/packages/zent/src/tooltip/demos/disabled.md
+++ b/packages/zent/src/tooltip/demos/disabled.md
@@ -29,6 +29,15 @@ ReactDOM.render(
 		<Tooltip trigger="hover" title="{i18n.content}">
 			<Radio disabled style={{ marginLeft: '12px' }} />
 		</Tooltip>
+		<Tooltip
+			trigger="hover"
+			title="{i18n.content}"
+			fixTooltipOnDisabledChildren
+		>
+			<Button.Directive type="primary" disabled>
+				<a href=""> ButtonDirective </a>
+			</Button.Directive>
+		</Tooltip>
 	</div>,
 	mountNode
 );

--- a/packages/zent/src/tooltip/demos/trigger.md
+++ b/packages/zent/src/tooltip/demos/trigger.md
@@ -40,7 +40,8 @@ ReactDOM.render(
 <style>
 	.zent-doc-tooltip-container {
 		display: flex;
-		justify-content: center;
+		justify-content: left;
+        align-items: center;
 
 		.zent-doc-tooltip-tag {
 			border: 1px solid #e5e5e5;

--- a/packages/zent/src/tooltip/demos/trigger.md
+++ b/packages/zent/src/tooltip/demos/trigger.md
@@ -41,7 +41,7 @@ ReactDOM.render(
 	.zent-doc-tooltip-container {
 		display: flex;
 		justify-content: left;
-        align-items: center;
+		align-items: center;
 
 		.zent-doc-tooltip-tag {
 			border: 1px solid #e5e5e5;


### PR DESCRIPTION
Workaround for #142 .

Popover / Pop / Tooltip
- Add `fixTooltipOnDisabledChildren` to fix the tooltip on disabled children when hover