### PR TITLE
fix(badge): optimize interface

### DIFF
--- a/packages/zent/src/badge/Badge.tsx
+++ b/packages/zent/src/badge/Badge.tsx
@@ -10,7 +10,7 @@ export interface IBadgeProps {
   showZero: boolean;
   offset?: [number, number];
   style?: React.CSSProperties;
-  children: React.ReactNode;
+  children?: React.ReactNode;
   className: string;
 }
 


### PR DESCRIPTION
Changes you made in this pull request:

- 独立徽标一般没有 `children` 属性，所以感觉把 `children` 属性改成**可选属性**更加合适
