### PR TITLE
[bugfix]: Input inside IMEComposition onchange event doesn't trigger in some brower

### DIFF
--- a/packages/zent/__tests__/ime-composition.js
+++ b/packages/zent/__tests__/ime-composition.js
@@ -47,7 +47,6 @@ describe('IMEComposition', () => {
     wrapper
       .find('input')
       .simulate('compositionEnd', { target: { value: '123' } });
-    wrapper.find('input').simulate('change', { target: { value: '123' } });
 
     expect(onChange.mock.calls.length).toBe(2);
     expect(wrapper.state().value).toBe('123');

--- a/packages/zent/src/ime-composition/hooks.ts
+++ b/packages/zent/src/ime-composition/hooks.ts
@@ -40,6 +40,10 @@ export function createUseIMEComposition(
       onCompositionEndRef.current = onCompositionEndProp;
     }, [onChangeProp, onCompositionStartProp, onCompositionEndProp]);
 
+    useEffect(() => {
+      setCompositionValue(propValue);
+    }, [propValue]);
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
     const onCompositionValueChange = useCallback(
       ((...args) => {
@@ -71,10 +75,10 @@ export function createUseIMEComposition(
         isCompositionRef.current = false;
         onCompositionEndRef.current?.(e);
         const currentValue = e.currentTarget.value;
+        setCompositionValue(currentValue);
         // 输入值更新时，手动触发 onChange 事件
         if (currentValue !== propValue) {
           e.type = 'change';
-          setCompositionValue(currentValue);
           onChangeRef.current?.(e);
         }
       },


### PR DESCRIPTION
`IMEComposition`:

- Fix input-elements inside `IMEComposition` event doesn't trigger in  some browser, like Safari.

