### PR TITLE
add threshold prop to InfiniteScroller

### DIFF
--- a/packages/zent/src/infinite-scroller/InfiniteScroller.tsx
+++ b/packages/zent/src/infinite-scroller/InfiniteScroller.tsx
@@ -14,6 +14,10 @@ export interface IInfiniteScrollerProps {
   useWindow?: boolean;
   loader?: React.ReactNode;
   children?: React.ReactNode;
+  /**
+   * The distance in pixels before the end of the items that will trigger a call to loadMore
+   */
+  threshold?: number;
 }
 
 const DEFAULT_LOADER = <BlockLoading height={60} loading icon="circle" />;
@@ -29,6 +33,7 @@ export const InfiniteScroller = forwardRef<
       skipLoadOnMount = false,
       useWindow = false,
       loader = DEFAULT_LOADER,
+      threshold = 0,
       className,
       children,
     },
@@ -90,6 +95,7 @@ export const InfiniteScroller = forwardRef<
           <Waypoint
             scrollableAncestor={useWindow ? window : undefined}
             onEnter={onEnter}
+            bottomOffset={-threshold}
           />
         )}
         {loading && loader}

--- a/packages/zent/src/infinite-scroller/README_en-US.md
+++ b/packages/zent/src/infinite-scroller/README_en-US.md
@@ -17,10 +17,11 @@ Infinite scrolling widget
 | Property        | Description                         | Type                                                              | Default        | Alternative |
 | --------------- | ----------------------------------- | ----------------------------------------------------------------- | -------------- | ----------- |
 | hasMore         | More data to load                   | `boolean`                                                         | `false`        | `true`      |
-| loadMore        | Callback to load more data          | `(() => Promise<unknown>) | ((stopLoading?: () => void) => void)` |
+| loadMore        | Callback to load more data          | `(() => Promise<unknown>) \| ((stopLoading?: () => void) => void)` |
 | skipLoadOnMount | Don't trigger a loading on mount    | `boolean`                                                         | `false`        | `true`      |
 | useWindow       | Use `window` as scrolling container | `boolean`                                                         | `false`        | `true`      |
 | loader          | Loading content                     | `ReactNode`                                                       | `BlockLoading` |             |
+| threshold | The distance in pixels before the end of the items that will trigger a call to loadMore | `number` | 0 |   |
 | className       | Custom class name                   | `string`                                                          |                |             |
 
 ### loadMore

--- a/packages/zent/src/infinite-scroller/README_zh-CN.md
+++ b/packages/zent/src/infinite-scroller/README_zh-CN.md
@@ -18,10 +18,11 @@ group: 展示
 | 参数            | 说明                                                                    | 类型                                                              | 默认值         | 备选值  |
 | --------------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------- | -------------- | ------- |
 | hasMore         | 是否还有更多数据待加载                                                  | `boolean`                                                         | `true`         | `false` |
-| loadMore        | 加载更多的回调函数，如果函数接收参数则会传入一个停止 loading 效果的回调 | `(() => Promise<unknown>) | ((stopLoading?: () => void) => void)` |                |         |
+| loadMore        | 加载更多的回调函数，如果函数接收参数则会传入一个停止 loading 效果的回调 | `(() => Promise<unknown>) \| ((stopLoading?: () => void) => void)` |                |         |
 | skipLoadOnMount | 初始化时是否触发一次数据加载                                            | `boolean`                                                         | `false`        | `true`  |
 | useWindow       | 是否使用 `window` 作为滚动容器                                          | `boolean`                                                         | `false`        | `true`  |
 | loader          | 加载时显示的内容                                                        | `ReactNode`                                                       | `BlockLoading` |         |
+| threshold | 触发 `loadMore` 时距离列表末尾的距离 | `number` | `0` |   |
 | className       | 自定义额外类名                                                          | `string`                                                          |                |         |
 
 ### loadMore


### PR DESCRIPTION
Add `threshold` props to `InfiniteScroller`.

The `threshold` is the distance in pixels before the end of the items that will trigger a call to `loadMore`.

Closes #1704 