### PR TITLE
loose context check in Form hooks

### DIFF
--- a/packages/zent/src/form/FieldSet.tsx
+++ b/packages/zent/src/form/FieldSet.tsx
@@ -68,7 +68,8 @@ export function FieldSet<T extends UnknownFieldSetModelChildren>(
   } = props as IFieldSetBaseProps<T>;
   const { name } = props as IFieldSetViewDrivenProps<T>;
   const { model: rawModel } = props as IFieldSetModelDrivenProps<T>;
-  const [ctx, model] = useFieldSet<T>(name || rawModel, validators);
+  // It's safe to use `any`
+  const [ctx, model] = useFieldSet<T>((name ?? rawModel) as any, validators);
   useImperativeHandle(modelRef, () => model, [model]);
   useFormChild(model as BasicModel<unknown>, scrollAnchorRef);
   useValue$(model.error$, model.error$.getValue());

--- a/packages/zent/src/form/Form.tsx
+++ b/packages/zent/src/form/Form.tsx
@@ -21,7 +21,9 @@ import {
   useFieldValue,
   FieldValid,
   useFieldValid,
+  // eslint-disable-next-line import/no-deprecated
   useModelValid,
+  // eslint-disable-next-line import/no-deprecated
   useModelValue,
 } from './formulr';
 import memorize from '../utils/memorize-one';
@@ -159,7 +161,9 @@ export class Form<T extends {}> extends Component<IFormProps<T>> {
   static FieldValid = FieldValid;
   static useFormValid = useFormValid;
   static useFieldValid = useFieldValid;
+  // eslint-disable-next-line import/no-deprecated
   static useModelValue = useModelValue;
+  // eslint-disable-next-line import/no-deprecated
   static useModelValid = useModelValid;
   static ValidateOption = ValidateOption;
   static createAsyncValidator = createAsyncValidator;

--- a/packages/zent/src/form/demos/21.subscribe-model.md
+++ b/packages/zent/src/form/demos/21.subscribe-model.md
@@ -13,7 +13,7 @@ en-US:
 import { Form, FormContext, FormStrategy, FormInputField } from 'zent';
 
 function PreviewName({ form }) {
-	const name = Form.useModelValue(form.model.get('name'));
+	const name = Form.useFieldValue(form.model.get('name'));
 
 	return (
 		<p>

--- a/packages/zent/src/form/formulr/context.ts
+++ b/packages/zent/src/form/formulr/context.ts
@@ -14,9 +14,13 @@ FormContext.displayName = 'FormContext';
 
 export const FormProvider = FormContext.Provider;
 
-export function useFormContext(): IFormContext {
+/**
+ * Returns current form context
+ * @param quiet Don't throw if context not found
+ */
+export function useFormContext(quiet = false): IFormContext | null {
   const ctx = useContext(FormContext);
-  if (ctx === null) {
+  if (ctx === null && !quiet) {
     throw new FormulrError('FormContext not found', [
       'Using form hooks outside the form context',
       "There's a copy of formulr in your project, run `yarn list formulr` to check",

--- a/packages/zent/src/form/formulr/context.ts
+++ b/packages/zent/src/form/formulr/context.ts
@@ -1,6 +1,6 @@
 import { createContext, useContext } from 'react';
 import { FormStrategy, FormModel, FieldSetModel } from './models';
-import { FormulrError } from './error';
+import { FormContextNotFoundError } from './error';
 
 export interface IFormContext {
   strategy: FormStrategy;
@@ -21,10 +21,7 @@ export const FormProvider = FormContext.Provider;
 export function useFormContext(quiet = false): IFormContext | null {
   const ctx = useContext(FormContext);
   if (ctx === null && !quiet) {
-    throw new FormulrError('FormContext not found', [
-      'Using form hooks outside the form context',
-      "There's a copy of formulr in your project, run `yarn list formulr` to check",
-    ]);
+    throw FormContextNotFoundError;
   }
   return ctx;
 }

--- a/packages/zent/src/form/formulr/error.ts
+++ b/packages/zent/src/form/formulr/error.ts
@@ -18,6 +18,14 @@ export class FormulrError extends Error {
   }
 }
 
+export const FormContextNotFoundError = new FormulrError(
+  'FormContext not found',
+  [
+    'Using form hooks outside the form context',
+    "There's a copy of formulr in your project, run `yarn list formulr` to check",
+  ]
+);
+
 export const createUnexpectedModelTypeError = (
   name: string,
   expectedType: string,

--- a/packages/zent/src/form/formulr/error.ts
+++ b/packages/zent/src/form/formulr/error.ts
@@ -1,3 +1,5 @@
+import type { IModel } from './models/base';
+import { typeOfModel } from './models/is';
 import { isArray } from './utils';
 
 export class FormulrError extends Error {
@@ -16,10 +18,23 @@ export class FormulrError extends Error {
   }
 }
 
-export const UnexpectedFormStrategyError = new FormulrError(
-  'Unexpected FormStrategy',
-  'The first argument to form hooks is string in a model-driven form context'
-);
+export const createUnexpectedModelTypeError = (
+  name: string,
+  expectedType: string,
+  model: IModel<unknown>
+) =>
+  new FormulrError(
+    'Model type mismatch',
+    `Model '${name}' is expected to be a '${expectedType}', but got a '${typeOfModel(
+      model
+    )}'.`
+  );
+
+export const createModelNotFoundError = (name: string) =>
+  new FormulrError(
+    'Model not found',
+    `Model '${name}' is not found in this form. Make sure model name is correct.`
+  );
 
 export const createUnexpectedModelError = (it: unknown) =>
   new FormulrError(

--- a/packages/zent/src/form/formulr/field-array.tsx
+++ b/packages/zent/src/form/formulr/field-array.tsx
@@ -13,7 +13,10 @@ import { useDestroyOnUnmount } from './utils';
 import { isSome, get } from './maybe';
 import { IValidators } from './validate';
 import { IModel } from './models/base';
-import { UnexpectedFormStrategyError } from './error';
+import {
+  createModelNotFoundError,
+  createUnexpectedModelTypeError,
+} from './error';
 
 export type IUseFieldArray<Item, Child extends IModel<Item>> = [
   Child[],
@@ -32,23 +35,30 @@ function useArrayModel<Item, Child extends IModel<Item>>(
   const model = useMemo(() => {
     let model: FieldArrayModel<Item, Child>;
     if (typeof field === 'string') {
-      if (strategy !== FormStrategy.View) {
-        throw UnexpectedFormStrategyError;
-      }
       const m = parent.get(field);
-      if (!m || !isFieldArrayModel<Item, Child>(m)) {
-        const potential = parent.getPatchedValue(field);
-        let v = defaultValue;
-        if (isSome(potential)) {
-          const inner = get(potential);
-          if (Array.isArray(inner)) {
-            v = inner;
+      if (strategy === FormStrategy.View) {
+        if (!m || !isFieldArrayModel<Item, Child>(m)) {
+          const potential = parent.getPatchedValue(field);
+          let v = defaultValue;
+          if (isSome(potential)) {
+            const inner = get(potential);
+            if (Array.isArray(inner)) {
+              v = inner;
+            }
           }
+          model = new FieldArrayModel<Item, Child>(null, v);
+          parent.registerChild(field, model);
+        } else {
+          model = m;
         }
-        model = new FieldArrayModel<Item, Child>(null, v);
-        parent.registerChild(field, model);
       } else {
-        model = m;
+        if (!m) {
+          throw createModelNotFoundError(field);
+        } else if (!isFieldArrayModel<Item, Child>(m)) {
+          throw createUnexpectedModelTypeError(field, 'FieldArrayModel', m);
+        } else {
+          model = m;
+        }
       }
     } else if (
       isModelRef<ReadonlyArray<Item>, any, FieldArrayModel<Item, Child>>(field)
@@ -111,11 +121,17 @@ export function useFieldArray<Item, Child extends IModel<Item>>(
   validators: IValidators<readonly Item[]> = [],
   defaultValue: readonly Item[] = []
 ): FieldArrayModel<Item, Child> {
-  const { parent, strategy } = useFormContext();
+  const { parent, strategy } = useFormContext(typeof field !== 'string') ?? {};
   const model = useArrayModel(field, parent, strategy, defaultValue);
-  if (typeof field === 'string' || isModelRef(field)) {
+
+  // Only update validators in View mode
+  if (
+    strategy === FormStrategy.View &&
+    (typeof field === 'string' || isModelRef(field))
+  ) {
     model.validators = validators;
   }
+
   const { error$, children$ } = model;
   /**
    * ignore returned value

--- a/packages/zent/src/form/formulr/field-array.tsx
+++ b/packages/zent/src/form/formulr/field-array.tsx
@@ -94,8 +94,10 @@ function useArrayModel<Item, Child extends IModel<Item>>(
 /**
  * 创建一个 `FieldArray`
  *
- * @param field 字段名，当 `FormStrategy` 是 `View` 的时候才能用字段名
- * @param validators 当 `field` 是字段名的时候，可以传入 `validator`
+ * `Model` 模式下传入字符串类型的 `field` 时， `validators` 和 `defaultValue` 均无效。
+ *
+ * @param field 字段名
+ * @param validators 校验函数数组
  * @param defaultValue 默认值
  */
 export function useFieldArray<Item, Child extends IModel<Item>>(

--- a/packages/zent/src/form/formulr/field-set.tsx
+++ b/packages/zent/src/form/formulr/field-set.tsx
@@ -84,8 +84,10 @@ function useFieldSetModel<T extends UnknownFieldSetModelChildren>(
 /**
  * 创建一个 `FieldSet`
  *
- * @param field 字段名，当`FormStrategy`是`View`的时候才能用字段名
- * @param validators 校验器
+ * `Model` 模式下传入字符串类型的 `field` 时， `validators` 无效。
+ *
+ * @param field 字段名
+ * @param validators 校验函数数组
  */
 export function useFieldSet<T extends UnknownFieldSetModelChildren>(
   field: string | ModelRef<$FieldSetValue<T>, any, FieldSetModel<T>>,

--- a/packages/zent/src/form/formulr/field.tsx
+++ b/packages/zent/src/form/formulr/field.tsx
@@ -78,10 +78,12 @@ function useModelAndChildProps<Value>(
 }
 
 /**
- * 获取一个 `Field`
+ * 获取一个 `Field`。
  *
- * @param field 字段名，当 `FormStrategy` 是 `View` 的时候才能用字段名
- * @param validators 当 `field` 是字段名的时候，可以传入`validator`
+ * `Model` 模式下传入字符串类型的 `field` 时， `validators` 和 `defaultValue` 均无效。
+ *
+ * @param field 字段名
+ * @param validators 校验函数数组
  * @param defaultValue 默认值
  */
 export function useField<Value>(

--- a/packages/zent/src/form/formulr/field.tsx
+++ b/packages/zent/src/form/formulr/field.tsx
@@ -3,18 +3,19 @@ import {
   FieldModel,
   BasicModel,
   FormStrategy,
-  FieldSetModel,
-  FormModel,
   ModelRef,
   isModelRef,
   isFieldModel,
 } from './models';
 import { useValue$ } from './hooks';
-import { useFormContext } from './context';
+import { IFormContext, useFormContext } from './context';
 import { IValidators } from './validate';
 import { useDestroyOnUnmount } from './utils';
 import { or } from './maybe';
-import { UnexpectedFormStrategyError } from './error';
+import {
+  createModelNotFoundError,
+  createUnexpectedModelTypeError,
+} from './error';
 
 function isValueFactory<Value>(
   candidate: Value | (() => Value)
@@ -23,28 +24,34 @@ function isValueFactory<Value>(
 }
 
 function useModelAndChildProps<Value>(
+  ctx: IFormContext | null,
   field: FieldModel<Value> | ModelRef<Value, any, FieldModel<Value>> | string,
-  parent: FieldSetModel,
-  strategy: FormStrategy,
-  defaultValue: Value | (() => Value),
-  form: FormModel
+  defaultValue: Value | (() => Value)
 ) {
   const model = useMemo(() => {
     let model: FieldModel<Value>;
     if (typeof field === 'string') {
-      if (strategy !== FormStrategy.View) {
-        throw UnexpectedFormStrategyError;
-      }
+      const { strategy, parent } = ctx ?? {};
       const m = parent.get(field);
-      if (!m || !isFieldModel<Value>(m)) {
-        const v = or<Value>(
-          parent.getPatchedValue(field),
-          isValueFactory(defaultValue) ? defaultValue : () => defaultValue
-        );
-        model = new FieldModel<Value>(v);
-        parent.registerChild(field, model as BasicModel<unknown>);
+      if (strategy === FormStrategy.View) {
+        if (!m || !isFieldModel<Value>(m)) {
+          const v = or<Value>(
+            parent.getPatchedValue(field),
+            isValueFactory(defaultValue) ? defaultValue : () => defaultValue
+          );
+          model = new FieldModel<Value>(v);
+          parent.registerChild(field, model as BasicModel<unknown>);
+        } else {
+          model = m;
+        }
       } else {
-        model = m;
+        if (!m) {
+          throw createModelNotFoundError(field);
+        } else if (!isFieldModel<Value>(m)) {
+          throw createUnexpectedModelTypeError(field, 'FieldModel', m);
+        } else {
+          model = m;
+        }
       }
     } else if (isModelRef<Value, any, FieldModel<Value>>(field)) {
       const m = field.getModel();
@@ -63,9 +70,9 @@ function useModelAndChildProps<Value>(
     } else {
       model = field;
     }
+
     return model;
-    /** ignore defaultValue */
-  }, [field, parent, strategy, form]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [field, ctx?.parent, ctx?.strategy, ctx?.form]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return model;
 }
@@ -97,20 +104,19 @@ export function useField<Value>(
   defaultValue?: Value | (() => Value),
   validators: IValidators<Value> = []
 ): FieldModel<Value> {
-  const { parent, strategy, form } = useFormContext();
-  const model = useModelAndChildProps(
-    field,
-    parent,
-    strategy,
-    defaultValue!,
-    form
-  );
+  const ctx = useFormContext(typeof field !== 'string');
+  const model = useModelAndChildProps(ctx, field, defaultValue!);
   const { value$, error$ } = model;
   useValue$(value$, value$.getValue());
   useValue$(error$, error$.getValue());
-  if (typeof field === 'string' || isModelRef(field)) {
+
+  // Only update validators in View mode
+  if (
+    ctx?.strategy === FormStrategy.View &&
+    (typeof field === 'string' || isModelRef(field))
+  ) {
     model.validators = validators;
   }
-  useDestroyOnUnmount(field, model, parent);
+  useDestroyOnUnmount(field, model, ctx?.parent);
   return model;
 }

--- a/packages/zent/src/form/formulr/listeners/array.ts
+++ b/packages/zent/src/form/formulr/listeners/array.ts
@@ -10,7 +10,7 @@ import { useModelFromContext } from './use-model';
 export function useFieldArrayValue<Item, Child extends IModel<Item>>(
   field: string | FieldArrayModel<Item, Child>
 ): Child[] | null {
-  const ctx = useFormContext();
+  const ctx = useFormContext(typeof field !== 'string');
   const model = useModelFromContext(
     ctx,
     field as string | undefined,

--- a/packages/zent/src/form/formulr/listeners/field.tsx
+++ b/packages/zent/src/form/formulr/listeners/field.tsx
@@ -43,7 +43,7 @@ export type IFieldValidProps<T> =
   | IFieldValidViewDrivenProps;
 
 /**
- * Subscribe the value state of a model
+ * 订阅 `model` 的值
  * @deprecated Use `useFieldValue`
  * @param model
  */
@@ -52,7 +52,7 @@ export function useModelValue<T>(model: IModel<T>): T | null {
 }
 
 /**
- * Subscribe the valid state of a model
+ * 订阅 `model` 的校验状态
  * @deprecated Use `useFieldValid`
  * @param model
  */
@@ -61,8 +61,8 @@ export function useModelValid<T>(model: IModel<T>): boolean | null {
 }
 
 /**
- * Subscribe the value state of a model.
- * Note that it works in FormContext only.
+ * 订阅 `model` 的值。
+ * 当参数是 `Model` 对象时不依赖 `FormContext`，参数是字段名时必须在有 `FormContext` 的环境下使用。
  * @param field
  */
 export function useFieldValue<T>(field: string | IModel<T>): T | null {
@@ -84,8 +84,9 @@ export function FieldValue<T>(
 }
 
 /**
- * Subscribe the valid state of a model.
- * Note that it works in FormContext only.
+ * 订阅 `model` 的校验状态
+ *
+ * 当参数是 `Model` 对象时不依赖 `FormContext`，参数是字段名时必须在有 `FormContext` 的环境下使用。
  * @param field
  */
 export function useFieldValid<T>(field: string | IModel<T>): boolean | null {
@@ -94,6 +95,8 @@ export function useFieldValid<T>(field: string | IModel<T>): boolean | null {
 
 /**
  * 根据 `name` 或者 `model` 订阅字段校验状态的更新
+ *
+ * 当参数是 `Model` 对象时不依赖 `FormContext`，参数是字段名时必须在有 `FormContext` 的环境下使用。
  */
 export function FieldValid<T>(
   props: IFieldValidProps<T>

--- a/packages/zent/src/form/formulr/listeners/use-model.ts
+++ b/packages/zent/src/form/formulr/listeners/use-model.ts
@@ -1,16 +1,17 @@
 import { useMemo, useState, useEffect } from 'react';
-import { merge, asapScheduler } from 'rxjs';
-import { observeOn, filter } from 'rxjs/operators';
 import noop from '../../../utils/noop';
 import { IFormContext } from '../context';
+import { getFieldSetChildChangeObservable } from './utils';
 
+// `ctx` 仅在 `name` 存在时才需要
 export function useModelFromContext<Model>(
-  ctx: IFormContext,
+  ctx: IFormContext | null,
   name: string | undefined,
   model: Model | undefined,
   check: (m: any) => m is Model
 ): Model | null {
-  const { parent } = ctx;
+  const { parent } = ctx ?? {};
+
   const m = useMemo(() => {
     if (typeof name === 'string') {
       const m = parent.get(name);
@@ -23,33 +24,23 @@ export function useModelFromContext<Model>(
     }
     return null;
   }, [name, model, check, parent]);
+
   const [maybeModel, setModel] = useState(m);
+
   useEffect(() => {
     if (!name) {
       return noop;
     }
+
     const m = parent.get(name);
     check(m) && setModel(m);
 
-    /**
-     * Because `FieldSetModel.prototype.registerChild` will be
-     * called inside `useMemo`, consume at next micro task queue
-     * to avoid react warning below.
-     *
-     * Cannot update a component from inside the function body
-     * of a different component.
-     */
-    const $ = merge(parent.childRegister$, parent.childRemove$)
-      .pipe(
-        observeOn(asapScheduler),
-        filter(change => change === name)
-      )
-      .subscribe(name => {
-        const candidate = parent.get(name);
-        if (check(candidate)) {
-          setModel(candidate);
-        }
-      });
+    const $ = getFieldSetChildChangeObservable(parent, name).subscribe(name => {
+      const candidate = parent.get(name);
+      if (check(candidate)) {
+        setModel(candidate);
+      }
+    });
     return () => $.unsubscribe();
   }, [name, parent, m, check]);
   return maybeModel;

--- a/packages/zent/src/form/formulr/listeners/utils.ts
+++ b/packages/zent/src/form/formulr/listeners/utils.ts
@@ -1,0 +1,22 @@
+import { asapScheduler, merge } from 'rxjs';
+import { filter, observeOn } from 'rxjs/operators';
+import type { FieldSetModel } from '../models/set';
+
+/**
+ * Because `FieldSetModel.prototype.registerChild` will be
+ * called inside `useMemo`, consume at next micro task queue
+ * to avoid react warning below.
+ *
+ * Cannot update a component from inside the function body
+ * of a different component.
+ */
+export function getFieldSetChildChangeObservable(
+  fieldSet: FieldSetModel,
+  name: string
+) {
+  const $ = merge(fieldSet.childRegister$, fieldSet.childRemove$).pipe(
+    observeOn(asapScheduler),
+    filter(change => change === name)
+  );
+  return $;
+}

--- a/packages/zent/src/form/formulr/models/is.ts
+++ b/packages/zent/src/form/formulr/models/is.ts
@@ -46,3 +46,31 @@ export function isFormModel<Children extends UnknownFieldSetModelChildren>(
 ): maybeModel is FormModel<Children> {
   return !!(maybeModel && maybeModel[FORM_ID]);
 }
+
+export function typeOfModel(model: any) {
+  if (isFieldModel(model)) {
+    return 'FieldModel';
+  }
+
+  if (isFieldArrayModel(model)) {
+    return 'FieldArrayModel';
+  }
+
+  if (isFieldSetModel(model)) {
+    return 'FieldSetModel';
+  }
+
+  if (isFormModel(model)) {
+    return 'FormModel';
+  }
+
+  if (isModelRef(model)) {
+    return 'ModelRef';
+  }
+
+  if (isModel(model)) {
+    return 'BasicModel';
+  }
+
+  return 'unknown';
+}

--- a/packages/zent/src/form/formulr/utils.ts
+++ b/packages/zent/src/form/formulr/utils.ts
@@ -13,7 +13,7 @@ export const id = <T>(it: T) => it;
 export function useDestroyOnUnmount<Model extends BasicModel<any>>(
   field: string | BasicModel<any> | ModelRef<any, any, Model>,
   model: BasicModel<any>,
-  parent: FieldSetModel
+  parent: FieldSetModel | undefined
 ) {
   useEffect(
     () => () => {


### PR DESCRIPTION
1. Allow `Field` and `FieldArray` hooks to be used without form context if using `Model` as argument. `FieldSet` hooks always require a form context.
2. Allow referencing models using names  in `Model` mode, it was only possible in `View` mode.
3. Deprecate `useModelValue` and `useModelValid`, use `useFieldValue` and `useFieldValid` instead.