### PR TITLE
feat: tag 组件支持传递 div 元素上的原生属性

### DIFF
--- a/packages/zent/src/tag/Tag.tsx
+++ b/packages/zent/src/tag/Tag.tsx
@@ -10,7 +10,7 @@ const PRESET_COLOR = {
   grey: true,
 };
 
-export interface ITagProps {
+export interface ITagProps extends React.HTMLAttributes<HTMLDivElement> {
   theme?: keyof typeof PRESET_COLOR;
   outline?: boolean;
   rounded?: boolean;
@@ -18,9 +18,7 @@ export interface ITagProps {
   onClose?: React.MouseEventHandler<HTMLElement>;
   style?: React.CSSProperties;
   closeButtonStyle?: React.CSSProperties;
-  className?: string;
   visible?: boolean;
-  children?: React.ReactNode;
 }
 
 export const Tag = forwardRef<HTMLDivElement, ITagProps>(
@@ -32,10 +30,10 @@ export const Tag = forwardRef<HTMLDivElement, ITagProps>(
       closable,
       children,
       className,
-      style,
       onClose,
       closeButtonStyle,
       visible = true,
+      ...rest
     },
     ref
   ) => {
@@ -56,7 +54,7 @@ export const Tag = forwardRef<HTMLDivElement, ITagProps>(
             'zent-tag-closable': closable,
           }
         )}
-        style={style}
+        {...rest}
       >
         <div className="zent-tag-content">{children}</div>
         {closable ? (


### PR DESCRIPTION
-  添加 Tag 组件对基本元素 div 上的原生属性的支持，以支持其他组件通过 cloneElement 方式注入的 props 属性。例如在  `Pop` 中使用的时候需要透传鼠标处理事件。