### PR TITLE
[bugfix]: 修复DatePicker组件中'当前时间'快捷按钮的禁用逻辑

### DIFF
--- a/packages/zent/assets/date-picker.scss
+++ b/packages/zent/assets/date-picker.scss
@@ -291,7 +291,7 @@
         margin-left: 12px;
       }
 
-      &-current_diabled {
+      &-current_disabled {
         @include gray-color;
       }
     }

--- a/packages/zent/src/date-picker/components/TimePickerBase.tsx
+++ b/packages/zent/src/date-picker/components/TimePickerBase.tsx
@@ -1,5 +1,7 @@
 import { useMemo, useCallback, useRef, useState } from 'react';
 import cx from 'classnames';
+import formatFn from 'date-fns/format';
+import parse from 'date-fns/parse';
 import PickerPopover from './PickerPopover';
 import { SingleInputTrigger } from './PickerTrigger';
 
@@ -72,6 +74,17 @@ const TimePickerBase: React.FC<ITimePickerBaseProps> = ({
     format,
   });
 
+  const currentTime = useMemo(() => formatFn(new Date(), format), [format]);
+  const selectCurrentDate = useMemo(
+    () => parse(currentTime, format, selectedDate),
+    [currentTime, format, selectedDate]
+  );
+  const isDisabledCurrent = useConfirmStatus({
+    selected: currentTime,
+    disabledTimeOption: disabledTime?.(selectCurrentDate) || {},
+    format,
+  });
+
   const onSelected = useCallback(
     (val, finished = false) => {
       setVisibleChange(false);
@@ -137,7 +150,13 @@ const TimePickerBase: React.FC<ITimePickerBaseProps> = ({
 
   return (
     <div className={cx('zent-datepicker', className)}>
-      <PanelContextProvider value={{ visibleChange, confirmStatus }}>
+      <PanelContextProvider
+        value={{
+          visibleChange,
+          confirmStatus,
+          isDisabledCurrent,
+        }}
+      >
         <PickerPopover
           panelVisible={panelVisible}
           onVisibleChange={onVisibleChange}

--- a/packages/zent/src/date-picker/context/PanelContext.ts
+++ b/packages/zent/src/date-picker/context/PanelContext.ts
@@ -9,6 +9,7 @@ export interface IPanelContext {
   // time panel
   visibleChange?: boolean;
   confirmStatus?: boolean;
+  isDisabledCurrent?: boolean;
   disabledTime?: IDisabledTime;
 }
 

--- a/packages/zent/src/date-picker/panels/date-panel/DateFooter.tsx
+++ b/packages/zent/src/date-picker/panels/date-panel/DateFooter.tsx
@@ -34,6 +34,12 @@ const DatePickerFooter: React.FC<IDatePickerFooterProps> = ({
     disabledTimeOption: (selected && disabledTime?.(selected)) || {},
     format,
   });
+
+  const isDisabledCurrent = useConfirmStatus({
+    selected: formatDate(format, today),
+    disabledTimeOption: disabledTime?.(today) || {},
+    format,
+  });
   const isDisableConfirm = useMemo(
     () => selected && disabledPanelDate(selected),
     [selected, disabledPanelDate]
@@ -42,9 +48,9 @@ const DatePickerFooter: React.FC<IDatePickerFooterProps> = ({
     disabledPanelDate,
   ]);
   const onClickCurrent = useCallback(() => {
-    if (isDisabledToday) return;
+    if (isDisabledCurrent || isDisabledToday) return;
     onSelected(new Date());
-  }, [isDisabledToday, onSelected]);
+  }, [isDisabledToday, isDisabledCurrent, onSelected]);
 
   const confirmHandler = useCallback(() => {
     selected && onSelected(selected);
@@ -69,7 +75,8 @@ const DatePickerFooter: React.FC<IDatePickerFooterProps> = ({
       <div>
         <a
           className={cx({
-            [`${footerPrefixCls}-current_diabled`]: isDisabledToday,
+            [`${footerPrefixCls}-current_disabled`]:
+              isDisabledCurrent || isDisabledToday,
           })}
           onClick={onClickCurrent}
         >
@@ -95,6 +102,7 @@ const DatePickerFooter: React.FC<IDatePickerFooterProps> = ({
     confirmStatus,
     isDisableConfirm,
     isDisabledToday,
+    isDisabledCurrent,
     confirmBtn,
     onClickCurrent,
   ]);

--- a/packages/zent/src/date-picker/panels/time-panel/TimeFooter.tsx
+++ b/packages/zent/src/date-picker/panels/time-panel/TimeFooter.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useContext, useMemo } from 'react';
+import cx from 'classnames';
 
 import PanelFooter from '../../components/PanelFooter';
 import Button from '../../../button';
@@ -13,15 +14,25 @@ const TimePickerFooter: React.FC<ITimePanelProps> = ({
   format,
 }) => {
   const { i18n } = useContext(PickerContext);
-  const { confirmStatus } = useContext(PanelContext);
+  const { confirmStatus, isDisabledCurrent } = useContext(PanelContext);
 
   const onClickCurrent = useCallback(() => {
+    if (isDisabledCurrent) return;
     onSelected(formatDate(format, new Date()), true);
-  }, [format, onSelected]);
+  }, [format, isDisabledCurrent, onSelected]);
 
   const renderToday = useMemo(() => {
-    return <a onClick={onClickCurrent}>{i18n.current.time}</a>;
-  }, [i18n, onClickCurrent]);
+    return (
+      <a
+        className={cx({
+          ['zent-datepicker-panel-footer-current_disabled']: isDisabledCurrent,
+        })}
+        onClick={onClickCurrent}
+      >
+        {i18n.current.time}
+      </a>
+    );
+  }, [i18n, isDisabledCurrent, onClickCurrent]);
 
   const confirmNode = useMemo(
     () => (


### PR DESCRIPTION
`DatePicker`

- 修复组件面板底部的 '当前时间' 快捷按钮的禁用逻辑

