### PR TITLE
fix: 当select初始化样式display为none，再显示时triggerWidth为0

### DIFF
--- a/packages/zent/src/select/Select.tsx
+++ b/packages/zent/src/select/Select.tsx
@@ -15,7 +15,6 @@ import { I18nReceiver as Receiver, II18nLocaleSelect } from '../i18n';
 import memoize from '../utils/memorize-one';
 import uniqueId from '../utils/uniqueId';
 import { filterReviver, reviveSelectItem } from './reviver';
-import { typeOf } from 'react-is';
 
 export interface ISelectItem<Key extends string | number = string | number> {
   key: Key;

--- a/packages/zent/src/select/Select.tsx
+++ b/packages/zent/src/select/Select.tsx
@@ -310,7 +310,8 @@ export class Select<
       return;
     }
 
-    const triggerWidth = this.triggerRef.current?.offsetWidth;
+    const triggerWidth =
+      this.triggerRef.current?.offsetWidth || this.props.width;
     this.setState({
       triggerWidth,
     });

--- a/packages/zent/src/select/Select.tsx
+++ b/packages/zent/src/select/Select.tsx
@@ -15,6 +15,7 @@ import { I18nReceiver as Receiver, II18nLocaleSelect } from '../i18n';
 import memoize from '../utils/memorize-one';
 import uniqueId from '../utils/uniqueId';
 import { filterReviver, reviveSelectItem } from './reviver';
+import { typeOf } from 'react-is';
 
 export interface ISelectItem<Key extends string | number = string | number> {
   key: Key;
@@ -311,7 +312,10 @@ export class Select<
     }
 
     const triggerWidth =
-      this.triggerRef.current?.offsetWidth || this.props.width;
+      this.triggerRef.current?.offsetWidth ||
+      typeof this.props.width === 'number'
+        ? this.props.width
+        : Select.defaultProps.width;
     this.setState({
       triggerWidth,
     });

--- a/packages/zent/src/select/Select.tsx
+++ b/packages/zent/src/select/Select.tsx
@@ -214,6 +214,8 @@ function defaultIsValidNewOption<Key extends string | number = string | number>(
 // 允许创建的临时 key
 const SELECT_CREATABLE_KEY = uniqueId('__ZENT_SELECT_CREATABLE_KEY__');
 
+const DEFAULT_TRIGGER_WIDTH = 240;
+
 export class Select<
   Key extends string | number = string | number,
   Item extends ISelectItem<Key> = ISelectItem<Key>
@@ -224,7 +226,7 @@ export class Select<
     filter: defaultFilter,
     isValidNewOption: defaultIsValidNewOption,
     highlight: defaultHighlight,
-    width: 240,
+    width: DEFAULT_TRIGGER_WIDTH,
     multiple: false,
     clearable: false,
     loading: false,
@@ -314,7 +316,7 @@ export class Select<
       this.triggerRef.current?.offsetWidth ||
       typeof this.props.width === 'number'
         ? this.props.width
-        : Select.defaultProps.width;
+        : DEFAULT_TRIGGER_WIDTH;
     this.setState({
       triggerWidth,
     });


### PR DESCRIPTION
fix: 当select初始化样式display为none，再显示时triggerWidth为0