### PR TITLE
fix: 修复缩小或放大浏览器时，图片没有设置no-repeat造成有小白点漏出

### DIFF
--- a/packages/zent/assets/checkbox.scss
+++ b/packages/zent/assets/checkbox.scss
@@ -93,6 +93,7 @@ $size: 16px;
     left: 2px;
     width: 10px;
     height: 8px;
+    background-repeat: no-repeat;
     background-size: contain;
     transform: scale(0);
     transition: all 0.12s ease-in-out;


### PR DESCRIPTION
- 修复缩小或放大浏览器时，图片没有设置no-repeat造成有小白点漏出
![image](https://user-images.githubusercontent.com/20199768/125932650-ccd5a3fa-cedd-4f11-aee1-be0a1191fefd.png)
