### PR TITLE
prefix all css classnames in Tree

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,5 +1,5 @@
 {
-  "*.js": ["yarn format", "eslint"],
+  "*.{js,jsx}": ["yarn format", "eslint"],
   "packages/zent/src/**/*.{ts,tsx}": ["yarn format", "eslint"],
   "packages/zent/scripts/cruiser/**/*.{ts,tsx}": ["yarn format", "eslint"],
   "site/**/*.scss": ["yarn format", "stylelint"],

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,7 +1,4 @@
 {
-  "*.{js,jsx}": ["yarn format", "eslint"],
-  "packages/zent/src/**/*.{ts,tsx}": ["yarn format", "eslint"],
-  "packages/zent/scripts/cruiser/**/*.{ts,tsx}": ["yarn format", "eslint"],
-  "site/**/*.scss": ["yarn format", "stylelint"],
-  "packages/zent/**/*.scss": ["yarn format", "stylelint"]
+  "*.{js,jsx,ts,tsx}": ["yarn format", "eslint"],
+  "*.scss": ["yarn format", "stylelint"]
 }

--- a/packages/zent/__tests__/tree.spec.jsx
+++ b/packages/zent/__tests__/tree.spec.jsx
@@ -581,7 +581,7 @@ describe('new Tree', () => {
     expect(onSelectMock.mock.calls.length).toBe(1);
   });
 
-  it('Tree will keep child state after their ancestor folded', () => {
+  it('Tree will keep child state after its ancestor folded', () => {
     const data = [
       {
         id: 1,

--- a/packages/zent/__tests__/tree.spec.jsx
+++ b/packages/zent/__tests__/tree.spec.jsx
@@ -124,7 +124,7 @@ describe('new Tree', () => {
     expect(wrapper.find('li').at(0).childAt(1).childAt(0).type()).toBe('ul');
     const example = wrapper.find('li').at(0).childAt(0);
     expect(example.hasClass('zent-tree-bar')).toBe(true);
-    expect(example.hasClass('off')).toBe(true);
+    expect(example.hasClass('zent-tree-bar--off')).toBe(true);
     expect(example.children().length).toBe(2);
     expect(example.childAt(0).type()).toBe('i');
     expect(example.childAt(1).type()).toBe('div');
@@ -172,7 +172,7 @@ describe('new Tree', () => {
      */
     const example = wrapper.find('li').at(2).childAt(0);
     expect(example.hasClass('zent-tree-bar')).toBe(true);
-    expect(example.hasClass('off')).toBe(true);
+    expect(example.hasClass('zent-tree-bar--off')).toBe(true);
     expect(example.children().length).toBe(1);
     expect(example.childAt(0).type()).toBe('div');
     expect(example.childAt(0).hasClass('zent-tree-node')).toBe(true);
@@ -245,7 +245,7 @@ describe('new Tree', () => {
     expect(wrapper.find('li').at(0).childAt(1).type()).toBe(AnimateHeight);
     const example = wrapper.find('li').at(0).childAt(0);
     expect(example.hasClass('zent-tree-bar')).toBe(true);
-    expect(example.hasClass('off')).toBe(true);
+    expect(example.hasClass('zent-tree-bar--off')).toBe(true);
     expect(example.children().length).toBe(2);
     expect(example.childAt(0).type()).toBe('i');
     expect(example.childAt(1).type()).toBe('div');
@@ -330,11 +330,11 @@ describe('new Tree', () => {
       .at(0)
       .simulate('click', { currentTarget: { classList: [] } });
     wrapper
-      .find('.content')
+      .find('.zent-tree-content')
       .at(0)
       .simulate('click', { currentTarget: { classList: [] } });
 
-    expect(wrapper.find('off').length).toBe(0);
+    expect(wrapper.find('zent-tree-bar--off').length).toBe(0);
     expect(onExpandMock.mock.calls.length).toBe(0);
     expect(onSelectMock.mock.calls.length).toBe(1);
   });
@@ -482,25 +482,27 @@ describe('new Tree', () => {
     expect(sonSpan.text()).toBe('son');
     expect(grandSonSpan.text()).toBe('grandSon');
     expect(daughterSpan.text()).toBe('daughter');
-    expect(rootSpan.closest('.zent-tree-bar').hasClass('off')).toBe(true);
+    expect(
+      rootSpan.closest('.zent-tree-bar').hasClass('zent-tree-bar--off')
+    ).toBe(true);
     rootSpan.simulate('click');
     // jest.runAllTimers();
 
     // NOTE: jest and enzyme couldn't simulate switcher.click()
-    // expect(rootSpan.closest('.zent-tree-bar').hasClass('off')).toBe(true);
+    // expect(rootSpan.closest('.zent-tree-bar').hasClass('zent-tree-bar--off')).toBe(true);
     // const iconRoot = wrapper.find('i').at(0);
     // iconRoot.simulate('click');
     // jest.runAllTimers();
-    // expect(rootSpan.closest('.zent-tree-bar').hasClass('off')).toBe(false);
+    // expect(rootSpan.closest('.zent-tree-bar').hasClass('zent-tree-bar--off')).toBe(false);
     // iconRoot.simulate('click');
     // jest.runAllTimers();
-    // expect(rootSpan.closest('.zent-tree-bar').hasClass('off')).toBe(true);
+    // expect(rootSpan.closest('.zent-tree-bar').hasClass('zent-tree-bar--off')).toBe(true);
     // expect(
     //   rootSpan.closest('.zent-tree-bar').getNode().nextSibling.style.display
     // ).toBe('none');
     // iconRoot.simulate('click');
     // jest.runAllTimers();
-    // expect(rootSpan.closest('.zent-tree-bar').hasClass('off')).toBe(false);
+    // expect(rootSpan.closest('.zent-tree-bar').hasClass('zent-tree-bar--off')).toBe(false);
     // expect(
     //   rootSpan.closest('.zent-tree-bar').getNode().nextSibling.style.display
     // ).toBe('block');
@@ -564,14 +566,18 @@ describe('new Tree', () => {
       />
     );
 
-    wrapper.find('.content').at(0).simulate('click');
-    expect(wrapper.find('.zent-tree-bar').at(0).hasClass('off')).toBe(true);
+    wrapper.find('.zent-tree-content').at(0).simulate('click');
+    expect(
+      wrapper.find('.zent-tree-bar').at(0).hasClass('zent-tree-bar--off')
+    ).toBe(true);
     expect(onExpandMock.mock.calls.length).toBe(0);
     expect(onSelectMock.mock.calls.length).toBe(1);
 
-    wrapper.find('i').at(0).simulate('click');
-    expect(wrapper.find('.zent-tree-bar').at(0).hasClass('off')).toBe(false);
-    expect(onExpandMock.mock.calls.length).toBe(1);
+    wrapper.find('.zent-tree-switcher').at(0).simulate('click');
+    expect(
+      wrapper.find('.zent-tree-bar').at(0).hasClass('zent-tree-bar--off')
+    ).toBe(true);
+    expect(onExpandMock.mock.calls.length).toBe(0);
     expect(onSelectMock.mock.calls.length).toBe(1);
   });
 
@@ -606,13 +612,13 @@ describe('new Tree', () => {
 
     iconRoot.simulate('click');
     // jest.runAllTimers();
-    // expect(rootSpan.closest('.zent-tree-bar').hasClass('off')).toBe(false);
+    // expect(rootSpan.closest('.zent-tree-bar').hasClass('zent-tree-bar--off')).toBe(false);
     // expect(
     //   rootSpan.closest('.zent-tree-bar').getNode().nextSibling.style.display
     // ).not.toBe('none');
     // iconSon.simulate('click');
     // jest.runAllTimers();
-    // expect(sonSpan.closest('.zent-tree-bar').hasClass('off')).toBe(false);
+    // expect(sonSpan.closest('.zent-tree-bar').hasClass('zent-tree-bar--off')).toBe(false);
     // expect(
     //   sonSpan.closest('.zent-tree-bar').getNode().nextSibling.style.display
     // ).not.toBe('none');
@@ -620,7 +626,7 @@ describe('new Tree', () => {
     // jest.runAllTimers();
     // // iconRoot.simulate('click');
     // // jest.runAllTimers();
-    // expect(sonSpan.closest('.zent-tree-bar').hasClass('off')).toBe(false);
+    // expect(sonSpan.closest('.zent-tree-bar').hasClass('zent-tree-bar--off')).toBe(false);
     // expect(
     //   sonSpan.closest('.zent-tree-bar').getNode().nextSibling.style.display
     // ).not.toBe('none');
@@ -760,9 +766,9 @@ describe('new Tree', () => {
     holdWrapper.find('i').at(1).simulate('click');
     holdWrapper.update();
     expect(holdWrapper.state().expandNode).toEqual([2, 1]);
-    expect(holdWrapper.find('.zent-tree-bar').at(0).hasClass('off')).toBe(
-      false
-    );
+    expect(
+      holdWrapper.find('.zent-tree-bar').at(0).hasClass('zent-tree-bar--off')
+    ).toBe(false);
 
     done();
   });
@@ -1038,14 +1044,36 @@ describe('new Tree', () => {
       },
     ];
     const wrapper = mount(<NewTree data={data} operations={operations} />);
-    expect(wrapper.find('.operation').length).toBe(2);
-    expect(wrapper.find('.operation').at(0).find('span').length).toBe(1);
-    expect(wrapper.find('.operation').at(0).find('.foo').length).toBe(1);
-    expect(wrapper.find('.operation').at(0).find('.bar').length).toBe(0);
-    expect(wrapper.find('.operation').at(1).find('span').length).toBe(2);
-    wrapper.find('.operation').at(0).find('span').simulate('click');
-    wrapper.find('.operation').at(1).find('span').at(0).simulate('click');
-    wrapper.find('.operation').at(1).find('span').at(1).simulate('click');
+    expect(wrapper.find('.zent-tree-operation-container').length).toBe(2);
+    expect(
+      wrapper.find('.zent-tree-operation-container').at(0).find('span').length
+    ).toBe(1);
+    expect(
+      wrapper.find('.zent-tree-operation-container').at(0).find('.foo').length
+    ).toBe(1);
+    expect(
+      wrapper.find('.zent-tree-operation-container').at(0).find('.bar').length
+    ).toBe(0);
+    expect(
+      wrapper.find('.zent-tree-operation-container').at(1).find('span').length
+    ).toBe(2);
+    wrapper
+      .find('.zent-tree-operation-container')
+      .at(0)
+      .find('span')
+      .simulate('click');
+    wrapper
+      .find('.zent-tree-operation-container')
+      .at(1)
+      .find('span')
+      .at(0)
+      .simulate('click');
+    wrapper
+      .find('.zent-tree-operation-container')
+      .at(1)
+      .find('span')
+      .at(1)
+      .simulate('click');
     expect(actionMockClone.mock.calls.length).toBe(2);
     expect(actionMockDelete.mock.calls.length).toBe(1);
 

--- a/packages/zent/assets/tree.scss
+++ b/packages/zent/assets/tree.scss
@@ -50,7 +50,7 @@
   font-size: $font-size-large;
 
   .zent-tree-bar {
-    .switcher {
+    .zent-tree-switcher {
       line-height: 20px;
 
       &:after {
@@ -66,7 +66,7 @@
   font-size: $font-size-small;
 
   .zent-tree-bar {
-    .switcher {
+    .zent-tree-switcher {
       line-height: 12px;
 
       &:after {
@@ -81,7 +81,7 @@
 .zent-tree-bar {
   position: relative;
 
-  .switcher {
+  .zent-tree-switcher {
     position: absolute;
     top: 2px;
     left: -18px;
@@ -107,8 +107,8 @@
     }
   }
 
-  &.off {
-    .switcher {
+  &.zent-tree-bar--off {
+    .zent-tree-switcher {
       &:after {
         transform: rotate(0deg);
       }
@@ -120,7 +120,7 @@
     line-height: 1.42857143;
     cursor: pointer;
 
-    .content {
+    .zent-tree-content {
       margin-left: -4px;
       padding: 0 4px;
       display: inline-block;
@@ -134,7 +134,7 @@
       }
     }
 
-    .operation {
+    .zent-tree-operation-container {
       display: inline-block;
       margin-left: 10px;
       opacity: 0;
@@ -142,13 +142,19 @@
       transition: opacity 0.3s ease-in;
       @include theme-color(color, stroke, 1);
 
-      & > span.opt:not(:last-of-type) {
+      & > span.zent-tree-operation:not(:last-of-type) {
         @include theme-color(border-left-color, stroke, 6);
         margin-right: 8px;
         padding-right: 8px;
         border-left-width: 2px;
         border-left-style: solid;
       }
+    }
+  }
+
+  &:hover {
+    .zent-tree-node .zent-tree-operation-container {
+      opacity: 1;
     }
   }
 

--- a/packages/zent/src/preview-image/README_en-US.md
+++ b/packages/zent/src/preview-image/README_en-US.md
@@ -1,5 +1,5 @@
 ---
-title: PreviewImage
+title: previewImage
 path: component/preview-image
 group: Data Display
 ---

--- a/packages/zent/src/preview-image/README_zh-CN.md
+++ b/packages/zent/src/preview-image/README_zh-CN.md
@@ -1,5 +1,5 @@
 ---
-title: PreviewImage
+title: previewImage
 subtitle: 图片预览
 path: component/preview-image
 group: 展示

--- a/packages/zent/src/tree/Tree.tsx
+++ b/packages/zent/src/tree/Tree.tsx
@@ -283,7 +283,7 @@ export class Tree extends Component<ITreeProps, ITreeState> {
   renderSwitcher(root: ITreeData) {
     return (
       <i
-        className="switcher"
+        className="zent-tree-switcher"
         onClick={e => {
           this.handleExpandClick(root, e);
         }}
@@ -299,7 +299,7 @@ export class Tree extends Component<ITreeProps, ITreeState> {
     const { render, onSelect } = this.props;
     return (
       <span
-        className="content"
+        className="zent-tree-content"
         onClick={e => {
           onSelect && onSelect(root, e.currentTarget);
 
@@ -355,7 +355,7 @@ export class Tree extends Component<ITreeProps, ITreeState> {
             <span
               key={`${opt.name}-${root[id]}`}
               onClick={opt.action.bind(null, root, isExpanded)}
-              className="opt"
+              className="zent-tree-operation"
             >
               {typeof opt.icon === 'string' ? (
                 <i className={opt.icon} />
@@ -367,7 +367,7 @@ export class Tree extends Component<ITreeProps, ITreeState> {
           )
         );
       });
-      return <div className="operation">{optNodes}</div>;
+      return <div className="zent-tree-operation-container">{optNodes}</div>;
     }
 
     return null;
@@ -385,7 +385,7 @@ export class Tree extends Component<ITreeProps, ITreeState> {
         const rootId = root[id];
         const isShowChildren = expandNode.indexOf(rootId) > -1;
         const barClassName = classnames('zent-tree-bar', {
-          off: !isShowChildren,
+          'zent-tree-bar--off': !isShowChildren,
         });
 
         return (


### PR DESCRIPTION
CSS class names affected:
```
switcher => zent-tree-switcher
content => zent-tree-content
opt => zent-tree-operation
operation => zent-tree-operation-container
off => zent-tree-bar--off
```

Fixes #1748 