### PR TITLE
fix typos

### DIFF
--- a/packages/zent/src/clamp-lines/ClampLines.tsx
+++ b/packages/zent/src/clamp-lines/ClampLines.tsx
@@ -166,9 +166,9 @@ export class ClampLines extends Component<IClampLinesProps, IClampLinesState> {
    *
    * Note:
    *
-   * Maually setting result string to DOM before return is required, because sometimes
+   * Manually setting result string to DOM before return is required, because sometimes
    * the `setState` just before return won't actually cause a re-render since
-   * there will cases when `props.text` changed but `state.text` remains the same as previous render.
+   * there will be cases when `props.text` changed but `state.text` remains the same as previous render.
    */
   private _clampLinesFast() {
     const { text } = this.props;
@@ -197,7 +197,7 @@ export class ClampLines extends Component<IClampLinesProps, IClampLinesState> {
     const chars = Array.from(text);
 
     // binary search to find suitable text size
-    // this is a variant to find the `rightmost` index satisfing the condition
+    // this is a variant to find the `rightmost` index satisfying the condition
     let start = 0;
     let middle = 0;
     let end = chars.length;
@@ -213,7 +213,7 @@ export class ClampLines extends Component<IClampLinesProps, IClampLinesState> {
       }
     }
 
-    // The rightmost character satisfing height <= maxHeight is at `end - 1`
+    // The rightmost character satisfying height <= maxHeight is at `end - 1`
     const overflowIndex = end - 1;
     const textSuited = slice(chars, 0, overflowIndex) + this.getEllipsis();
     this.innerElement.current.textContent = textSuited;
@@ -227,11 +227,11 @@ export class ClampLines extends Component<IClampLinesProps, IClampLinesState> {
    * This algorithm does not rely on the assumption that each line has same height.
    * But it might be slow because its time complexity is proportional to text length and lines.
    *
-   * It works by finding wrapping point(the postion where a line wrap happens) one by one.
+   * It works by finding wrapping point(the position where a line wrap happens) one by one.
    *
    * Note:
    *
-   * Maually setting result string to DOM before return is required, because sometimes
+   * Manually setting result string to DOM before return is required, because sometimes
    * the `setState` just before return won't actually cause a re-render since
    * there will cases when `props.text` changed but `state.text` remains the same as previous render.
    */

--- a/packages/zent/src/form/README_zh-CN.md
+++ b/packages/zent/src/form/README_zh-CN.md
@@ -98,7 +98,7 @@ validator 和 builder 下文会详细说明。
 - `form.isSubmitting` 表单是否在提交中。
 - `form.isSubmitFailed` 表单上一次提交是否失败。
 - `form.isSubmitSucceeded` 表单上一次提交是否成功。
-- `form.validate()` 触发一次表单校验。
+- `form.validate(options?: ValidateOption)` 触发一次表单校验。
 - `form.isValid()` 表单是否通过校验，不会自动触发 `form.validate`。
 - `form.isValidating()` 表单是否正在校验过程中。
 - `form.model` 获取表单对应的 model 对象。
@@ -270,7 +270,7 @@ type SyncValidator<T> = (value: T, ctx: ValidatorContext<T>) => IMaybeError<T>;
 
 校验选项是一个 `BitSet`，在自定义表单组件中，使用 `Model` 上的 `validate` 方法进行校验时，使用 `|` 运算符联合所需的选项作为参数传入即可。
 
-不传参数调用 `form.validate()` 等价于 `form.validate(ValidateOption.Default | ValidateOption.IncludeChildrenRecursively)`。如果调用 `form.validate` 时手动指定校验选项的话需要自行设置需要的所有选项，包括默认的两个选项。
+不传参数调用 `form.validate()` 等价于 `form.validate(ValidateOption.Default)`。
 
 <!-- demo-slot-16 -->
 


### PR DESCRIPTION
1. Comment typos in `ClampLines`
2. Doc typos in `Form`