### PR TITLE
fix InfiniteScroller loadMore not triggered when page is zoomed in

### DIFF
--- a/packages/zent/package.json
+++ b/packages/zent/package.json
@@ -79,6 +79,7 @@
     "cssnano": "^5.0.6",
     "cheerio": "^1.0.0-rc.10",
     "enzyme": "^3.11.0",
+    "glob": "^7.1.7",
     "jest": "^27.0.6",
     "postcss-cli": "^8.3.1",
     "postcss-selector-parser": "^6.0.2",

--- a/packages/zent/scripts/check-deadlink.js
+++ b/packages/zent/scripts/check-deadlink.js
@@ -3,11 +3,13 @@ const fs = require('fs').promises;
 const https = require('https');
 const { URL } = require('url');
 const cheerio = require('cheerio');
+const glob = require('glob');
 const { exit } = require('process');
 
-const FILES = ['src/form/README_zh-CN.md', 'src/form/README_en-US.md'].map(f =>
-  path.resolve(__dirname, '..', f)
-);
+const FILES = glob.sync('**/*.md', {
+  cwd: path.resolve(__dirname, '../src'),
+  absolute: true,
+});
 
 const APIDOC_REGEXP = /[./]+\/(apidoc\/.+?|apidoc\/?)\)/g;
 

--- a/packages/zent/src/form/demos/13.interact.md
+++ b/packages/zent/src/form/demos/13.interact.md
@@ -5,13 +5,15 @@ zh-CN:
 	noLimit: 不限制
 	limit: 限制
 	count: 次
-	message: 次数限制不能为0.
+	message: 次数限制不能为0
+	submit: 提交
 en-US:
 	title: Fields interact
 	noLimit: Not limited
 	limit: Limit 
 	count: times.
-	message: Count limit should not be zero.
+	message: Count limit should not be zero
+	submit: Submit
 ---
 
 ```jsx
@@ -82,7 +84,6 @@ function Limit() {
 
 function App() {
 	const form = Form.useForm(FormStrategy.View);
-	const submit = useCallback(() => form.submit(), []);
 	const onSubmit = useCallback(() => {
 		console.log('onSubmit');
 		return Promise.resolve();
@@ -93,8 +94,8 @@ function App() {
 				<Limit />
 			</FieldSet>
 			<div>
-				<Button onClick={submit} style={{ marginTop: 16 }}>
-					Submit
+				<Button htmlType="submit" style={{ marginTop: 16 }}>
+					{i18n.submit}
 				</Button>
 			</div>
 		</Form>

--- a/packages/zent/src/infinite-scroller/InfiniteScroller.tsx
+++ b/packages/zent/src/infinite-scroller/InfiniteScroller.tsx
@@ -33,7 +33,7 @@ export const InfiniteScroller = forwardRef<
       skipLoadOnMount = false,
       useWindow = false,
       loader = DEFAULT_LOADER,
-      threshold = 0,
+      threshold = 1,
       className,
       children,
     },

--- a/packages/zent/src/infinite-scroller/README_en-US.md
+++ b/packages/zent/src/infinite-scroller/README_en-US.md
@@ -21,7 +21,7 @@ Infinite scrolling widget
 | skipLoadOnMount | Don't trigger a loading on mount    | `boolean`                                                         | `false`        | `true`      |
 | useWindow       | Use `window` as scrolling container | `boolean`                                                         | `false`        | `true`      |
 | loader          | Loading content                     | `ReactNode`                                                       | `BlockLoading` |             |
-| threshold | The distance in pixels before the end of the items that will trigger a call to loadMore | `number` | 0 |   |
+| threshold | The distance in pixels before the end of the items that will trigger a call to loadMore | `number` | 1 |   |
 | className       | Custom class name                   | `string`                                                          |                |             |
 
 ### loadMore

--- a/packages/zent/src/infinite-scroller/README_zh-CN.md
+++ b/packages/zent/src/infinite-scroller/README_zh-CN.md
@@ -22,7 +22,7 @@ group: 展示
 | skipLoadOnMount | 初始化时是否触发一次数据加载                                            | `boolean`                                                         | `false`        | `true`  |
 | useWindow       | 是否使用 `window` 作为滚动容器                                          | `boolean`                                                         | `false`        | `true`  |
 | loader          | 加载时显示的内容                                                        | `ReactNode`                                                       | `BlockLoading` |         |
-| threshold | 触发 `loadMore` 时距离列表末尾的距离 | `number` | `0` |   |
+| threshold | 触发 `loadMore` 时距离列表末尾的距离 | `number` | `1` |   |
 | className       | 自定义额外类名                                                          | `string`                                                          |                |         |
 
 ### loadMore

--- a/packages/zent/src/waypoint/README_en-US.md
+++ b/packages/zent/src/waypoint/README_en-US.md
@@ -28,9 +28,9 @@ Invoke a callback when scrolling to some DOM node, can be used in any scrolling 
 | fireOnRapidScroll  | Trigger `onEnter` and `onLeave` on rapid scroll                                           | `boolean`                               | No       | `true`  |             |
 | children           | Element to track, you can think of the waypoint as a line across the container if omitted | `ReactNode`                             | No       |         |             |
 
-**Notes**
+### FAQs
 
-- [Definition of `IWaypointCallbackData`](../../apidoc/interfaces/iwaypointcallbackdata.html).
+- [Definition of `IWaypointCallbackData`](../../apidoc/interfaces/IWaypointCallbackData.html).
 - A rapid scroll is when you scroll the page fast enough, the tracking element leaves the viewport immediately after it enters the viewport.
 - `topOffset` and `bottomOffset` can be positive or negative just like `margin`. Positive value pushes the boundaries inward the page, and negative value pushes boundaries outward the page.
 - You can use percentage value in `topOffset` and `bottomOffset`, relative to its scrolling container.

--- a/packages/zent/src/waypoint/README_zh-CN.md
+++ b/packages/zent/src/waypoint/README_zh-CN.md
@@ -29,9 +29,9 @@ group: 基础
 | fireOnRapidScroll  | 当快速滚动时是否触发 `onEnter` 和 `onLeave`                   | `boolean`                               | 否       | `true`  |        |
 | children           | 待追踪的元素，不传时可以认为是追踪屏幕内一条线                | `ReactNode`                             | 否       |         |        |
 
-**几点说明**
+### FAQs
 
-- [`IWaypointCallbackData` 的定义](../../apidoc/interfaces/iwaypointcallbackdata.html)
+- [`IWaypointCallbackData` 的定义](../../apidoc/interfaces/IWaypointCallbackData.html)
 - 快速滚动顾名思义就是滚动速度非常快，元素可能进入屏幕后立刻又出了屏幕
 - `topOffset` 和 `bottomOffset` 可正可负，正负数效果和 `margin` 一样，正数往屏幕内偏移，负数往屏幕外偏移
 - `topOffset` 和 `bottomOffset` 可以是一个百分比，这个百分比是相对滚动容器大小的

--- a/packages/zent/src/waypoint/Waypoint.tsx
+++ b/packages/zent/src/waypoint/Waypoint.tsx
@@ -163,7 +163,7 @@ export class Waypoint extends PureComponent<IWaypointProps> {
 
   /**
    * @param event the native scroll event coming from the scrollable
-   *   ancestor, or resize event coming from the window. Will be undefined if
+   *   ancestor, or resize event coming from the window. Will be null if
    *   called by a React life cycle method
    */
   private handleScroll = (event: Event | null) => {
@@ -252,10 +252,9 @@ export class Waypoint extends PureComponent<IWaypointProps> {
       contextScrollTop = 0;
     } else {
       const node = this.scrollableAncestor as HTMLElement;
-      contextHeight = horizontal ? node.offsetWidth : node.offsetHeight;
-      contextScrollTop = horizontal
-        ? node.getBoundingClientRect().left
-        : node.getBoundingClientRect().top;
+      const boundingBox = node.getBoundingClientRect();
+      contextHeight = horizontal ? boundingBox.width : boundingBox.height;
+      contextScrollTop = horizontal ? boundingBox.left : boundingBox.top;
     }
 
     const { bottomOffset, topOffset } = this.props;
@@ -264,10 +263,10 @@ export class Waypoint extends PureComponent<IWaypointProps> {
     const contextBottom = contextScrollTop + contextHeight;
 
     return {
-      waypointTop,
-      waypointBottom,
-      viewportTop: contextScrollTop + topOffsetPx,
-      viewportBottom: contextBottom - bottomOffsetPx,
+      waypointTop: Math.round(waypointTop),
+      waypointBottom: Math.round(waypointBottom),
+      viewportTop: Math.round(contextScrollTop + topOffsetPx),
+      viewportBottom: Math.round(contextBottom - bottomOffsetPx),
     };
   }
 


### PR DESCRIPTION
- Adjust `threshold` default value from 0 to 1 in InfiniteScroller. This should fix `loadMore` not triggered when page in zoomed in in most cases.
- Dead link checking now covers all markdown files in `packages/zent/src`
- Replace usage of `offsetWidth`/`offsetHeight` with `getBoundingClientRect` in `Waypoint` to avoid mixing rendered size and layout size. https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model/Determining_the_dimensions_of_elements 