### PR TITLE
add auto mode for topOffset and bottomOffset in Waypoint

### DIFF
--- a/packages/zent/src/waypoint/README_en-US.md
+++ b/packages/zent/src/waypoint/README_en-US.md
@@ -21,18 +21,22 @@ Invoke a callback when scrolling to some DOM node, can be used in any scrolling 
 | onEnter            | Callback when element enters viewport                                                     | `(data: IWaypointCallbackData) => void` | No       |         |             |
 | onLeave            | Callback when element leaves viewport                                                     | `(data: IWaypointCallbackData) => void` | No       |         |             |
 | onPositionChange   | Callback when element position changes                                                    | `(data: IWaypointCallbackData) => void` | No       |         |             |
-| topOffset          | Offset to scrolling container top                                                         | `number` \| `string`                    | No       | `0px`   |             |
-| bottomOffset       | Offset to scrolling container bottom                                                      | `number` \| `string`                    | No       | `0px`   |             |
+| topOffset          | Offset to scrolling container top                                                         | `number` \| `'auto'` \| `string`                    | No       | `0px`   |             |
+| bottomOffset       | Offset to scrolling container bottom                                                      | `number` \| `'auto'` \| `string`                    | No       | `0px`   |             |
 | horizontal         | Use horizontal scroll                                                                     | `boolean`                               | No       | `false` | `true`      |
 | scrollableAncestor | Specify a scrolling container DOM node                                                    | `Element`                               | No       |         |             |
 | fireOnRapidScroll  | Trigger `onEnter` and `onLeave` on rapid scroll                                           | `boolean`                               | No       | `true`  |             |
 | children           | Element to track, you can think of the waypoint as a line across the container if omitted | `ReactNode`                             | No       |         |             |
 
+#### `topOffset` and `bottomOffset`
+- Scroll container's [scroll area](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model/Determining_the_dimensions_of_elements#what.27s_the_size_of_the_displayed_content.3f) is `clientWidth`✖️`clientHeight`, but `getBoundingClientRect` returns `width` and `height` with `border` included. You need to set `topOffset` and `bottomOffset` if your scroll container has borders.
+- `topOffset` and `bottomOffset` can be positive or negative just like `margin`. Positive value pushes the boundaries inward the page, and negative value pushes boundaries outward the page.
+- You can use percentage value in `topOffset` and `bottomOffset`, relative to its scrolling container.
+- If `horizontal` is on, `topOffset` becomes `leftOffset`, and `bottomOffset` becomes `rightOffset`. Names are kept the same for simplicity's sake.
+- `topOffset` and `bottomOffset` can be set to `'auto'`, `Waypoint` will infer scroll container's border width and fall back to `0` if infer fails. Don't use `transform` on scroll container with `'auto'`.
+
 ### FAQs
 
 - [Definition of `IWaypointCallbackData`](../../apidoc/interfaces/IWaypointCallbackData.html).
 - A rapid scroll is when you scroll the page fast enough, the tracking element leaves the viewport immediately after it enters the viewport.
-- `topOffset` and `bottomOffset` can be positive or negative just like `margin`. Positive value pushes the boundaries inward the page, and negative value pushes boundaries outward the page.
-- You can use percentage value in `topOffset` and `bottomOffset`, relative to its scrolling container.
-- If `horizontal` is on, `topOffset` becomes `leftOffset`, and `bottomOffset` becomes `rightOffset`. Names are kept the same for simplicity's sake.
 - `children` can only be **one** element, it must be one of native DOM element, element returned from `React.forwardRef`, or an element with an `innerRef` prop. The `ref` must be properly passed to the tracking DOM node.

--- a/packages/zent/src/waypoint/README_zh-CN.md
+++ b/packages/zent/src/waypoint/README_zh-CN.md
@@ -22,18 +22,23 @@ group: 基础
 | onEnter            | 元素滚动到屏幕内时的回调函数                                  | `(data: IWaypointCallbackData) => void` | 否       |         |        |
 | onLeave            | 元素滚动到屏幕外时的回调函数                                  | `(data: IWaypointCallbackData) => void` | 否       |         |        |
 | onPositionChange   | 元素位置变化时的回调函数                                      | `(data: IWaypointCallbackData) => void` | 否       |         |        |
-| topOffset          | 距离容器顶部的距离                                            | `number` \| `string`                    | 否       | `0px`   |        |
-| bottomOffset       | 距离容器底部的距离                                            | `number` \| `string`                    | 否       | `0px`   |        |
+| topOffset          | 距离容器顶部的距离                                            | `number` \| `'auto'` \| `string`                    | 否       | `0`   |        |
+| bottomOffset       | 距离容器底部的距离                                            | `number` \| `'auto'` \| `string`                    | 否       | `0`   |        |
 | horizontal         | 是否使用水平滚动模式                                          | `boolean`                               | 否       | `false` | `true` |
 | scrollableAncestor | 指定滚动容器的 DOM 元素，一般当外层有多个滚动容器时才需要使用 | `Element`                               | 否       |         |        |
 | fireOnRapidScroll  | 当快速滚动时是否触发 `onEnter` 和 `onLeave`                   | `boolean`                               | 否       | `true`  |        |
 | children           | 待追踪的元素，不传时可以认为是追踪屏幕内一条线                | `ReactNode`                             | 否       |         |        |
 
+#### `topOffset` 和 `bottomOffset`
+
+- 容器的[可滚动区域](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model/Determining_the_dimensions_of_elements#what.27s_the_size_of_the_displayed_content.3f) 是 `clientWidth`✖️`clientHeight`，但是 `getBoundingClientRect` 的返回值包含了 `border` 的宽度，如果容器设置了 `border` 就需要使用 `topOffset` 或者 `bottomOffset` 传入 `border` 宽度
+- `topOffset` 和 `bottomOffset` 可正可负，正负数效果和 `margin` 一样，正数往屏幕内偏移，负数往屏幕外偏移
+- `topOffset` 和 `bottomOffset` 可以是一个百分比，这个百分比是相对滚动容器大小的
+- 开启 `horizontal` 后，`topOffset` 其实是 `leftOffset`，而 `bottomOffset` 其实是 `rightOffset`，参数名特意没有变
+- `topOffset` 和 `bottomOffset` 可以设置为 `'auto'`，此时会尝试获取滚动容器的 `border` 宽度，目前仅支持解析[绝对长度单位](https://developer.mozilla.org/en-US/docs/Web/CSS/length#absolute_length_units)以及 `em` 和 `rem`，如果解析失败则使用默认值 `0`；不支持容器的 `transform` 属性，请不要一起使用
+
 ### FAQs
 
 - [`IWaypointCallbackData` 的定义](../../apidoc/interfaces/IWaypointCallbackData.html)
 - 快速滚动顾名思义就是滚动速度非常快，元素可能进入屏幕后立刻又出了屏幕
-- `topOffset` 和 `bottomOffset` 可正可负，正负数效果和 `margin` 一样，正数往屏幕内偏移，负数往屏幕外偏移
-- `topOffset` 和 `bottomOffset` 可以是一个百分比，这个百分比是相对滚动容器大小的
-- 开启 `horizontal` 后，`topOffset` 其实是 `leftOffset`，而 `bottomOffset` 其实是 `rightOffset`，参数名特意没有变
 - `children` 只能是**一个**元素，这个元素必须是原生组件、`React.forwardRef` 包装过的自定义组件，或者是接受一个 `innerRef` 参数的自定义组件，其中自定义组件必须把 `ref` 设置到需要跟踪位置的 DOM 元素上

--- a/packages/zent/src/waypoint/cssom.ts
+++ b/packages/zent/src/waypoint/cssom.ts
@@ -1,0 +1,84 @@
+/**
+ * Returns font size in pixels, only supports absolute length units.
+ */
+export function parseFontSize(fontSize: string): number | null {
+  return parseCSSAbsoluteUnit(fontSize.toLowerCase());
+}
+
+/**
+ * Returns border width in pixels
+ */
+export function parseBorderWidth(
+  width: string,
+  fontSize: () => number,
+  rootFontSize: () => number
+): number | null {
+  width = width.toLowerCase();
+  // try absolute units
+  const pixels = parseCSSAbsoluteUnit(width);
+  if (pixels !== null) {
+    return pixels;
+  }
+
+  return parseCSSFontRelativeUnit(width, fontSize, rootFontSize);
+}
+
+const CSS_ABSOLUTE_UNIT_REGEXP = /(^-?\d*\.?\d+)(cm|mm|in|px|pt|pc)$/;
+
+/**
+ * Parse CSS absolute length units to pixels
+ */
+function parseCSSAbsoluteUnit(value: string): number | null {
+  const result = CSS_ABSOLUTE_UNIT_REGEXP.exec(value);
+  if (result) {
+    const val = parseFloat(result[1]);
+    switch (result[2]) {
+      case 'cm':
+        return (val * 9600) / 254;
+      case 'mm':
+        return (val * 960) / 254;
+      case 'in':
+        return val * 96;
+      case 'pt':
+        return (val * 4) / 3;
+      case 'pc':
+        return val * 16;
+      case 'px':
+        return val;
+      default:
+        return null;
+    }
+  }
+
+  return null;
+}
+
+const CSS_FONT_RELATIVE_UNIT_REGEXP = /(^-?\d*\.?\d+)(em|rem)$/;
+
+/**
+ * Parse CSS font relative units to pixels, only supports em and rem
+ */
+function parseCSSFontRelativeUnit(
+  value: string,
+  fontSize: () => number,
+  rootFontSize: () => number
+): number | null {
+  const result = CSS_FONT_RELATIVE_UNIT_REGEXP.exec(value);
+  if (result) {
+    const val = parseFloat(result[1]);
+    switch (result[2]) {
+      case 'em': {
+        const fs = fontSize();
+        return fs !== null ? fs * val : null;
+      }
+      case 'rem': {
+        const fs = rootFontSize();
+        return fs !== null ? fs * val : null;
+      }
+      default:
+        return null;
+    }
+  }
+
+  return null;
+}

--- a/packages/zent/src/waypoint/demos/01-basic.md
+++ b/packages/zent/src/waypoint/demos/01-basic.md
@@ -2,24 +2,39 @@
 order: 1
 zh-CN:
 	title: 基础用法
+	auto: 猜测 topOffset 和 bottomOffset
 	enter: Waypoint 进入屏幕
 	leave: Waypoint 离开屏幕
 en-US:
 	title: Basic Usage
+	auto: Guess topOffset and bottomOffset
 	enter: Waypoint enter
 	leave: Waypoint leave
 ---
 
 ```js
-import { Waypoint, Icon } from 'zent';
+import { Waypoint, Icon, Checkbox } from 'zent';
 
 function Demo(props) {
 	const [msg, setMsg] = React.useState(null);
+	const [autoBorderWidth, setAutoBorderWidth] = React.useState(true);
 	const setEnterMsg = React.useCallback(() => setMsg('{i18n.enter}'), []);
 	const setLeaveMsg = React.useCallback(() => setMsg('{i18n.leave}'), []);
+	const setAuto = React.useCallback(e => setAutoBorderWidth(e.target.checked), []);
+  const autoProps = React.useMemo(() => {
+    return autoBorderWidth ? {
+			topOffset: 'auto',
+			bottomOffset: 'auto'
+		} : {};
+	}, [autoBorderWidth]);
 
 	return (
 		<div className="waypoint-demo-basic">
+			<div style={{marginBottom: 16}}>
+				<Checkbox checked={autoBorderWidth} onChange={setAuto}>
+					{i18n.auto}
+				</Checkbox>
+			</div>
 			{msg ? <div className="waypoint-demo-basic__message">{msg}</div> : null}
 			<div className="waypoint-demo-basic__scrollable-parent">
 				<Spacer />
@@ -28,8 +43,7 @@ function Demo(props) {
 				<Spacer />
 				<Spacer />
 				<Spacer />
-				<div className="waypoint-demo-basic__waypoint-line" />
-				<Waypoint onEnter={setEnterMsg} onLeave={setLeaveMsg} />
+				<Waypoint onEnter={setEnterMsg} onLeave={setLeaveMsg} {...autoProps}/>
 				<Spacer />
 				<Spacer />
 				<Spacer />
@@ -53,14 +67,17 @@ ReactDOM.render(<Demo />, mountNode);
 ```
 
 <style>
-.waypoint-demo-basic {
-  position: relative;
+.waypoint-demo-basic .zent-waypoint-marker {
+	display: block;
+	height: 4px;
+	background: #d40000;
 }
 
 .waypoint-demo-basic__scrollable-parent {
   max-height: 400px;
   overflow: scroll;
   position: relative;
+	border: 20px solid rgba(21, 91, 212, 0.2);
 }
 
 .waypoint-demo-basic__spacer {
@@ -70,21 +87,14 @@ ReactDOM.render(<Demo />, mountNode);
   text-align: center;
 }
 
-.waypoint-demo-basic__waypoint-line {
-  border-top: 2px dashed #d40000;
-}
-
 .waypoint-demo-basic__message {
 	box-sizing: border-box;
   background-color: #f2f3f5;
   color: #323233;
-  left: 0;
   opacity: 0.8;
   padding: 10px 0;
   pointer-events: none;
-  position: absolute;
   text-align: center;
-  top: 0;
   width: 100%;
 }
 </style>


### PR DESCRIPTION
Fixes #1781 

Only supports CSS absolute length units, `em` and `rem` in `border-width`.