### PR TITLE
移除按钮的danger/success/waring类型的hover/active状态

### DIFF
--- a/packages/zent/assets/theme/semantic/_color.scss
+++ b/packages/zent/assets/theme/semantic/_color.scss
@@ -178,21 +178,21 @@ $theme-primary-8: map-get(map-get($color-sets, 'default'), 'hover-bg');
 // Green
 $theme-success-1: map-get(map-get($color-sets, 'success'), 'color');
 $theme-success-2: map-get(map-get($color-sets, 'success'), 'color');
-$theme-success-3: map-get(map-get($color-sets, 'success'), 'hover-bg');
+$theme-success-3: map-get(map-get($color-sets, 'success'), 'color');
 $theme-success-4: map-get(map-get($color-sets, 'success'), 'color');
 $theme-success-5: map-get(map-get($color-sets, 'success'), 'bg');
 
 // Red
 $theme-error-1: map-get(map-get($color-sets, 'danger'), 'color');
 $theme-error-2: map-get(map-get($color-sets, 'danger'), 'color');
-$theme-error-3: map-get(map-get($color-sets, 'danger'), 'hover-bg');
+$theme-error-3: map-get(map-get($color-sets, 'danger'), 'color');
 $theme-error-4: map-get(map-get($color-sets, 'danger'), 'color');
 $theme-error-5: map-get(map-get($color-sets, 'danger'), 'bg');
 
 // Orange
 $theme-warn-1: map-get(map-get($color-sets, 'warning'), 'color');
 $theme-warn-2: map-get(map-get($color-sets, 'warning'), 'color');
-$theme-warn-3: map-get(map-get($color-sets, 'warning'), 'hover-bg');
+$theme-warn-3: map-get(map-get($color-sets, 'warning'), 'color');
 $theme-warn-4: map-get(map-get($color-sets, 'warning'), 'color');
 $theme-warn-5: map-get(map-get($color-sets, 'warning'), 'bg');
 
@@ -347,7 +347,7 @@ $theme-colors-mapping: (
     ),
     (
       cat: 'success',
-      attr: 'bg',
+      attr: 'color',
     ),
     (
       cat: 'success',
@@ -369,7 +369,7 @@ $theme-colors-mapping: (
     ),
     (
       cat: 'danger',
-      attr: 'bg',
+      attr: 'color',
     ),
     (
       cat: 'danger',
@@ -391,7 +391,7 @@ $theme-colors-mapping: (
     ),
     (
       cat: 'warning',
-      attr: 'bg',
+      attr: 'color',
     ),
     (
       cat: 'warning',

--- a/packages/zent/src/button/README_en-US.md
+++ b/packages/zent/src/button/README_en-US.md
@@ -22,7 +22,7 @@ Button. Basic style and basic status are provided.
 
 | Property         | Description                                                                                          | Type   | Default     | Alternative                          |
 | ---------------- | ---------------------------------------------------------------------------------------------------- | ------ | ----------- | ------------------------------------ |
-| type             | style                                                                                                | string | `'default'` | `'primary'`、`'danger'`、`'success'` |
+| type             | style                                                                                                | string | `'default'` | `'primary'`                          |
 | size             | size                                                                                                 | string | `'medium'`  | `'large'`、`'small'`                 |
 | htmlType         | button tag native type attribute                                                                     | string | `'button'`  | `submit`、`reset`、`button`          |
 | block            | whether to be displayed as a block                                                                   | bool   | `false`     |                                      |

--- a/packages/zent/src/button/README_zh-CN.md
+++ b/packages/zent/src/button/README_zh-CN.md
@@ -23,7 +23,7 @@ group: 数据
 
 | 参数      | 说明                                              | 类型   | 默认值      | 备选值                               |
 | --------- | ------------------------------------------------- | ------ | ----------- | ------------------------------------ |
-| type      | 风格                                              | string | `'default'` | `'primary'`、`'danger'`、`'success'` |
+| type      | 风格                                              | string | `'default'` | `'primary'`                          |
 | size      | 尺寸                                              | string | `'medium'`  | `'large'`、`'small'`                 |
 | htmlType  | button 标签原生 type 属性                         | string | `'button'`  | `submit`、`reset`、`button`          |
 | block     | 是否以块级元素的形式展开                          | bool   | `false`     |                                      |

--- a/packages/zent/src/pop/README_en-US.md
+++ b/packages/zent/src/pop/README_en-US.md
@@ -34,7 +34,7 @@ A floating card opened by clicking, hovering or focusing.
 | onCancel | Cancel callback | func | No | |  |
 | confirmText | Confirm button text | string | No | `'Confirm'` |  |
 | cancelText | Cancel button text | string | No | `'Cancel'` |  |
-| type | Confirm button type | string | No | `'primary'` | `'default'`, `'danger'`, `'success'` |
+| type | Confirm button type | string | No | `'primary'` | `'default'`                          |
 | visible | Pop switch to controlled mode if this prop is set, must be used with `onVisibleChange` | bool | No | | |
 | onVisibleChange | Must be used with `visible` | func | No | | |
 | onPositionUpdated | callback after position updates, a position update does not imply a position change | func | No | `noop` | |

--- a/packages/zent/src/pop/README_zh-CN.md
+++ b/packages/zent/src/pop/README_zh-CN.md
@@ -35,7 +35,7 @@ group: 反馈
 | onCancel | 用户使用 confirm 的时候可自定义取消的回调 | func | 否  |  |  |
 | confirmText | 用户自定义按钮名 | string | 否 | `'确定'` |  |
 | cancelText | 用户自定义取消按钮 | string | 否 | `'取消'` |  |
-| type | 影响确定按钮的样式 | string | 否  | `'primary'` | `'default'`, `'danger'`, `'success'` |
+| type | 影响确定按钮的样式 | string | 否  | `'primary'` | `'default'`                          |
 | visible | 外部维护 `Pop` 的显示状态，此时外部拥有 `Pop` 的全部控制权，必须和 `onVisibleChange` 一起使用 | bool | 否 |  | |
 | onVisibleChange | 和 `visible` 一起使用 | func | 否 | | |
 | onPositionUpdated | 位置更新时的回调，不保证调用这个函数时位置一定变化 | func | 否 | `noop` | |

--- a/packages/zent/src/pop/demos/custom-confirm.md
+++ b/packages/zent/src/pop/demos/custom-confirm.md
@@ -31,7 +31,7 @@ class Wrapper extends React.Component {
 				trigger="click"
 				header="{i18n.popHeader}"
 				content="{i18n.popContent}"
-				type="danger"
+				type="primary"
 				confirmText="Error"
 				cancelText="Close"
 				onConfirm={this.confirmHandler}

--- a/packages/zent/src/split-button/README_en-US.md
+++ b/packages/zent/src/split-button/README_en-US.md
@@ -12,7 +12,7 @@ SplitButton a button with a dropdown menu
 
 | 参数             | 说明                                                                                                       | 类型   | 默认值               | 备选值                               |
 | ---------------- | ---------------------------------------------------------------------------------------------------------- | ------ | -------------------- | ------------------------------------ |
-| type             | button style                                                                                               | string | `'default'`          | `'primary'`、`'danger'`、`'success'` |
+| type             | button style                                                                                               | string | `'default'`          | `'primary'`                          |
 | disabled         | is the button disabled                                                                                     | bool   | `false`              | `true`、`false`                      |
 | loading          | is show loading icon                                                                                       | bool   | `false`              | `true`, `false`                      |
 | size             | button size                                                                                                | string | `'medium'`           | `'large'`、`'medium'`、`'small'`     |

--- a/packages/zent/src/split-button/README_zh-CN.md
+++ b/packages/zent/src/split-button/README_zh-CN.md
@@ -13,7 +13,7 @@ SplitButton 带有下拉菜单功能的按钮
 
 | 参数             | 说明                                                                         | 类型   | 默认值               | 备选值                               |
 | ---------------- | ---------------------------------------------------------------------------- | ------ | -------------------- | ------------------------------------ |
-| type             | 按钮风格                                                                     | string | `'default'`          | `'primary'`、`'danger'`、`'success'` |
+| type             | 按钮风格                                                                     | string | `'default'`          | `'primary'`                          |
 | disabled         | 按钮是否禁用                                                                 | bool   | `false`              | `true`、`false`                      |
 | loading          | 是否显示 loading 图标                                                        | bool   | `false`              | `true`, `false`                      |
 | size             | 按钮尺寸                                                                     | string | `'medium'`           | `'large'`、`'medium'`、`'small'`     |

--- a/packages/zent/src/split-button/demos/basic.md
+++ b/packages/zent/src/split-button/demos/basic.md
@@ -81,20 +81,6 @@ class Simple extends React.Component {
 				>
 					{i18n.loading}
 				</SplitButton>
-				<SplitButton
-					type="danger"
-					size="large"
-					dropdownData={list}
-				>
-					{i18n.big}
-				</SplitButton>
-				<SplitButton
-					type="success"
-					size="small"
-					dropdownData={list}
-				>
-					{i18n.small}
-				</SplitButton>
 			</div>
 		);
 	}

--- a/packages/zent/src/split-button/demos/dropdown-position.md
+++ b/packages/zent/src/split-button/demos/dropdown-position.md
@@ -39,31 +39,18 @@ class Simple extends React.Component {
 
 	render() {
 		return (
-			<div>
-				<SplitButton
-					type="primary"
-					dropdownData={list}
-					dropdownTrigger="hover"
-					dropdownValue="id"
-					dropdownText="value"
-					dropdownPosition="top-left"
-					onClick={this.handleClick}
-					onSelect={this.handleSelect}
-				>
-					{i18n.up}
-				</SplitButton>
-				<SplitButton
-					type="danger"
-					dropdownData={list}
-					dropdownValue="id"
-					dropdownText="value"
-					dropdownPosition="bottom-right"
-					onClick={this.handleClick}
-					onSelect={this.handleSelect}
-				>
-					{i18n.down}
-				</SplitButton>
-			</div>
+			<SplitButton
+				type="primary"
+				dropdownData={list}
+				dropdownTrigger="hover"
+				dropdownValue="id"
+				dropdownText="value"
+				dropdownPosition="top-left"
+				onClick={this.handleClick}
+				onSelect={this.handleSelect}
+			>
+				{i18n.up}
+			</SplitButton>
 		);
 	}
 }

--- a/packages/zent/src/split-button/demos/dropdown-position.md
+++ b/packages/zent/src/split-button/demos/dropdown-position.md
@@ -39,18 +39,30 @@ class Simple extends React.Component {
 
 	render() {
 		return (
-			<SplitButton
-				type="primary"
-				dropdownData={list}
-				dropdownTrigger="hover"
-				dropdownValue="id"
-				dropdownText="value"
-				dropdownPosition="top-left"
-				onClick={this.handleClick}
-				onSelect={this.handleSelect}
-			>
-				{i18n.up}
-			</SplitButton>
+			<div>
+				<SplitButton
+					type="primary"
+					dropdownData={list}
+					dropdownTrigger="hover"
+					dropdownValue="id"
+					dropdownText="value"
+					dropdownPosition="top-left"
+					onClick={this.handleClick}
+					onSelect={this.handleSelect}
+				>
+					{i18n.up}
+				</SplitButton>
+				<SplitButton
+					dropdownData={list}
+					dropdownValue="id"
+					dropdownText="value"
+					dropdownPosition="bottom-right"
+					onClick={this.handleClick}
+					onSelect={this.handleSelect}
+				>
+					{i18n.down}
+				</SplitButton>
+			</div>
 		);
 	}
 }

--- a/packages/zent/src/split-button/demos/dropdown.md
+++ b/packages/zent/src/split-button/demos/dropdown.md
@@ -39,31 +39,17 @@ class Simple extends React.Component {
 
 	render() {
 		return (
-			<div>
-				<SplitButton
-					type="primary"
-					dropdownData={list}
-					dropdownTrigger="hover"
-					dropdownValue="id"
-					dropdownText="value"
-					onClick={this.handleClick}
-					onSelect={this.handleSelect}
-				>
-					{i18n.button}
-				</SplitButton>
-				<SplitButton
-					type="danger"
-					disabled
-					dropdownData={list}
-					dropdownTrigger="hover"
-					dropdownValue="id"
-					dropdownText="value"
-					onClick={this.handleClick}
-					onSelect={this.handleSelect}
-				>
-					{i18n.disabled}
-				</SplitButton>
-			</div>
+			<SplitButton
+				type="primary"
+				dropdownData={list}
+				dropdownTrigger="hover"
+				dropdownValue="id"
+				dropdownText="value"
+				onClick={this.handleClick}
+				onSelect={this.handleSelect}
+			>
+				{i18n.button}
+			</SplitButton>
 		);
 	}
 }

--- a/packages/zent/src/sweetalert/README_en-US.md
+++ b/packages/zent/src/sweetalert/README_en-US.md
@@ -23,7 +23,7 @@ Sweetalert is a function used for arouse a Dialog rapidly.
 | title           | title of the dialog                                                           | node          | `''`        |                                                   |
 | onConfirm       | callback of confirm operation                                                 | func          | `noop`      |                                                   |
 | confirmText     | text of confirm button                                                        | string        | `'OK'`      |                                                   |
-| confirmType     | type of confirm button                                                        | string        | `'primary'` | `'default'`、`'primary'`、`'danger'`、`'success'` |
+| confirmType     | type of confirm button                                                        | string        | `'primary'` | `'default'`、`'primary'`                          |
 | closeBtn        | visibility of the close button at the upper right corner                      | bool          | `false`     |
 | maskClosable    | wether click on the mask is to close the dialog                               | bool          | `true`      |
 | parentComponent | Parent component instance，i18n needs this to pass context through            | ReactInstance |             |                                                   |
@@ -40,7 +40,7 @@ Sweetalert is a function used for arouse a Dialog rapidly.
 | onConfirm    | callback of confirm operation                                                 | func   | `noop`      |                                                   |
 | cancelText   | text of cancel button                                                         | string | `'Cancel'`  |                                                   |
 | confirmText  | text of confirm button                                                        | string | `'Confirm'` |                                                   |
-| confirmType  | type of confirm button                                                        | string | `'primary'` | `'default'`、`'primary'`、`'danger'`、`'success'` |
+| confirmType  | type of confirm button                                                        | string | `'primary'` | `'default'`、`'primary'`                          |
 | closeBtn     | visibility of the close button at the upper right corner                      | bool   | `false`     |
 | maskClosable | wether click on the mask is to close the dialog                               | bool   | `true`      |
 | className    | custom classname                                                              | string | `''`        |                                                   |

--- a/packages/zent/src/sweetalert/README_zh-CN.md
+++ b/packages/zent/src/sweetalert/README_zh-CN.md
@@ -24,7 +24,7 @@ group: 反馈
 | title           | 弹窗的标题                                                      | node          | `''`         |                                                   |
 | onConfirm       | 确定操作回调函数                                                | func          | `noop`       |                                                   |
 | confirmText     | 确定按钮文案                                                    | string        | `'我知道了'` |                                                   |
-| confirmType     | 确定按钮的类型                                                  | string        | `'primary'`  | `'default'`、`'primary'`、`'danger'`、`'success'` |
+| confirmType     | 确定按钮的类型                                                  | string        | `'primary'`  | `'default'`、`'primary'`                          |
 | closeBtn        | 是否显示右上角关闭按钮                                          | bool          | `false`      |
 | maskClosable    | 点击遮罩是否可以关闭                                            | bool          | `false`      |
 | parentComponent | 父级组件实例，i18n 需要通过这个传递 context                     | ReactInstance |              |                                                   |
@@ -41,7 +41,7 @@ group: 反馈
 | onConfirm    | 确定操作回调函数                                                | func   | `noop`      |                                                   |
 | cancelText   | 取消按钮文案                                                    | string | `'取消'`    |                                                   |
 | confirmText  | 确定按钮文案                                                    | string | `'确定'`    |                                                   |
-| confirmType  | 确定按钮的类型                                                  | string | `'primary'` | `'default'`、`'primary'`、`'danger'`、`'success'` |
+| confirmType  | 确定按钮的类型                                                  | string | `'primary'` | `'default'`、`'primary'`                          |
 | closeBtn     | 是否显示右上角关闭按钮                                          | bool   | `false`     |
 | maskClosable | 点击遮罩是否可以关闭                                            | bool   | `false`     |
 | className    | 额外的 className                                                | string | `''`        |                                                   |

--- a/packages/zent/src/sweetalert/demos/button-type.md
+++ b/packages/zent/src/sweetalert/demos/button-type.md
@@ -22,7 +22,7 @@ import { Sweetalert, Button } from 'zent';
 class Wrapper extends React.Component {
 	showAlertConfirm = () => {
 		Sweetalert.confirm({
-			confirmType: 'danger',
+			confirmType: 'primary',
 			confirmText: '{i18n.confirm}',
 			cancelText: '{i18n.cancel}',
 			content: '{i18n.content}',
@@ -32,7 +32,7 @@ class Wrapper extends React.Component {
 	}
 
 	render() {
-		return <Button onClick={this.showAlertConfirm} type="danger">{i18n.button}</Button>;
+		return <Button onClick={this.showAlertConfirm}>{i18n.button}</Button>;
 	}
 }
 

--- a/packages/zent/src/sweetalert/demos/button-type.md
+++ b/packages/zent/src/sweetalert/demos/button-type.md
@@ -5,14 +5,12 @@ zh-CN:
 	content: 确认删除吗？
 	title1: 请确认
 	confirm: 删除
-	cancel: 取消
 	button: 删除
 en-US:
 	title: The type of button in Dialog is settable.
 	content: Confirm to delete?
 	title1: Confirm
 	confirm: Delete
-	cancel: Cancel
 	button: Remove
 ---
 
@@ -21,10 +19,9 @@ import { Sweetalert, Button } from 'zent';
 
 class Wrapper extends React.Component {
 	showAlertConfirm = () => {
-		Sweetalert.confirm({
+		Sweetalert.alert({
 			confirmType: 'default',
 			confirmText: '{i18n.confirm}',
-			cancelText: '{i18n.cancel}',
 			content: '{i18n.content}',
 			title: '{i18n.title1}',
 			parentComponent: this

--- a/packages/zent/src/sweetalert/demos/button-type.md
+++ b/packages/zent/src/sweetalert/demos/button-type.md
@@ -22,7 +22,7 @@ import { Sweetalert, Button } from 'zent';
 class Wrapper extends React.Component {
 	showAlertConfirm = () => {
 		Sweetalert.confirm({
-			confirmType: 'primary',
+			confirmType: 'default',
 			confirmText: '{i18n.confirm}',
 			cancelText: '{i18n.cancel}',
 			content: '{i18n.content}',

--- a/packages/zent/src/upload/demos/custom-item.md
+++ b/packages/zent/src/upload/demos/custom-item.md
@@ -21,7 +21,7 @@ const CustomItem = props => {
 			<p>进度：{item.percent}%</p>
 			<div>
 				{item.status === FILE_UPLOAD_STATUS.failed && <Button onClick={() => onRetry(item)}>重试</Button>}
-				<Button type="danger" onClick={() => onDelete(item)}>删除</Button>
+				<Button type="primary" onClick={() => onDelete(item)}>删除</Button>
 			</div>
 		</div>
 	)


### PR DESCRIPTION
1. 去除 Button 中 danger/success/waring 类型的文档显示，保留已使用的场景代码
2. 已使用的场景不区分hover/active的状态颜色变化，警示色不存在状态区分

Fixes #1787 