### PR TITLE
fix: format dates value in RangeDatePicker

### DIFF
--- a/packages/zent/src/date-picker/components/RangePickerBase.tsx
+++ b/packages/zent/src/date-picker/components/RangePickerBase.tsx
@@ -20,6 +20,7 @@ import {
   DateNullTuple,
 } from '../types';
 import useRangeDisabledTime from '../hooks/useRangeDisabledTime';
+import { endOfDay, startOfDay } from 'date-fns';
 
 const { START, END } = RangeTypeMap;
 interface IRangePickerProps extends IRangePropsWithDefault {
@@ -89,12 +90,18 @@ const RangePicker: React.FC<IRangePickerProps> = ({
 
   const onChangeStartOrEnd = useCallback(
     (type: RangeType) => (val: Date | null) => {
-      const dates: DateNullTuple = type === START ? [val, end] : [start, val];
+      let dates: DateNullTuple = type === START ? [val, end] : [start, val];
+      if (!showTime) {
+        dates = [
+          dates[0] ? startOfDay(dates[0]) : dates[0],
+          dates[1] ? endOfDay(dates[1]) : dates[1],
+        ];
+      }
       setSelected(dates);
       // props onChange
       onChangeRef.current?.(getCallbackRangeValue?.(dates) || null);
     },
-    [start, end, onChangeRef, getCallbackRangeValue, setSelected]
+    [start, end, showTime, onChangeRef, getCallbackRangeValue, setSelected]
   );
 
   const { disabledStartTimes, disabledEndTimes } = useRangeDisabledTime({

--- a/packages/zent/src/date-picker/panels/combined-date-range-panel/index.tsx
+++ b/packages/zent/src/date-picker/panels/combined-date-range-panel/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import cx from 'classnames';
-import { parse, addMonths } from 'date-fns';
+import { parse, addMonths, endOfDay, startOfDay } from 'date-fns';
 
 import DatePanel from '../date-panel/index';
 import RangePickerFooter from './RangeFooter';
@@ -59,15 +59,19 @@ const CombinedDateRangePanel: React.FC<ICombinedDateRangePanelProps> = ({
         selectedTemp = [
           startShowTime
             ? parse(defaultStartTime(start), formatStart, start)
-            : start,
-          endShowTime ? parse(defaultEndTime(val), formatEnd, val) : val,
+            : startOfDay(start),
+          endShowTime
+            ? parse(defaultEndTime(val), formatEnd, val)
+            : endOfDay(val),
         ];
         onSelected(selectedTemp, !showTime);
       }
       // 选中开始时间是清除上一次的结束时间
       else {
         selectedTemp = [
-          startShowTime ? parse(defaultStartTime(val), formatStart, val) : val,
+          startShowTime
+            ? parse(defaultStartTime(val), formatStart, val)
+            : startOfDay(val),
           null,
         ];
         onSelected(selectedTemp);


### PR DESCRIPTION
Changes you made in this pull request:

- 日期范围选择组件在不使用 `showTime` 时，返回值的开始、结束时间都默认为 `00:00:00` 的问题修复
