### PR TITLE
add useObservableBatchedEagerState

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -135,7 +135,7 @@ module.exports = {
           version: 'detect', // React version. "detect" automatically picks the version you have installed.
         },
       },
-      plugins: ['react', 'react-hooks'],
+      plugins: ['react'],
       parserOptions: {
         ecmaFeatures: {
           jsx: true,
@@ -159,9 +159,6 @@ module.exports = {
         'react/no-unescaped-entities': 'error',
         'react/no-unknown-property': 'error',
         'react/require-render-return': 'error',
-
-        'react-hooks/rules-of-hooks': 'error',
-        'react-hooks/exhaustive-deps': 'error',
       },
     },
     {
@@ -338,8 +335,11 @@ module.exports = {
       env: {
         browser: true,
       },
-      plugins: ['ban'],
+      plugins: ['ban', 'react-hooks'],
       rules: {
+        'react-hooks/rules-of-hooks': 'error',
+        'react-hooks/exhaustive-deps': 'error',
+
         'ban/ban': [
           'error',
           {
@@ -382,6 +382,11 @@ module.exports = {
       parserOptions: {
         project: './tsconfig.json',
         tsconfigRootDir: path.resolve(__dirname, 'site'),
+      },
+      plugins: ['react-hooks'],
+      rules: {
+        'react-hooks/rules-of-hooks': 'error',
+        'react-hooks/exhaustive-deps': 'error',
       },
     },
 

--- a/packages/zent/src/form/README_zh-CN.md
+++ b/packages/zent/src/form/README_zh-CN.md
@@ -304,6 +304,7 @@ type Middleware<T> = (next: IValidator<T>) => IValidator<T>;
 - `Form.useFieldValid`：接收 `name` 或 `model`，返回其校验状态
 - `Form.useFormValid`：接收 `ZentForm` 对象（即 `useForm` 的返回值），返回表单的校验状态
 - 订阅 `FieldArray`, `FieldSet` 或者 `Form` 的校验状态可能会导致性能问题，因为这些是容器类型，订阅它们意味着需要订阅它们内部包含的所有表单项的校验状态变化，这是一个非常耗资源并且影响性能的操作，所以不推荐大范围频繁使用；开发模式下在 console 中会有一个警告信息。
+- 当遇到订阅导致重绘次数过多的性能问题时，可以考虑使用 `useObservableBatchedEagerState` 将操作做批处理，减少重绘次数。
 
 <!-- demo-slot-19 -->
 
@@ -388,10 +389,18 @@ type Middleware<T> = (next: IValidator<T>) => IValidator<T>;
 - `Form.useFieldValue` 提供了一种 hooks 的风格来获取表单值（包括 FieldSet、FieldArray、Field），它可以深度监听表单值
 - `Form.useFormValue` 提供了一种 hooks 的风格来获取整个表单的值，它可以深度监听表单值
 
-⚠️ 注意：订阅单个表单项的值一般不会有什么问题，但是订阅 `FieldArray`, `FieldSet` 或者 `Form` 的值时需要谨慎，因为这些是容器类型，订阅它们意味着需要订阅它们内部包含的所有表单项的变化，这是一个非常耗资源并且影响性能的操作，所以不推荐大范围频繁使用。针对这个问题，开发模式下会有一个警告信息来提醒使用者。
-
 <!-- demo-slot-12 -->
 <!-- demo-slot-20 -->
+
+⚠️ 注意：订阅单个表单项的值一般不会有什么问题，但是订阅 `FieldArray`, `FieldSet` 或者 `Form` 的值时需要谨慎，因为这些是容器类型，订阅它们意味着需要订阅它们内部包含的所有表单项的变化，这是一个非常耗资源并且影响性能的操作，所以不推荐大范围频繁使用。针对这个问题，开发模式下会有一个警告信息来提醒使用者。
+
+当遇到订阅导致重绘次数过多的性能问题时，可以考虑使用 `useObservableBatchedEagerState` 将操作做批处理，减少重绘次数。
+
+下面这个示例的场景比较特殊，在 useCallback 的回调中同步触发重绘的话 React 会自动合并无用的重绘；但是如果在异步代码中触发重绘的话 React 并不会自动合并，导致大量重绘操作在短时间内触发，引起性能问题。
+
+此时可用使用 `useObservableBatchedEagerState` 来合并 Observable 的修改，从而间接的减少 React 重绘，优化性能。
+
+<!-- demo-slot-23 -->
 
 ### 通过 Model 订阅数据
 

--- a/packages/zent/src/form/demos/23.batched-updates.md
+++ b/packages/zent/src/form/demos/23.batched-updates.md
@@ -1,0 +1,99 @@
+---
+order: 23
+zh-CN:
+	title: 批处理优化重绘性能
+	batchUpdate: 批量更新
+	update: 逐个更新
+	renderCount: 重绘次数
+en-US:
+	title: Batched updates
+	batchUpdate: Batch Update
+	update: Update One by One
+	renderCount: Number of renders
+---
+
+```jsx
+import {
+	Form,
+	Button,
+	FormInputField,
+	useObservableBatchedEagerState,
+} from 'zent';
+
+const { useState, useCallback } = React;
+
+const formModel = Form.form({
+	list: Form.array(
+		Form.set({
+			v: Form.field(0),
+		})
+	).defaultValue([{ v: 1 }, { v: 2 }, { v: 3 }]),
+});
+
+function App() {
+	const form = Form.useForm(formModel);
+
+	return (
+		<Form form={form} layout="horizontal">
+			<List />
+		</Form>
+	);
+}
+
+function List() {
+	const model = Form.useFieldArray('list');
+
+	const [batchedListValue, runInBatchContext] = useObservableBatchedEagerState(
+		model.value$
+	);
+	console.log('list value change', batchedListValue);
+
+	const batchUpdate = useCallback(() => {
+		setTimeout(() => {
+			runInBatchContext(() => {
+				model.children.forEach(m => {
+					const vm = m.get('v');
+					vm.value = vm.value + 1;
+				});
+			});
+		}, 0);
+	}, [model, runInBatchContext]);
+
+	const update = useCallback(() => {
+		setTimeout(() => {
+			model.children.forEach(m => {
+				const vm = m.get('v');
+				vm.value = vm.value + 1;
+			});
+		}, 0);
+	}, [model]);
+
+	return (
+		<>
+			{model.children.map((child, index) => {
+				return (
+					<div key={child.id}>
+						<FormInputField model={child.get('v')} />
+					</div>
+				);
+			})}
+			<Button onClick={batchUpdate}>{i18n.batchUpdate}</Button>
+			<Button onClick={update}>{i18n.update}</Button>
+		</>
+	);
+}
+
+function Preview({ form }) {
+	// You will see a warning about performance issues in console.
+	// Only do this if you know what you are doing.
+	const valid = useFormValid(form);
+
+	return (
+		<Alert type={valid ? 'success' : 'error'} style={{ marginBottom: 24 }}>
+			Form is {valid ? 'valid' : 'invalid'}
+		</Alert>
+	);
+}
+
+ReactDOM.render(<App />, mountNode);
+```

--- a/packages/zent/src/form/formulr/index.ts
+++ b/packages/zent/src/form/formulr/index.ts
@@ -16,4 +16,5 @@ export {
   UnknownFieldSetModelChildren,
   UnknownFieldSetBuilderChildren,
 } from './utils';
+export * from './use-observable-batched-state';
 export { Validators, FieldUtils, ValidatorMiddlewares };

--- a/packages/zent/src/form/formulr/use-observable-batched-state.ts
+++ b/packages/zent/src/form/formulr/use-observable-batched-state.ts
@@ -1,0 +1,52 @@
+import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
+import {
+  useObservable,
+  useObservableEagerState,
+  useRefFn,
+} from 'observable-hooks';
+import { filter, mergeMap, map } from 'rxjs/operators';
+import { useCallback } from 'react';
+
+/**
+ * 类似 observable-hooks 里的 `useObservableEagerState`。
+ *
+ * `input$` 在 `runInBatchContext` 执行过程中产生的新值，除最后一个外都会被忽略；
+ * 在 `runInBatchContext` 之外的更新操作不受影响。
+ *
+ * 使用场景示例：
+ *
+ * 批量更新 `FieldArrayModel` 中每一项的值，但又不希望监听 `FieldArrayModel.value$` 的回调频繁触发，导致页面不停的被重绘。
+ * @param input$ 通常是 `model.value$`
+ */
+export function useObservableBatchedEagerState<T>(
+  input$: Observable<T>
+): [value: T, runInBatchContext: (fn: () => void) => void] {
+  const batching$Ref = useRefFn(() => new BehaviorSubject(false));
+
+  const runInBatchContext = useCallback(
+    (fn: () => void) => {
+      batching$Ref.current.next(true);
+      fn();
+      batching$Ref.current.next(false);
+    },
+    [batching$Ref]
+  );
+
+  const observable$ = useObservable(
+    args$ => {
+      return args$.pipe(
+        mergeMap(sources$ => {
+          return combineLatest(sources$).pipe(
+            filter(([_, batching]) => !batching),
+            map(([v]) => v)
+          );
+        })
+      );
+    },
+    [input$, batching$Ref.current]
+  );
+
+  const value = useObservableEagerState(observable$);
+
+  return [value, runInBatchContext];
+}

--- a/packages/zent/src/form/index.ts
+++ b/packages/zent/src/form/index.ts
@@ -27,6 +27,7 @@ export {
   IMaybeError,
   IValidateResult,
   ValidatorContext,
+  useObservableBatchedEagerState,
 } from './formulr';
 export { useFormChild, IFormFieldPropsBase } from './shared';
 


### PR DESCRIPTION
这个场景比较特殊，在 useCallback 的回调中同步触发重绘的话 React 会自动合并无用的重绘；但是如果在异步代码中触发重绘的话 React 并不会自动合并，导致大量重绘操作在短时间内触发，引起性能问题。

此时可用使用 `useObservableBatchedEagerState` 来合并 Observable 的修改，从而间接的减少 React 重绘，优化性能。

Closes #1810 