### PR TITLE
fix Notice.push not working if ReactDOM.render is async

### DIFF
--- a/packages/zent/src/notice/Notice.tsx
+++ b/packages/zent/src/notice/Notice.tsx
@@ -1,6 +1,7 @@
 import { useContext, useCallback, ReactNode, CSSProperties } from 'react';
 import cx from 'classnames';
 import { Icon } from '../icon';
+import uniqueId from '../utils/uniqueId';
 import { NoticePositions, getContainer, remove } from './Container';
 import { NoticeContext } from './Wrap';
 import { isElement } from 'react-is';
@@ -97,8 +98,14 @@ Notice.push = function push(node: ReactNode) {
   if (isElement(node) && node.props) {
     position = node.props.position || position;
   }
-  const container = getContainer(position);
-  return container.push(node);
+
+  const id = uniqueId('zent-notice-');
+
+  getContainer(position, container => {
+    container.push(node, id);
+  });
+
+  return id;
 };
 
 Notice.close = remove;

--- a/packages/zent/src/notice/README_en-US.md
+++ b/packages/zent/src/notice/README_en-US.md
@@ -20,3 +20,14 @@ group: Feedback
 | timeout   | Auto closing timeout                                | number              | No       |             |                                                        |
 | children  | Children                                            | React.ReactNode     | No       |             |                                                        |
 | position  | Position                                            | string              | No       | `top-right` | `right-top`, `right-bottom`, `left-top`, `left-bottom` |
+
+#### `Notice.push(node: ReactNode): string`
+
+Open a new notice. The returned `id` can be used to close this notice.
+
+Note：The returned `id` may be not ready to use due to the asynchronous behavior of `ReactDOM.render`, `close(id)` will be
+a no-op in this case.
+
+#### `Notice.close(id: string): void`
+
+Close the notice with `id`.

--- a/packages/zent/src/notice/README_zh-CN.md
+++ b/packages/zent/src/notice/README_zh-CN.md
@@ -21,3 +21,14 @@ group: 反馈
 | timeout   | 自动关闭的延迟时间                          | number              | 否       |             |                                                        |
 | children  | 内容                                        | React.ReactNode     | 否       |             |                                                        |
 | position  | 位置                                        | string              | 否       | `top-right` | `right-top`, `right-bottom`, `left-top`, `left-bottom` |
+
+#### `Notice.push(node: ReactNode): string`
+
+打开一个新的通知，返回值是这个通知的 `id`，可通过 `Notice.close(id)` 手动关闭通知。
+
+注意：由于 `ReactDOM.render` 在某些场景下是异步的（比如在 `useEffect` 内部调用的时候），所以 `push` 返回的 `id` 并不能立刻用于 `close`，如果调用 `close(id)` 时 `ReactDOM.render`
+还未渲染出来，那么此次 `close` 调用不会有效果。
+
+#### `Notice.close(id: string): void`
+
+关闭 `id` 指定的通知。

--- a/packages/zent/src/notice/Wrap.tsx
+++ b/packages/zent/src/notice/Wrap.tsx
@@ -6,8 +6,8 @@ import { runInNextFrame } from '../utils/nextFrame';
 import { instanceMap } from './Container';
 
 export interface INoticeWrapProps {
-  id: number;
-  onExited(id: number): void;
+  id: string;
+  onExited(id: string): void;
 }
 
 export interface INoticeWrapState {


### PR DESCRIPTION
- Fixes #1812 
- Changes `Notice.push` return type from `number` to `string`
- Add `Notice.push` and `Notice.close` to doc