### PR TITLE
warn instead of error on `require` in babel-plugin-zent

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -292,6 +292,9 @@ module.exports = {
         'packages/babel-plugin-zent/src/*.js',
         'packages/babel-plugin-zent/__tests__/*.js',
       ],
+      env: {
+        node: true,
+      },
       parserOptions: {
         babelOptions: {
           root: path.resolve(__dirname, 'packages/babel-plugin-zent'),
@@ -300,9 +303,6 @@ module.exports = {
     },
     {
       files: ['packages/babel-plugin-zent/__tests__/*.spec.js'],
-      env: {
-        node: true,
-      },
       rules: {
         'no-console': 'off',
       },

--- a/packages/babel-plugin-zent/.babelrc
+++ b/packages/babel-plugin-zent/.babelrc
@@ -4,8 +4,9 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": 6
-        }
+          "node": 12
+        },
+        "modules": "cjs"
       }
     ]
   ]

--- a/packages/babel-plugin-zent/__tests__/index.spec.js
+++ b/packages/babel-plugin-zent/__tests__/index.spec.js
@@ -55,8 +55,9 @@ describe('babel-plugin-zent', () => {
   it('warns on require', () => {
     const errorFn = jest.spyOn(console, 'error');
 
-    expect(() => compile("require('zent')")).not.toThrowError();
-    expect(() => compile("require('foobar')").toBe("require('foobar')"));
+    expect(compile("require('foobar')")).toBe("require('foobar');");
+
+    expect(compile("require('zent')")).toBe("require('zent');");
     expect(errorFn).toHaveBeenCalledTimes(1);
     expect(errorFn).toHaveBeenCalledWith(
       expect.stringMatching(/`require\('zent'\)` is ignored/)

--- a/packages/babel-plugin-zent/__tests__/index.spec.js
+++ b/packages/babel-plugin-zent/__tests__/index.spec.js
@@ -52,12 +52,17 @@ describe('babel-plugin-zent', () => {
     );
   });
 
-  it('throws on require', () => {
-    expect(() => compile("require('zent')")).toThrowError(
-      /require\('zent'\) is not allowed/
+  it('warns on require', () => {
+    const errorFn = jest.spyOn(console, 'error');
+
+    expect(() => compile("require('zent')")).not.toThrowError();
+    expect(() => compile("require('foobar')").toBe("require('foobar')"));
+    expect(errorFn).toHaveBeenCalledTimes(1);
+    expect(errorFn).toHaveBeenCalledWith(
+      expect.stringMatching(/`require\('zent'\)` is ignored/)
     );
 
-    expect(() => compile("require('foobar')").toBe("require('foobar')"));
+    errorFn.mockRestore();
   });
 
   it('throws if module mapping file not found', () => {

--- a/packages/babel-plugin-zent/package.json
+++ b/packages/babel-plugin-zent/package.json
@@ -13,7 +13,7 @@
     "lib"
   ],
   "dependencies": {
-    "@babel/runtime": "^7.1.5"
+    "chalk": "^4.1.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.5",

--- a/packages/babel-plugin-zent/src/index.js
+++ b/packages/babel-plugin-zent/src/index.js
@@ -10,6 +10,8 @@
 // import Button from 'zent-button';
 // require('zent-button')
 
+import chalk from 'chalk';
+
 const hasOwn = Object.prototype.hasOwnProperty;
 
 export default function babelPluginZent(babel) {
@@ -21,7 +23,7 @@ export default function babelPluginZent(babel) {
         const { node } = path;
         const libName = getLibraryName(state);
 
-        // no require('zent') calls
+        // No require('zent') calls
         if (
           t.isIdentifier(node.callee, { name: 'require' }) &&
           node.arguments &&
@@ -29,8 +31,12 @@ export default function babelPluginZent(babel) {
         ) {
           const source = node.arguments[0];
           if (t.isStringLiteral(source, { value: libName })) {
-            throw path.buildCodeFrameError(
-              `require('${libName}') is not allowed, use import { ... } from '${libName}'`
+            console.error(
+              chalk.red(
+                `\`require('${libName}')\` is ignored, use \`import { ... } from '${libName}'\`\n` +
+                  `The actual cause of this might be \`@babel/preset-env\` \`modules\` option is resolved to \`cjs\`\n` +
+                  `Use the \`debug\` option in \`@babel/preset-env\` to check this\n`
+              )
             );
           }
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3073,6 +3073,14 @@ chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"


### PR DESCRIPTION
1. Bump required Node.js to 12
2. Better error message when processing `require('zent')`, and `console.error` instead of throwing an error