### PR TITLE
keep startDate's time value when endDate updates in combined-date-picker(#1823)

### DIFF
--- a/packages/zent/src/date-picker/README_en-US.md
+++ b/packages/zent/src/date-picker/README_en-US.md
@@ -117,8 +117,8 @@ interface IDisableDateMap {
 ```ts
 interface IDisabledTimeOption {
 	disabledHours?: () => number[];
-	disabledMinutes: (hour: number) => number[];;
-	disabledSeconds?: (hour: number, minute: number) => number[];;
+	disabledMinutes: (hour: number) => number[];
+	disabledSeconds?: (hour: number, minute: number) => number[];
 }
 ```
 

--- a/packages/zent/src/date-picker/README_zh-CN.md
+++ b/packages/zent/src/date-picker/README_zh-CN.md
@@ -122,8 +122,8 @@ interface IDisableDateMap {
 ```ts
 interface IDisabledTimeOption {
 	disabledHours?: () => number[];
-	disabledMinutes: (hour: number) => number[];;
-	disabledSeconds?: (hour: number, minute: number) => number[];;
+	disabledMinutes: (hour: number) => number[];
+	disabledSeconds?: (hour: number, minute: number) => number[];
 }
 ```
 

--- a/packages/zent/src/date-picker/components/TimeRangePickerBase.tsx
+++ b/packages/zent/src/date-picker/components/TimeRangePickerBase.tsx
@@ -89,7 +89,6 @@ const TimeRangePickerBase: React.FC<ITimeRangePickerBaseProps> = ({
             onOpen={() => onOpen?.(START)}
             onClose={() => onClose?.(START)}
             name={name?.[0]}
-            autoComplete={true}
             placeholder={placeholder[0]}
           />
           <span className="zent-datepicker-seperator">{seperator}</span>
@@ -102,7 +101,6 @@ const TimeRangePickerBase: React.FC<ITimeRangePickerBaseProps> = ({
             onOpen={() => onOpen?.(END)}
             onClose={() => onClose?.(END)}
             name={name?.[1]}
-            autoComplete={true}
             placeholder={placeholder[1]}
           />
         </PanelContextProvider>

--- a/packages/zent/src/date-picker/panels/combined-date-range-panel/index.tsx
+++ b/packages/zent/src/date-picker/panels/combined-date-range-panel/index.tsx
@@ -57,9 +57,7 @@ const CombinedDateRangePanel: React.FC<ICombinedDateRangePanelProps> = ({
           : defaultTimeEnd;
       if (start && !end) {
         selectedTemp = [
-          startShowTime
-            ? parse(defaultStartTime(start), formatStart, start)
-            : startOfDay(start),
+          startShowTime ? start : startOfDay(start),
           endShowTime
             ? parse(defaultEndTime(val), formatEnd, val)
             : endOfDay(val),


### PR DESCRIPTION
Fixes #1823 .
1. Keep startDate's time value when endDate updates in combined-date-picker
2. OnChange can be triggered only when the confirm button is clicked in time-range-picker