### PR TITLE
add destroyOnUnmount and normalizeBeforeSubmit support to FieldSet and FieldArray

### DIFF
--- a/packages/zent/src/form/FieldSet.tsx
+++ b/packages/zent/src/form/FieldSet.tsx
@@ -68,8 +68,19 @@ export function FieldSet<T extends UnknownFieldSetModelChildren>(
   } = props as IFieldSetBaseProps<T>;
   const { name } = props as IFieldSetViewDrivenProps<T>;
   const { model: rawModel } = props as IFieldSetModelDrivenProps<T>;
+
   // It's safe to use `any`
   const [ctx, model] = useFieldSet<T>((name ?? rawModel) as any, validators);
+
+  if (isFieldSetViewDrivenProps(props)) {
+    const { normalizeBeforeSubmit, destroyOnUnmount } = props;
+
+    model.destroyOnUnmount = Boolean(destroyOnUnmount);
+    if (normalizeBeforeSubmit) {
+      model.normalizeBeforeSubmit = normalizeBeforeSubmit;
+    }
+  }
+
   useImperativeHandle(modelRef, () => model, [model]);
   useFormChild(model as BasicModel<unknown>, scrollAnchorRef);
   useObservableEagerState(model.error$);
@@ -79,4 +90,10 @@ export function FieldSet<T extends UnknownFieldSetModelChildren>(
       {renderError(model.error as IMaybeError<any>)}
     </FormProvider>
   );
+}
+
+function isFieldSetViewDrivenProps<T extends UnknownFieldSetModelChildren>(
+  props: IFieldSetModelDrivenProps<T> | IFieldSetViewDrivenProps<T>
+): props is IFieldSetViewDrivenProps<T> {
+  return (props as IFieldSetViewDrivenProps<T>).name !== undefined;
 }

--- a/packages/zent/src/form/formulr/builders/array.ts
+++ b/packages/zent/src/form/formulr/builders/array.ts
@@ -36,6 +36,7 @@ export class FieldArrayBuilder<
       or(defaultValue, () => this._defaultValue)
     );
     model.validators = this._validators;
+    model.normalizeBeforeSubmit = this._normalizeBeforeSubmit;
 
     // Remove readonly modifier temporarily
     (model.builder as FieldArrayBuilder<ChildBuilder>) = this;

--- a/packages/zent/src/form/formulr/builders/basic.ts
+++ b/packages/zent/src/form/formulr/builders/basic.ts
@@ -1,3 +1,5 @@
+import identity from '../../../utils/identity';
+import { INormalizeBeforeSubmit } from '../models';
 import { IModel } from '../models/base';
 import { IValidators } from '../validate';
 
@@ -11,6 +13,16 @@ export type $GetBuilderModel<T> = T extends BasicBuilder<infer _, infer M>
 
 export abstract class BasicBuilder<Value, Model extends IModel<Value>> {
   protected _validators: IValidators<Value> = [];
+
+  protected _normalizeBeforeSubmit: INormalizeBeforeSubmit<Value, any> =
+    identity;
+
+  normalizeBeforeSubmit<T>(
+    normalizeBeforeSubmit: INormalizeBeforeSubmit<Value, T>
+  ) {
+    this._normalizeBeforeSubmit = normalizeBeforeSubmit;
+    return this;
+  }
 
   abstract build(defaultValue?: unknown): Model;
 

--- a/packages/zent/src/form/formulr/builders/field.ts
+++ b/packages/zent/src/form/formulr/builders/field.ts
@@ -1,7 +1,6 @@
-import { FieldModel, INormalizeBeforeSubmit } from '../models';
+import { FieldModel } from '../models';
 import { BasicBuilder } from './basic';
 import { Maybe, or } from '../maybe';
-import { id } from '../utils';
 
 export class FieldBuilder<Value> extends BasicBuilder<
   Value,
@@ -9,15 +8,6 @@ export class FieldBuilder<Value> extends BasicBuilder<
 > {
   constructor(protected _defaultValue: Value) {
     super();
-  }
-
-  private _normalizeBeforeSubmit: INormalizeBeforeSubmit<Value, any> = id;
-
-  normalizeBeforeSubmit<T>(
-    normalizeBeforeSubmit: INormalizeBeforeSubmit<Value, T>
-  ) {
-    this._normalizeBeforeSubmit = normalizeBeforeSubmit;
-    return this;
   }
 
   build(defaultValue?: Maybe<Value>) {

--- a/packages/zent/src/form/formulr/builders/set.ts
+++ b/packages/zent/src/form/formulr/builders/set.ts
@@ -46,6 +46,7 @@ export class FieldSetBuilder<
       children as $FieldSetBuilderChildren<ChildBuilders>
     );
     model.validators = this._validators;
+    model.normalizeBeforeSubmit = this._normalizeBeforeSubmit;
 
     // Remove readonly modifier temporarily
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion

--- a/packages/zent/src/form/formulr/field-utils.ts
+++ b/packages/zent/src/form/formulr/field-utils.ts
@@ -10,9 +10,10 @@ import {
   unstable_IdlePriority as IdlePriority,
   unstable_scheduleCallback as scheduleCallback,
 } from 'scheduler';
+import identity from '../../utils/identity';
 import { FieldModel } from './models/field';
 import { ValidateOption } from './validate';
-import { id, last } from './utils';
+import { last } from './utils';
 
 export function multi<T, R>(...funcs: ((t: T) => R)[]): (t: T) => void {
   return (t: T) => {
@@ -222,7 +223,10 @@ export function usePipe<T, R>(...args: any[]): (v: T) => R {
     deps = args;
   }
   return useMemo(() => {
-    const fn = args.reduceRight((next, f) => (arg: any) => next(f(arg)), id);
+    const fn = args.reduceRight(
+      (next, f) => (arg: any) => next(f(arg)),
+      identity
+    );
     return (t: T): R => fn(t);
   }, deps); // eslint-disable-line react-hooks/exhaustive-deps
 }

--- a/packages/zent/src/form/formulr/models/field.ts
+++ b/packages/zent/src/form/formulr/models/field.ts
@@ -1,8 +1,8 @@
 import { BehaviorSubject } from 'rxjs';
+import identity from '../../../utils/identity';
 import { BasicModel } from './basic';
 import { Some, None, or, isSome, get } from '../maybe';
 import { ValidateOption } from '../validate';
-import { id } from '../utils';
 import isNil from '../../../utils/isNil';
 import uniqueId from '../../../utils/uniqueId';
 import { FIELD_ID } from './is';
@@ -41,7 +41,7 @@ class FieldModel<Value> extends BasicModel<Value> {
   /**
    * 用于表单提交前格式化 `Field` 值的回调函数
    */
-  normalizeBeforeSubmit: INormalizeBeforeSubmit<Value, any> = id;
+  normalizeBeforeSubmit: INormalizeBeforeSubmit<Value, any> = identity;
 
   owner: BasicModel<any> | null = null;
 

--- a/packages/zent/src/form/formulr/utils.ts
+++ b/packages/zent/src/form/formulr/utils.ts
@@ -8,8 +8,6 @@ export function last<T>(arr: T[]) {
   return arr.length ? arr[arr.length - 1] : null;
 }
 
-export const id = <T>(it: T) => it;
-
 export function useDestroyOnUnmount<Model extends BasicModel<any>>(
   field: string | BasicModel<any> | ModelRef<any, any, Model>,
   model: BasicModel<any>,


### PR DESCRIPTION
- Add `destroyOnUnmount` and `normalizeBeforeSubmit` support to `FieldSet` and `FieldArray`
- Fix crash when using `destroyOnUnmount` on `FieldSet` and `value` is never read