### PR TITLE
日期选择器选择具体时间时，确认按钮置为disabled

### DIFF
--- a/packages/zent/src/date-picker/panels/date-panel/DateFooter.tsx
+++ b/packages/zent/src/date-picker/panels/date-panel/DateFooter.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useMemo } from 'react';
+import { useCallback, useContext, useMemo, useState } from 'react';
 import cx from 'classnames';
 import { parse } from 'date-fns';
 import Pop from '../../../pop';
@@ -27,6 +27,7 @@ const DatePickerFooter: React.FC<IDatePickerFooterProps> = ({
   onSelected,
   disabledPanelDate,
 }) => {
+  const [timePickerIsOpen, setTimePickerIsOpen] = useState<boolean>(false);
   const { i18n, autoComplete } = useContext(PickerContext);
   const { format = '' } = showTimeOption || {};
   const confirmStatus = useConfirmStatus({
@@ -61,14 +62,23 @@ const DatePickerFooter: React.FC<IDatePickerFooterProps> = ({
     () => (
       <Button
         type="primary"
-        disabled={confirmStatus || isDisableConfirm || !selected}
+        disabled={
+          confirmStatus || isDisableConfirm || !selected || timePickerIsOpen
+        }
         onClick={confirmHandler}
         className={`${footerPrefixCls}-btn`}
       >
         {i18n.confirm}
       </Button>
     ),
-    [i18n, confirmStatus, selected, isDisableConfirm, confirmHandler]
+    [
+      i18n,
+      confirmStatus,
+      selected,
+      isDisableConfirm,
+      confirmHandler,
+      timePickerIsOpen,
+    ]
   );
 
   const renderToday = useMemo(() => {
@@ -118,7 +128,8 @@ const DatePickerFooter: React.FC<IDatePickerFooterProps> = ({
   );
 
   const timeInput = useMemo(() => {
-    const { defaultTime, ...restOption } = showTimeOption || {};
+    const { defaultTime, onOpen, onClose, ...restOption } =
+      showTimeOption || {};
     const defaultTimeString =
       typeof defaultTime === 'function' ? defaultTime(selected) : defaultTime;
 
@@ -131,6 +142,14 @@ const DatePickerFooter: React.FC<IDatePickerFooterProps> = ({
         value={formatDate(format, selected)}
         hiddenIcon={true}
         onChange={onTimeChange}
+        onOpen={() => {
+          onOpen?.();
+          setTimePickerIsOpen(true);
+        }}
+        onClose={() => {
+          onClose?.();
+          setTimePickerIsOpen(false);
+        }}
         disabledTime={disabledTime}
         autoComplete={autoComplete}
       />

--- a/packages/zent/src/date-picker/panels/date-panel/DateFooter.tsx
+++ b/packages/zent/src/date-picker/panels/date-panel/DateFooter.tsx
@@ -27,7 +27,7 @@ const DatePickerFooter: React.FC<IDatePickerFooterProps> = ({
   onSelected,
   disabledPanelDate,
 }) => {
-  const [timePickerIsOpen, setTimePickerIsOpen] = useState<boolean>(false);
+  const [timePickerIsOpen, setTimePickerIsOpen] = useState(false);
   const { i18n, autoComplete } = useContext(PickerContext);
   const { format = '' } = showTimeOption || {};
   const confirmStatus = useConfirmStatus({

--- a/packages/zent/src/date-picker/panels/date-panel/DateFooter.tsx
+++ b/packages/zent/src/date-picker/panels/date-panel/DateFooter.tsx
@@ -126,10 +126,14 @@ const DatePickerFooter: React.FC<IDatePickerFooterProps> = ({
     },
     [selected, format, onSelected]
   );
-
+  const onTimeOpen = useCallback(() => {
+    setTimePickerIsOpen(true);
+  }, []);
+  const onTimeClose = useCallback(() => {
+    setTimePickerIsOpen(false);
+  }, []);
   const timeInput = useMemo(() => {
-    const { defaultTime, onOpen, onClose, ...restOption } =
-      showTimeOption || {};
+    const { defaultTime, ...restOption } = showTimeOption || {};
     const defaultTimeString =
       typeof defaultTime === 'function' ? defaultTime(selected) : defaultTime;
 
@@ -142,14 +146,8 @@ const DatePickerFooter: React.FC<IDatePickerFooterProps> = ({
         value={formatDate(format, selected)}
         hiddenIcon={true}
         onChange={onTimeChange}
-        onOpen={() => {
-          onOpen?.();
-          setTimePickerIsOpen(true);
-        }}
-        onClose={() => {
-          onClose?.();
-          setTimePickerIsOpen(false);
-        }}
+        onOpen={onTimeOpen}
+        onClose={onTimeClose}
         disabledTime={disabledTime}
         autoComplete={autoComplete}
       />
@@ -162,6 +160,8 @@ const DatePickerFooter: React.FC<IDatePickerFooterProps> = ({
     format,
     disabledTime,
     onTimeChange,
+    onTimeOpen,
+    onTimeClose,
   ]);
 
   return <PanelFooter leftNode={timeInput} rightNode={renderToday} />;

--- a/packages/zent/src/date-picker/types.ts
+++ b/packages/zent/src/date-picker/types.ts
@@ -212,8 +212,6 @@ interface ITimePickerBase<T> {
   openPanel?: boolean;
   width?: string | number;
   className?: string;
-  onOpen?: () => void;
-  onClose?: () => void;
 }
 
 interface ITimePickerProps<T = SingleTime> extends ITimePickerBase<T> {
@@ -222,6 +220,8 @@ interface ITimePickerProps<T = SingleTime> extends ITimePickerBase<T> {
   hiddenIcon?: boolean;
   autoComplete?: boolean;
   disabledTime?: IDisabledTime;
+  onOpen?: () => void;
+  onClose?: () => void;
 }
 
 export interface ISingleTimePickerProps extends ITimePickerProps<SingleTime> {

--- a/packages/zent/src/date-picker/types.ts
+++ b/packages/zent/src/date-picker/types.ts
@@ -212,6 +212,8 @@ interface ITimePickerBase<T> {
   openPanel?: boolean;
   width?: string | number;
   className?: string;
+  onOpen?: () => void;
+  onClose?: () => void;
 }
 
 interface ITimePickerProps<T = SingleTime> extends ITimePickerBase<T> {
@@ -220,8 +222,6 @@ interface ITimePickerProps<T = SingleTime> extends ITimePickerBase<T> {
   hiddenIcon?: boolean;
   autoComplete?: boolean;
   disabledTime?: IDisabledTime;
-  onOpen?: () => void;
-  onClose?: () => void;
 }
 
 export interface ISingleTimePickerProps extends ITimePickerProps<SingleTime> {


### PR DESCRIPTION
当日期选择器设置了showTimes属性选择具体时间时，通过onOpen和onClose修改timePicker的选择面板开启状态，当选择面板开启时，确认按钮置为disabled
