### PR TITLE
V10 tooltip

### DIFF
--- a/packages/zent/assets/tooltip.scss
+++ b/packages/zent/assets/tooltip.scss
@@ -5,7 +5,6 @@
 .zent-tooltip-v2 {
   @include font-normal;
   @include theme-color(background-color, stroke, 1);
-  @include theme-shadow(layer);
 
   border-radius: 2px;
   z-index: 2000;
@@ -15,13 +14,12 @@
     @include theme-color(color, stroke, 9);
     position: relative;
     border-radius: 2px;
-    padding: 5px 6px;
+    padding: 2px 6px;
     z-index: 2;
   }
 
   .zent-tooltip-v2-arrow {
     @include theme-color(background-color, stroke, 1);
-    @include theme-shadow(layer);
 
     position: absolute;
     z-index: 1;

--- a/packages/zent/assets/tooltip.scss
+++ b/packages/zent/assets/tooltip.scss
@@ -4,23 +4,23 @@
 
 .zent-tooltip-v2 {
   @include font-normal;
-  @include theme-color(background-color, stroke, 2);
+  @include theme-color(background-color, stroke, 1);
   @include theme-shadow(layer);
 
   border-radius: 2px;
   z-index: 2000;
 
   .zent-tooltip-v2-inner {
-    @include theme-color(background-color, stroke, 2);
+    @include theme-color(background-color, stroke, 1);
     @include theme-color(color, stroke, 9);
     position: relative;
     border-radius: 2px;
-    padding: 8px 16px;
+    padding: 5px 6px;
     z-index: 2;
   }
 
   .zent-tooltip-v2-arrow {
-    @include theme-color(background-color, stroke, 2);
+    @include theme-color(background-color, stroke, 1);
     @include theme-shadow(layer);
 
     position: absolute;

--- a/packages/zent/src/tooltip/README_en-US.md
+++ b/packages/zent/src/tooltip/README_en-US.md
@@ -1,7 +1,7 @@
 ---
 title: Tooltip
 path: component/tooltip
-group: FIXME group name here
+group: Data Display
 ---
 
 ## Tooltip

--- a/packages/zent/src/tooltip/README_zh-CN.md
+++ b/packages/zent/src/tooltip/README_zh-CN.md
@@ -2,7 +2,7 @@
 title: Tooltip
 subtitle: 工具提示
 path: component/tooltip
-group: 展示
+group: 信息展示
 ---
 
 ## Tooltip

--- a/packages/zent/src/tooltip/README_zh-CN.md
+++ b/packages/zent/src/tooltip/README_zh-CN.md
@@ -1,6 +1,6 @@
 ---
 title: Tooltip
-subtitle: 文字提示
+subtitle: 工具提示
 path: component/tooltip
 group: 展示
 ---

--- a/packages/zent/src/tooltip/Tooltip.tsx
+++ b/packages/zent/src/tooltip/Tooltip.tsx
@@ -50,8 +50,8 @@ type ITooltipProps =
 export class Tooltip extends Component<ITooltipProps> {
   static defaultProps = {
     trigger: 'hover',
-    position: 'top-center',
-    cushion: 10,
+    position: 'bottom-center',
+    cushion: 8,
     centerArrow: false,
     containerSelector: 'body',
   };

--- a/packages/zent/src/tooltip/Tooltip.tsx
+++ b/packages/zent/src/tooltip/Tooltip.tsx
@@ -50,7 +50,7 @@ type ITooltipProps =
 export class Tooltip extends Component<ITooltipProps> {
   static defaultProps = {
     trigger: 'hover',
-    position: 'bottom-center',
+    position: 'top-center',
     cushion: 8,
     centerArrow: false,
     containerSelector: 'body',

--- a/packages/zent/src/tooltip/demos/positions.md
+++ b/packages/zent/src/tooltip/demos/positions.md
@@ -36,25 +36,13 @@ ReactDOM.render(
 			</Tooltip>
 		</div>
 		<div className="zent-doc-tooltip-positions-left-col">
-			<Tooltip trigger={trigger} position="left-top" title="LT">
-				<Button>LeftTop</Button>
-			</Tooltip>
 			<Tooltip trigger={trigger} position="left-center" title="LC">
 				<Button>LeftCenter</Button>
 			</Tooltip>
-			<Tooltip trigger={trigger} position="left-bottom" title="LB">
-				<Button>LeftBottom</Button>
-			</Tooltip>
 		</div>
 		<div className="zent-doc-tooltip-positions-right-col">
-			<Tooltip trigger={trigger} position="right-top" title="RT">
-				<Button>RightTop</Button>
-			</Tooltip>
 			<Tooltip trigger={trigger} position="right-center" title="RC">
 				<Button>RightCenter</Button>
-			</Tooltip>
-			<Tooltip trigger={trigger} position="right-bottom" title="RB">
-				<Button>RightBottom</Button>
 			</Tooltip>
 		</div>
 	</div>,

--- a/packages/zent/src/tooltip/demos/positions.md
+++ b/packages/zent/src/tooltip/demos/positions.md
@@ -52,6 +52,7 @@ ReactDOM.render(
 
 <style>
   .zent-doc-tooltip-positions {
+		width: 630px;
     position: relative;
 
 		&-top-row,
@@ -65,7 +66,7 @@ ReactDOM.render(
     }
 
     &-bottom-row {
-      margin-top: 200px;
+      margin-top: 64px;
     }
 
     &-left-col, &-right-col {
@@ -90,7 +91,7 @@ ReactDOM.render(
     }
 
     &-right-col {
-      right: 0;
+      right: -10px;
     }
 
     .zent-tooltip-wrapper {


### PR DESCRIPTION
- 🦀️   `tooltip`背景色与padding大小的修改，去掉阴影
- 📚  文档中删除LT、LB、RT、RB 四个方向。