### PR TITLE
fix: 修复 withPop HOC 的类型错误

### DIFF
--- a/packages/zent/src/popover/withPopover.tsx
+++ b/packages/zent/src/popover/withPopover.tsx
@@ -28,7 +28,7 @@ export function exposePopover<N extends string>(propName: N) {
     const componentName =
       Base.displayName || Base.constructor.name || 'Component';
     const shouldPassRef = isClassComponent(Base) || isForwardRef(Base);
-    const comp = forwardRef<any, Props>((props, ref) => {
+    const comp = forwardRef<any, Omit<Props, N>>((props, ref) => {
       const popover = usePopover();
       const childProps: any = {
         [propName]: popover,


### PR DESCRIPTION
- 去除 withPop 生成的 HOC 组件的 props 类型中多余的字段
