### PR TITLE
feat: 添加 normalizeBeforeBlur 属性，支持 onBlur 时修改值

### DIFF
--- a/packages/zent/src/form/Field.tsx
+++ b/packages/zent/src/form/Field.tsx
@@ -116,7 +116,7 @@ export function FormField<Value>(props: IFormFieldProps<Value>) {
     validateOccasion = ValidateOccasion.Default,
     getValidateOption = defaultGetValidateOption,
     normalize = id,
-    normalizeBeforeBlur = id,
+    normalizeBeforeBlur,
     format = id,
     withoutLabel,
     touchWhen = TouchWhen.Change,
@@ -169,7 +169,9 @@ export function FormField<Value>(props: IFormFieldProps<Value>) {
       if (touchWhen === TouchWhen.Blur) {
         model.isTouched = true;
       }
-      model.value = normalizeBeforeBlur(model.value);
+      if (normalizeBeforeBlur) {
+        model.value = normalizeBeforeBlur(model.value);
+      }
       if (validateOccasion & ValidateOccasion.Blur) {
         model.validate(getValidateOption('blur'));
       }

--- a/packages/zent/src/form/Field.tsx
+++ b/packages/zent/src/form/Field.tsx
@@ -116,6 +116,7 @@ export function FormField<Value>(props: IFormFieldProps<Value>) {
     validateOccasion = ValidateOccasion.Default,
     getValidateOption = defaultGetValidateOption,
     normalize = id,
+    normalizeBeforeBlur = id,
     format = id,
     withoutLabel,
     touchWhen = TouchWhen.Change,
@@ -168,12 +169,20 @@ export function FormField<Value>(props: IFormFieldProps<Value>) {
       if (touchWhen === TouchWhen.Blur) {
         model.isTouched = true;
       }
+      model.value = normalizeBeforeBlur(model.value);
       if (validateOccasion & ValidateOccasion.Blur) {
         model.validate(getValidateOption('blur'));
       }
       onBlurProps?.(e);
     },
-    [getValidateOption, validateOccasion, touchWhen, model, onBlurProps]
+    [
+      getValidateOption,
+      validateOccasion,
+      normalizeBeforeBlur,
+      touchWhen,
+      model,
+      onBlurProps,
+    ]
   );
   const { onCompositionStart, onCompositionEnd } =
     FieldUtils.useCompositionHandler(model, {

--- a/packages/zent/src/form/README_zh-CN.md
+++ b/packages/zent/src/form/README_zh-CN.md
@@ -365,7 +365,7 @@ type Middleware<T> = (next: IValidator<T>) => IValidator<T>;
 
 - `Form.useFieldArrayChildModels`
 - `Form.useNamedChildModel(parent: FieldSetModel, name: string): BasicModel`，注意 `FormModel` 是 `FieldSetModel` 的子类，所以也适用于这个方法。
-	
+
 这两个 hook 不监听子 model 内部状态的变化，如有需要，需使用它们返回的 model 对象自行调用 `useField` 等 hook 来实现。
 
 通过结合上述这些能力，就可以完成 `Model` 模式下表单项的动态增删了。
@@ -375,6 +375,7 @@ type Middleware<T> = (next: IValidator<T>) => IValidator<T>;
 ### 表单值的格式化
 
 - 可以通过 `normalize` 和 `format` 参数来格式化 `Field` 的输入输出
+- 可以通过 `normalizeBeforeBlur` 方法，在 `InputField` 等输入框触发 `onBlur` 事件时修改 `model` 内的值
 - 也可以使用 `normalizeBeforeSubmit` 属性和 `form.getSubmitValue()` 方法，在不改变 model 内存储值的情况下修改表单提交的值
 
 <!-- demo-slot-11 -->
@@ -432,7 +433,7 @@ type Middleware<T> = (next: IValidator<T>) => IValidator<T>;
 `Form` 组件使用 `flex` 布局，有两个参数控制基本的布局结构
 
 - `layout` 控制**表单项内**的布局方式，支持水平 `horizontal` 和垂直 `vertical` 两种布局
-- `direction` 控制**表单项间**的排列方式，支持 `column` 和 `row` 两种排列。 
+- `direction` 控制**表单项间**的排列方式，支持 `column` 和 `row` 两种排列。
 
 水平排列通常来说需要设置表单项的**最小宽度**才能正常工作，可以通过 `FormContext` 中的 `controlStyle` 来批量设置。
 

--- a/packages/zent/src/form/demos/11.normalizer.md
+++ b/packages/zent/src/form/demos/11.normalizer.md
@@ -9,7 +9,7 @@ en-US:
 ---
 
 ```jsx
-import { FormInputField, Form, FormStrategy } from 'zent';
+import { FormInputField, Form, FormStrategy, Validators } from 'zent';
 
 function App() {
 	const form = Form.useForm(FormStrategy.View);
@@ -18,6 +18,7 @@ function App() {
 			<FormInputField
 				name="field1"
 				label="field1"
+				normalizeBeforeBlur={value => value.trim()}
 				normalize={value => value.toUpperCase()}
 				format={value => value.toLowerCase()}
 			/>

--- a/packages/zent/src/form/shared.tsx
+++ b/packages/zent/src/form/shared.tsx
@@ -154,9 +154,13 @@ export interface IFormFieldPropsBase<Value>
    */
   validateOccasion?: ValidateOccasion;
   /**
-   * 触发onChange时会先经过 `normalize` 再写入到内部的 `model `上
+   * 触发 onChange 时会先经过 `normalize` 再写入到内部的 `model `上
    */
   normalize?: (value: Value, prevValue: Value) => Value;
+  /**
+   * 触发 onBlur 时会先经过 `normalizeBeforeBlur` 再写入到内部的 `model `上
+   */
+  normalizeBeforeBlur?: (value: Value) => Value;
   /**
    * 渲染前会先经过 `format`
    */

--- a/packages/zent/src/form/shared.tsx
+++ b/packages/zent/src/form/shared.tsx
@@ -158,7 +158,7 @@ export interface IFormFieldPropsBase<Value>
    */
   normalize?: (value: Value, prevValue: Value) => Value;
   /**
-   * 触发 onBlur 时会先经过 `normalizeBeforeBlur` 再写入到内部的 `model `上
+   * 触发 onBlur 时会经过 `normalizeBeforeBlur`，将返回值作为新的 `model` 值进行更新
    */
   normalizeBeforeBlur?: (value: Value) => Value;
   /**


### PR DESCRIPTION
使用场景：

- 在输入框失焦时，删除头部和尾部的空字符

```
<FormInputField
  name="field"
  label="field"
  normalizeBeforeBlur={value => value.trim()}
/>
```