### PR TITLE
fix: 修复css variable名字匹配问题,老版颜色可覆盖,删除无用前缀

### DIFF
--- a/packages/zent/assets/theme/semantic/_color.scss
+++ b/packages/zent/assets/theme/semantic/_color.scss
@@ -144,57 +144,66 @@ $color-sets: (
 
 // old
 // Text colors
-$theme-stroke-1: map-get($title-colors, 'color'); // text
-$theme-stroke-2: map-get($hint-colors, 'color'); // text
-$theme-stroke-3: map-get($hint-colors, 'color'); // help text
-$theme-stroke-4: map-get($disabled-colors, 'color'); // disabled text
+$theme-stroke-1: map-get($title-colors, 'color') !default; // text
+$theme-stroke-2: map-get($hint-colors, 'color') !default; // text
+$theme-stroke-3: map-get($hint-colors, 'color') !default; // help text
+$theme-stroke-4: map-get($disabled-colors, 'color') !default; // disabled text
 
 // Border and line colors
-$theme-stroke-5: map-get($section-colors, 'border-color');
-$theme-stroke-6: map-get($section-colors, 'border-color');
+$theme-stroke-5: map-get($section-colors, 'border-color') !default;
+$theme-stroke-6: map-get($section-colors, 'border-color') !default;
 
 // Background colors
-$theme-stroke-7: map-get($section-colors, 'bg');
-$theme-stroke-8: map-get($section-colors, 'bg');
+$theme-stroke-7: map-get($section-colors, 'bg') !default;
+$theme-stroke-8: map-get($section-colors, 'bg') !default;
 $theme-stroke-9: map-get(
   $body-colors,
   'bg'
-); // White button normal background color
+) !default; // White button normal background color
 
 // Button background color
-$theme-stroke-10: map-get($section-colors, 'border-color'); // Active
-$theme-stroke-11: map-get(map-get($color-sets, 'body'), 'bg'); // Hover
+$theme-stroke-10: map-get($section-colors, 'border-color') !default; // Active
+$theme-stroke-11: map-get(map-get($color-sets, 'body'), 'bg') !default; // Hover
 
 // Blue(primary)
-$theme-primary-1: map-get(map-get($color-sets, 'primary'), 'active-bg');
-$theme-primary-2: map-get(map-get($color-sets, 'primary'), 'active-bg');
-$theme-primary-3: map-get(map-get($color-sets, 'primary'), 'active-bg');
-$theme-primary-4: map-get(map-get($color-sets, 'primary'), 'bg');
-$theme-primary-5: map-get(map-get($color-sets, 'primary'), 'hover-bg');
-$theme-primary-6: map-get(map-get($color-sets, 'primary'), 'hover-bg');
-$theme-primary-7: map-get(map-get($color-sets, 'primary'), 'hover-bg');
-$theme-primary-8: map-get(map-get($color-sets, 'default'), 'hover-bg');
+$theme-primary-1: map-get(
+  map-get($color-sets, 'primary'),
+  'active-bg'
+) !default;
+$theme-primary-2: map-get(
+  map-get($color-sets, 'primary'),
+  'active-bg'
+) !default;
+$theme-primary-3: map-get(
+  map-get($color-sets, 'primary'),
+  'active-bg'
+) !default;
+$theme-primary-4: map-get(map-get($color-sets, 'primary'), 'bg') !default;
+$theme-primary-5: map-get(map-get($color-sets, 'primary'), 'hover-bg') !default;
+$theme-primary-6: map-get(map-get($color-sets, 'primary'), 'hover-bg') !default;
+$theme-primary-7: map-get(map-get($color-sets, 'primary'), 'hover-bg') !default;
+$theme-primary-8: map-get(map-get($color-sets, 'default'), 'hover-bg') !default;
 
 // Green
-$theme-success-1: map-get(map-get($color-sets, 'success'), 'color');
-$theme-success-2: map-get(map-get($color-sets, 'success'), 'color');
-$theme-success-3: map-get(map-get($color-sets, 'success'), 'color');
-$theme-success-4: map-get(map-get($color-sets, 'success'), 'color');
-$theme-success-5: map-get(map-get($color-sets, 'success'), 'bg');
+$theme-success-1: map-get(map-get($color-sets, 'success'), 'color') !default;
+$theme-success-2: map-get(map-get($color-sets, 'success'), 'color') !default;
+$theme-success-3: map-get(map-get($color-sets, 'success'), 'color') !default;
+$theme-success-4: map-get(map-get($color-sets, 'success'), 'color') !default;
+$theme-success-5: map-get(map-get($color-sets, 'success'), 'bg') !default;
 
 // Red
-$theme-error-1: map-get(map-get($color-sets, 'danger'), 'color');
-$theme-error-2: map-get(map-get($color-sets, 'danger'), 'color');
-$theme-error-3: map-get(map-get($color-sets, 'danger'), 'color');
-$theme-error-4: map-get(map-get($color-sets, 'danger'), 'color');
-$theme-error-5: map-get(map-get($color-sets, 'danger'), 'bg');
+$theme-error-1: map-get(map-get($color-sets, 'danger'), 'color') !default;
+$theme-error-2: map-get(map-get($color-sets, 'danger'), 'color') !default;
+$theme-error-3: map-get(map-get($color-sets, 'danger'), 'color') !default;
+$theme-error-4: map-get(map-get($color-sets, 'danger'), 'color') !default;
+$theme-error-5: map-get(map-get($color-sets, 'danger'), 'bg') !default;
 
 // Orange
-$theme-warn-1: map-get(map-get($color-sets, 'warning'), 'color');
-$theme-warn-2: map-get(map-get($color-sets, 'warning'), 'color');
-$theme-warn-3: map-get(map-get($color-sets, 'warning'), 'color');
-$theme-warn-4: map-get(map-get($color-sets, 'warning'), 'color');
-$theme-warn-5: map-get(map-get($color-sets, 'warning'), 'bg');
+$theme-warn-1: map-get(map-get($color-sets, 'warning'), 'color') !default;
+$theme-warn-2: map-get(map-get($color-sets, 'warning'), 'color') !default;
+$theme-warn-3: map-get(map-get($color-sets, 'warning'), 'color') !default;
+$theme-warn-4: map-get(map-get($color-sets, 'warning'), 'color') !default;
+$theme-warn-5: map-get(map-get($color-sets, 'warning'), 'bg') !default;
 
 $loading-icon-youzan-color: #e00 !default;
 

--- a/packages/zent/assets/theme/semantic/_helper.scss
+++ b/packages/zent/assets/theme/semantic/_helper.scss
@@ -69,7 +69,7 @@
   @if is-old-version($cat, $attr) {
     @return #{$prefix}-#{get-mapping-css-var($cat, $attr)};
   }
-  @return #{$prefix}-rgb-#{get-css-var-name($cat, $attr)};
+  @return #{$prefix}-#{get-css-var-name($cat, $attr)};
 }
 
 @function get-size-var($map, $cat, $size) {

--- a/packages/zent/plugins/postcss-plugin-theme-css-vars.js
+++ b/packages/zent/plugins/postcss-plugin-theme-css-vars.js
@@ -66,7 +66,7 @@ module.exports = () => {
 
           if (isThemeVar) {
             const words = parseValue(decl.value);
-            const prefixName = /[a-zA-Z]+[^-]/.exec(decl.prop)[0];
+            const prefixName = /([a-zA-Z-]+)-colors/.exec(decl.prop)[1];
             let firstNodeSourceIndex;
             words.walk(node => {
               if (!firstNodeSourceIndex) {


### PR DESCRIPTION
1. 生成的theme-css-vars.json里weak-link匹配成了weak
2. 老版的$theme-stroke-x可以覆盖，加上!default
3.  内部无使用的get-rgb-css-var去除重复的rgb前缀