### PR TITLE
fix: sortable 拖拽中占位覆盖元素 zIndex 层级设置

### DIFF
--- a/packages/zent/assets/sortable.scss
+++ b/packages/zent/assets/sortable.scss
@@ -27,6 +27,7 @@
       position: absolute;
       top: 0;
       left: 0;
+      z-index: 1;
     }
   }
 }


### PR DESCRIPTION
- 🦀️ `sortable`元素拖拽中占位覆盖元素`zIndex`层级设置