### PR TITLE
fix: [sortable]移除拖拽元素overflow:hidden设置

### DIFF
--- a/packages/zent/assets/sortable.scss
+++ b/packages/zent/assets/sortable.scss
@@ -16,7 +16,6 @@
 
   .zent-sortable__ghost {
     position: relative;
-    overflow: hidden;
 
     &::before {
       @include theme-color(background-color, stroke, 8);


### PR DESCRIPTION
- 🦀️ `Sortable`取消拖拽过程中拖拽元素`overflow:hidden`样式设置
