### PR TITLE
feat: [Tabs]多标签滚动模式下, 隐藏项 tab 弹框宽度限制, 超出显示省略号

### DIFF
--- a/packages/zent/assets/tabs.scss
+++ b/packages/zent/assets/tabs.scss
@@ -236,7 +236,7 @@
   &-tabs {
     @include theme-color(background-color, stroke, 9);
     @include theme-shadow(modal);
-    min-width: 148px;
+    width: 148px;
     border-radius: 2px;
     max-height: 256px;
     overflow-y: scroll;
@@ -245,6 +245,9 @@
   &-tab {
     padding: 6px 12px;
     cursor: pointer;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 
     &:hover {
       @include theme-color(background-color, stroke, 8);


### PR DESCRIPTION
- `Tabs`
  - 🦀️ 多标签滚动模式下,隐藏项tab弹框宽度限制,超出显示省略号
