### PR TITLE
fix: [Select]修复使用文本高亮时正则特殊字符报错问题

### DIFF
--- a/packages/zent/src/select/Select.tsx
+++ b/packages/zent/src/select/Select.tsx
@@ -184,6 +184,7 @@ function defaultHighlight<
       searchWords={[keyword]}
       textToHighlight={option.text}
       highlightStyle={{ backgroundColor: 'initial', color: '#155bd4' }}
+      autoEscape
     />
   );
 }

--- a/packages/zent/src/select/demos/6.custom-search.md
+++ b/packages/zent/src/select/demos/6.custom-search.md
@@ -71,7 +71,7 @@ function CustomSearch() {
 			placeholder="{i18n.placeholder}"
 			filter={false}
 			loading={loading}
-			renderOptionContent={it => <TextMark searchWords={[keyword]} textToHighlight={it.text} />}
+			renderOptionContent={it => <TextMark searchWords={[keyword]} textToHighlight={it.text} autoEscape />}
 		/>
 	);
 }


### PR DESCRIPTION
- `Select`
  - 🦀 修复使用文本高亮时正则特殊字符报错问题 