### PR TITLE
fix(form): 修复vertical变更导致的demo样式布局错位

### DIFF
--- a/packages/zent/src/form/demos/9.model-first.md
+++ b/packages/zent/src/form/demos/9.model-first.md
@@ -207,7 +207,7 @@ function App() {
 	}, [form]);
 
 	return (
-		<Form className="demo-form" layout="vertical" form={form}>
+		<Form className="demo-form" layout="horizontal" form={form}>
 			<FormNumberInputField
 				model={number}
 				label="{i18n.totalNumber}："


### PR DESCRIPTION
- `form`
  - 📚  修复`vertical`变更导致的demo样式布局错位