### PR TITLE
fix(button): outline模式下修复hover背景色为#fff

### DIFF
--- a/packages/zent/assets/button.scss
+++ b/packages/zent/assets/button.scss
@@ -137,6 +137,7 @@ $btn-warning-active: 1;
   &:hover {
     @include theme-color(color, $name, $hover);
     @include theme-color(border-color, $name, $hover);
+    @include btn-white(background-color);
   }
 
   &:active {

--- a/packages/zent/src/button/demos/style.md
+++ b/packages/zent/src/button/demos/style.md
@@ -21,6 +21,7 @@ ReactDOM.render(
 	<div>
 		<div>
 			<Button type="primary">{i18n.button1}</Button>
+			<Button type="primary" outline>{i18n.button1}</Button>
 			<Button>{i18n.button3}</Button>
 			<Button type="text">{i18n.button2}</Button>
 			<Button type='icon' icon='search'></Button>


### PR DESCRIPTION
- `button`
  - 🦀  `outline`模式下修复`hover`背景色为#fff