### PR TITLE
fix(casacder): 修复级联选择器选中option文字没有加粗

### DIFF
--- a/packages/zent/src/cascader/components/MenuContent.tsx
+++ b/packages/zent/src/cascader/components/MenuContent.tsx
@@ -167,9 +167,9 @@ class MenuContent extends Component<IMenuContentProps> {
         'zent-cascader-v2__menu-item--disabled': node.disabled,
         'zent-cascader-v2__menu-item--multiple': multiple,
         'zent-cascader-v2__menu-item--multiple--checkbox':
-          multipleType === 'checkbox',
+          multiple && multipleType === 'checkbox',
         'zent-cascader-v2__menu-item--multiple--normal':
-          multipleType === 'normal',
+          multiple && multipleType === 'normal',
         'zent-cascader-v2__menu-item--leaf':
           node.children.length === 0 && !node.loadChildrenOnExpand,
       });


### PR DESCRIPTION
- `casacder`
  - 🦀  修复级联选择器选中`option`文字没有加粗