### PR TITLE
fix: [notice][placeholder]notice样式调整&placeholder类型补全

### DIFF
--- a/packages/zent/assets/notice.scss
+++ b/packages/zent/assets/notice.scss
@@ -89,7 +89,6 @@
 
   &-animation {
     flex: 0 0 auto;
-    overflow-y: hidden;
 
     &-enter {
       transition: transform 160ms ease-in;

--- a/packages/zent/src/placeholder/presets/RichTextBlock.tsx
+++ b/packages/zent/src/placeholder/presets/RichTextBlock.tsx
@@ -13,9 +13,9 @@ export interface IPlaceholderRichTextBlock {
   size?: number;
   animate?: boolean;
   dashed?: boolean;
-  widths;
-  dashSegments;
-  lineSpacing;
+  widths?: number[];
+  dashSegments?: Array<Array<string | number>>;
+  lineSpacing?: string | number;
 }
 
 export default class RichTextBlock extends PureComponent<IPlaceholderRichTextBlock> {


### PR DESCRIPTION
- `notice`
  - 🦀 去除`overflow-y: hidden`，解决下方阴影显示不完全的问题
- `placeholder`
  - 🦀 ts类型补全