### PR TITLE
fix(alert): Icon样式写法调整,与v9保证一致

### DIFF
--- a/packages/zent/assets/alert.scss
+++ b/packages/zent/assets/alert.scss
@@ -168,8 +168,8 @@ $type-map: (
     &.zenticon,
     .zent-loading-icon-and-text {
       width: 16px;
-      height: 16px;
-      padding-top: 2px;
+      height: 20px;
+      line-height: 20px;
     }
   }
 }


### PR DESCRIPTION
- `alert`
  - 🦀 Icon样式写法调整,与v9保证一致