### PR TITLE
fix: fix theme-colors-mapping

### DIFF
--- a/packages/zent/assets/theme/semantic/_color.scss
+++ b/packages/zent/assets/theme/semantic/_color.scss
@@ -321,15 +321,11 @@ $theme-colors-mapping: (
       attr: 'bg',
     ),
     (
-      cat: 'section',
-      attr: 'border-color',
-    ),
-    (
       cat: 'default',
       attr: 'border-color',
     ),
     (
-      cat: 'body',
+      cat: 'section',
       attr: 'bg',
     ),
   ),


### PR DESCRIPTION
Changes you made in this pull request:

- fix `stroke` set in `$theme-colors-mapping` definition，to be consistent with `$theme-colors`
