### PR TITLE
fix: fix disabled button's href and withErrorBoundary-onError type

### DIFF
--- a/packages/zent/__tests__/button.spec.jsx
+++ b/packages/zent/__tests__/button.spec.jsx
@@ -151,8 +151,8 @@ describe('<Button />', () => {
     );
     const buttonNode = findRenderedDOMComponentWithTag(tree, 'a');
     expect(buttonNode.classList.contains('zent-btn-disabled')).toBe(true);
+    expect(buttonNode.getAttribute('href')).toBe(null);
     /** call event.preventDefault within `onClick` callback */
-    expect(buttonNode.href).toBe('http://youzan.com/');
     Simulate.click(buttonNode);
     expect(isClicked).toBe(false);
   });

--- a/packages/zent/src/button/Button.tsx
+++ b/packages/zent/src/button/Button.tsx
@@ -66,7 +66,12 @@ export class Button extends Component<IButtonProps> {
         onMouseLeave={this.props.onMouseLeave}
       >
         {href || target ? (
-          <a href={href || ''} target={target} download={download} {...props}>
+          <a
+            href={disabled ? undefined : href || ''}
+            target={target}
+            download={download}
+            {...props}
+          >
             {children}
           </a>
         ) : (

--- a/packages/zent/src/button/README_zh-CN.md
+++ b/packages/zent/src/button/README_zh-CN.md
@@ -35,9 +35,14 @@ group: 基础控件
 | target    | 可选，和 href 一起使用，就是 a 标签的 target 属性 | string | `''`        | `'_blank'`                           |
 | download  | HTML5 的下载功能                                  | string |             |                                      |
 | className | 自定义类名                                        | string |             |                                      |
-| style     | 自定 style                                        | object |             |                                      |
+| style     | 自定义 style                                        | object |             |                                      |
 
 #### ButtonDirective
 
 这个组件会将 `Button` 的样式渲染到自己的 `children` 上，主要用在需要 `Button` 的样式，但是需要有特殊逻辑的按钮，例如将一个 `react-router` 的 `Link` 渲染成 `Button` 的样式，但是保留 `Link` 自身的功能。API 只支持 `Button` 的样式参数，用法参考 demo。
 
+#### disabled 状态
+
+Button 处于禁用状态时，传入的 `onClick` 事件回调不会触发；点击事件的默认行为会被禁止（`event.preventDefault()`），但不会禁止事件冒泡；
+
+如果传入了 `href` 属性，禁用时 `href` 不会传递给渲染的 a 标签。

--- a/packages/zent/src/error-boundary/withErrorBoundary.tsx
+++ b/packages/zent/src/error-boundary/withErrorBoundary.tsx
@@ -1,11 +1,12 @@
 import ErrorBoundary, {
   IErrorBoundaryFallbackComponentProps,
+  IOnErrorCallback,
 } from './ErrorBoundary';
 
 export interface IWithErrorBoundaryOption<P> {
   Component?: React.ComponentType<P>;
   FallbackComponent?: React.ComponentType<IErrorBoundaryFallbackComponentProps>;
-  onError?: (error: any) => void;
+  onError?: IOnErrorCallback;
 }
 
 export function withErrorBoundary<P>({


### PR DESCRIPTION
Changes you made in this pull request:

- Button: 渲染为 a 标签的情况下，在 disabled 状态时不传 href；
- withErrorBoundary: onError 类型修复；
