### PR TITLE
修复 NumberInput 渲染死循环的问题

### DIFF
--- a/packages/zent/src/number-input/NumberInput.tsx
+++ b/packages/zent/src/number-input/NumberInput.tsx
@@ -342,15 +342,19 @@ export class NumberInput extends Component<
         onChange && onChange(this.state.value as number);
       }
     } else {
-      const { onChange, decimal } = this.props;
+      const { onChange, decimal, value: propsValue } = this.props;
       const { value } = this.state as INumberInputDecimalState;
       const roundedStateValue = value.toFixed(decimal);
+      // 外部不规范的使用方式会去修改 onChange 抛出去的值以及它的类型，这里统一转成字符串
+      const roundedPropsValue =
+        typeof propsValue === 'number'
+          ? propsValue.toFixed(decimal)
+          : propsValue;
       if (
         onChange &&
         this.props.value !== '' &&
         this.state.input !== '' &&
-        // 外部传入的 value 有可能类型错误，转成字符串之后再比较
-        String(this.props.value) !== roundedStateValue
+        roundedPropsValue !== roundedStateValue
       ) {
         onChange(roundedStateValue);
       }


### PR DESCRIPTION
```jsx

// 输入 1.289
function Demo1() {
  const [value, setValue] = React.useState("1.00");

  return <NumberInput value={value} onChange={setValue} decimal={2} />;
}

function Demo2() {
  const [value, setValue] = React.useState(0);
  const [datasets, setDatasets] = React.useState([
    {
      id: 1,
      name: "test",
      value: 129,
    },
  ]);

  return (
    <>
      <NumberInput
        placeholder=""
        width={120}
        value={Number(value) / 100}
        max={100}
        min={0}
        addonAfter="%"
        decimal={2}
        onChange={(val) => {
          setValue(val);
        }}
      />
      <NumberInput
        placeholder=""
        width={120}
        value={Number(datasets[0].value) / 100}
        max={100}
        min={0}
        addonAfter="%"
        decimal={2}
        onChange={(val) => {
          console.log("onChange");
          const newData = [...datasets];
          newData[0].value = Number(val) * 100;
          setDatasets(newData);
        }}
      />
    </>
  );
}

```