### PR TITLE
fix: [withErrorBoundary] onError type

### DIFF
--- a/packages/zent/src/error-boundary/withErrorBoundary.tsx
+++ b/packages/zent/src/error-boundary/withErrorBoundary.tsx
@@ -1,11 +1,12 @@
 import ErrorBoundary, {
   IErrorBoundaryFallbackComponentProps,
+  IOnErrorCallback,
 } from './ErrorBoundary';
 
 export interface IWithErrorBoundaryOption<P> {
   Component?: React.ComponentType<P>;
   FallbackComponent?: React.ComponentType<IErrorBoundaryFallbackComponentProps>;
-  onError?: (error: any) => void;
+  onError?: IOnErrorCallback;
 }
 
 export function withErrorBoundary<P>({


### PR DESCRIPTION
Changes you made in this pull request:

withErrorBoundary: onError type fixes