### PR TITLE
hotfix(dep): 修复因 observable-hooks 自动升级 4.3.2 下的打包报错问题

### DIFF
--- a/packages/zent/package.json
+++ b/packages/zent/package.json
@@ -46,7 +46,7 @@
     "classnames": "^2.2.6",
     "date-fns": "^2.7.0",
     "lunar-typescript": "^1.6.10",
-    "observable-hooks": "^4.1.0",
+    "observable-hooks": "4.2.0",
     "react-is": "^17.0.1",
     "react-transition-group": "^4.4.1",
     "rxjs": "^7.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8138,10 +8138,10 @@ object.values@^1.1.0, object.values@^1.1.1, object.values@^1.1.3, object.values@
     define-properties "^1.1.3"
     es-abstract "^1.18.2"
 
-observable-hooks@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/observable-hooks/-/observable-hooks-4.1.0.tgz#b471747c75d2b44470f5bf889adeb2f3271a5a25"
-  integrity sha512-3kkmT76K4h03bzDM0xK6UFQlEnGB0sz63Dwd0szREzcP8vIGH8ikkWvsZfd3k1vZMFtnANU2tFb50n/XgwImug==
+observable-hooks@4.2.0:
+  version "4.2.0"
+  resolved "http://registry.npm.qima-inc.com/observable-hooks/download/observable-hooks-4.2.0.tgz#dd4df9678f90604a91f9fd66a4f924b503bfa530"
+  integrity sha1-3U35Z4+QYEqR+f1mpPkktQO/pTA=
 
 obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8140,8 +8140,8 @@ object.values@^1.1.0, object.values@^1.1.1, object.values@^1.1.3, object.values@
 
 observable-hooks@4.2.0:
   version "4.2.0"
-  resolved "http://registry.npm.qima-inc.com/observable-hooks/download/observable-hooks-4.2.0.tgz#dd4df9678f90604a91f9fd66a4f924b503bfa530"
-  integrity sha1-3U35Z4+QYEqR+f1mpPkktQO/pTA=
+  resolved "https://registry.yarnpkg.com/observable-hooks/-/observable-hooks-4.2.0.tgz#dd4df9678f90604a91f9fd66a4f924b503bfa530"
+  integrity sha512-bGjfGQI9vXrOIf1zAc3dmMqIXSqGQM+MLYOSQuqTzgP/8ptyDn9Gsm3tXXnohHkL7byyzHFc0/zuWyydUjtAFg==
 
 obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
- 修复observable-hooks引起的打包错误
![image](https://github.com/youzan/zent/assets/24364731/b931e4b2-670a-4259-a4ae-c0be90250ecb)
