### PR TITLE
fix(grid): fix the key of cell in grid component to rerender correctly(zent10)

### DIFF
--- a/packages/zent/src/grid/Row.tsx
+++ b/packages/zent/src/grid/Row.tsx
@@ -73,6 +73,7 @@ class Row<Data> extends PureComponent<IGridRowProps<Data>> {
           column: columnIndex,
           fixed,
         };
+        const columnKey = column.name || columnIndex;
 
         cells.push(
           <Cell
@@ -80,7 +81,7 @@ class Row<Data> extends PureComponent<IGridRowProps<Data>> {
             data={data}
             pos={pos}
             columnIndex={columnIndex}
-            key={columnIndex}
+            key={columnKey}
             prefix={prefix}
           />
         );


### PR DESCRIPTION
- change the key of cell in gird component with column name and index
