### PR TITLE
fix(tooltip): children prop type defined miss ReactNode

### DIFF
--- a/packages/zent/src/tooltip/Tooltip.tsx
+++ b/packages/zent/src/tooltip/Tooltip.tsx
@@ -20,7 +20,7 @@ export interface ITooltipBaseProps {
   containerSelector?: string;
   visible?: boolean;
   onVisibleChange?: (visible: boolean) => void;
-  children: ReactElement | string | number;
+  children: ReactElement | string | number | React.ReactNode;
   fixMouseEventsOnDisabledChildren?: boolean;
 }
 


### PR DESCRIPTION
- 修复tooltips的children定义缺少ReactNode的问题
