### PR TITLE
fix(Grid): fix hover color in grid row

### DIFF
--- a/packages/zent/assets/grid.scss
+++ b/packages/zent/assets/grid.scss
@@ -246,7 +246,7 @@ $fixed-left-column-box-shadow: 4px 0 8px -4px rgba($shadow-color, 0.1);
 
     &:hover,
     &__mouseover {
-      @include theme-color(background-color, default, bg);
+      @include theme-color(background-color, primary, 8);
     }
 
     &__expanded {


### PR DESCRIPTION
修复Grid的hover样式不生效的问题 
原 @include theme-color(background-color, default, bg); 生成的--theme-default-bg 变量未定义

